### PR TITLE
feat(chat): scope mutes to lounge/ladder — exempt clan & custom-game lobbies

### DIFF
--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1112,6 +1112,307 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             "Other shadow-banned users must be hidden");
     }
 
+    // ── Task 7 tests ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task BanUser_LiveUser_FullBan_UpdatesCacheToFull()
+    {
+        // Arrange: a live user in W3C Lounge
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        // Mock Clients.Client so the PlayerBannedFromChat send doesn't NRE
+        var victimProxy = new Mock<ISingleClientProxy>();
+        victimProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
+
+        // Admin performs ban
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+        _hubCallerContext.Setup(c => c.ConnectionId).Returns("TestId");
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
+
+        // Mute cache must be updated on the live connection
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached),
+            "Full ban must produce a cache HIT on the live connection");
+        Assert.AreEqual(MuteStatus.Full, cached.Status,
+            "Full ban must update the cached MuteStatus to Full for the live connection");
+    }
+
+    [Test]
+    public async Task BanUser_LiveUser_ShadowBan_UpdatesCacheToShadow()
+    {
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "spam", true, endDate);
+
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached),
+            "Shadow ban must produce a cache HIT on the live connection");
+        Assert.AreEqual(MuteStatus.Shadow, cached.Status,
+            "Shadow ban must update the cached MuteStatus to Shadow for the live connection");
+    }
+
+    [Test]
+    public async Task BanUser_LiveUser_FullBan_CacheEndDateMatchesBanEndDate()
+    {
+        // Verify the cached endDate is populated so expiry enforcement works from the cache
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        // Mock Clients.Client so the PlayerBannedFromChat send doesn't NRE
+        var victimProxy = new Mock<ISingleClientProxy>();
+        victimProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDateStr = DateTime.UtcNow.AddDays(7).ToString("O");
+        await _chatHub.BanUser("victim#123", "reason", false, endDateStr);
+
+        _connectionMapping.TryGetMute("VictimConn", out var cached);
+        Assert.AreEqual(MuteStatus.Full, cached.Status);
+        // EndDate must be in the future (ban is active) and close to the requested endDate
+        Assert.Greater(cached.EndDate, DateTime.UtcNow,
+            "Cached EndDate must be in the future for an active full ban");
+    }
+
+    [Test]
+    public async Task BanUser_LiveUser_FullBan_InBannedRoom_SendsPlayerBannedFromChat()
+    {
+        // Live user sitting in W3C Lounge (a banned room)
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        // Separate client proxy for the victim connection
+        var victimProxy = new Mock<ISingleClientProxy>();
+        string signalSent = null;
+        LoungeMute muteInSignal = null;
+        victimProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "PlayerBannedFromChat")
+                {
+                    signalSent = method;
+                    muteInSignal = args[0] as LoungeMute;
+                }
+            })
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
+
+        Assert.AreEqual("PlayerBannedFromChat", signalSent,
+            "Live fully-banned user in a banned room must receive PlayerBannedFromChat");
+        Assert.IsNotNull(muteInSignal,
+            "PlayerBannedFromChat payload must include the LoungeMute");
+        Assert.AreEqual("victim#123", muteInSignal.battleTag,
+            "LoungeMute in signal must have the correct battleTag");
+    }
+
+    [Test]
+    public async Task BanUser_LiveUser_FullBan_InBannedRoom_NoContextAbort()
+    {
+        // G1: PlayerBannedFromChat is sent with NO Context.Abort() — the connection must stay alive
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var victimProxy = new Mock<ISingleClientProxy>();
+        victimProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
+
+        Assert.IsFalse(abortCalled,
+            "BanUser must NOT call Context.Abort() on the admin or victim (G1 — no abort anywhere)");
+    }
+
+    [Test]
+    public async Task BanUser_LiveUser_FullBan_DoesNotEvictFromRoom()
+    {
+        // Spec §12: do NOT forcibly evict the user from their current room.
+        // Enforcement happens on their next SendMessage/SwitchRoom which reads the updated cache.
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var victimProxy = new Mock<ISingleClientProxy>();
+        victimProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
+
+        // The victim must still be in W3C Lounge after the ban — not evicted
+        var room = _connectionMapping.GetRoom("VictimConn");
+        Assert.AreEqual("W3C Lounge", room,
+            "BanUser must NOT evict the user from their current room (spec §12)");
+    }
+
+    [Test]
+    public async Task BanUser_LiveUser_ShadowBan_SendsNoSignalToTarget()
+    {
+        // Shadow ban: illusion preserved — no PlayerBannedFromChat sent to target
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var victimProxy = new Mock<ISingleClientProxy>();
+        int victimSignalCount = 0;
+        victimProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => victimSignalCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "spam", true, endDate);
+
+        Assert.AreEqual(0, victimSignalCount,
+            "Shadow ban must send NO signal to the target (illusion preserved)");
+    }
+
+    [Test]
+    public async Task BanUser_LiveUser_FullBan_SubsequentSendMessage_InBannedRoom_IsRejectedFromCache()
+    {
+        // End-to-end: full ban applied live → subsequent SendMessage in banned room is rejected
+        // WITHOUT requiring another DB read (the cache is now Full).
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var victimProxy = new Mock<ISingleClientProxy>();
+        victimProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
+
+        // Now switch to victim's hub context and attempt to send
+        _hubCallerContext.Setup(c => c.ConnectionId).Returns("VictimConn");
+        _chatHub.Clients = _clients.Object;
+        _chatHub.Context = _hubCallerContext.Object;
+
+        int groupSendCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => groupSendCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        await _chatHub.SendMessage("Should be rejected");
+
+        Assert.IsFalse(abortCalled, "Context.Abort() must NOT be called from SendMessage after a live ban");
+        Assert.AreEqual(0, groupSendCount,
+            "SendMessage in a banned room after a live full ban must be rejected without a DB read");
+        Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"),
+            "Rejected message must not enter history");
+    }
+
+    [Test]
+    public async Task BanUser_LiveUser_ShadowBan_SubsequentSendMessage_InBannedRoom_IsDroppedFromCache()
+    {
+        // End-to-end: shadow ban applied live → subsequent SendMessage in banned room is echo-only
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "spam", true, endDate);
+
+        // Switch to victim's hub context
+        _hubCallerContext.Setup(c => c.ConnectionId).Returns("VictimConn");
+
+        // Setup victim's caller proxy
+        var victimCallerProxy = new Mock<ISingleClientProxy>();
+        ChatMessage callerEcho = null;
+        victimCallerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "ReceiveMessage" && args.Length > 0)
+                    callerEcho = args[0] as ChatMessage;
+            })
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Caller).Returns(victimCallerProxy.Object);
+
+        int groupSendCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => groupSendCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.SendMessage("Invisible message");
+
+        Assert.AreEqual(0, groupSendCount,
+            "Shadow-banned user's message in banned room must be dropped (not broadcast) after live shadow ban");
+        Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"),
+            "Dropped shadow message must not enter history");
+        Assert.IsNotNull(callerEcho, "Shadow-banned user must still receive echo of their own message");
+        Assert.AreEqual("Invisible message", callerEcho.Message);
+    }
+
+    [Test]
+    public async Task BanUser_UserNotConnected_NoException()
+    {
+        // Banning a user who is not currently connected — should complete without error
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+
+        Assert.DoesNotThrowAsync(async () =>
+            await _chatHub.BanUser("offline#999", "reason", false, endDate));
+    }
+
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
     [TestCase("W3C Lounge",      ExpectedResult = true)]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -637,6 +637,136 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         Assert.AreEqual("1 vs 1", room);
     }
 
+    // ── Task 5 tests ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task SendMessage_NoRoom_MembershipCheck_Rejected()
+    {
+        // User is NOT added to any room (not in _connectionMapping)
+        // Calling SendMessage without being a member → rejected, no group broadcast
+
+        await _chatHub.SendMessage("Hello world");
+
+        Assert.AreEqual(0, _groupSendCount,
+            "Message must not be broadcast when user has no room membership");
+        Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"));
+    }
+
+    [Test]
+    public async Task SendMessage_FullBan_InBannedRoom_IsRejectedSilently()
+    {
+        // Full-banned user somehow ends up in a banned room (defense-in-depth)
+        await AddFullBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        await _chatHub.SendMessage("Hello world");
+
+        Assert.IsFalse(abortCalled, "Context.Abort() must not be called from SendMessage");
+        Assert.AreEqual(0, _groupSendCount, "Full-banned message in banned room must not be broadcast");
+        Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"));
+    }
+
+    [Test]
+    public async Task SendMessage_FullBan_InExemptRoom_Broadcasts()
+    {
+        await AddFullBan("peter#123");
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+
+        await _chatHub.SendMessage("Hello clan");
+
+        Assert.AreEqual(1, _groupSendCount, "Full-banned user's message in exempt room must broadcast");
+        Assert.AreEqual(1, _chatHistory.GetMessages("clan AB").Count);
+        Assert.AreEqual("Hello clan", _chatHistory.GetMessages("clan AB")[0].Message);
+    }
+
+    [Test]
+    public async Task SendMessage_ShadowBan_InBannedRoom_DroppedEchoToCaller()
+    {
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        ChatMessage callerEcho = null;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "ReceiveMessage" && args.Length > 0)
+                    callerEcho = args[0] as ChatMessage;
+            })
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.SendMessage("Invisible message");
+
+        Assert.AreEqual(0, _groupSendCount, "Shadow-banned message in banned room must NOT be broadcast to group");
+        Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"), "Dropped message must not enter history");
+        Assert.IsNotNull(callerEcho, "Shadow-banned user must receive echo of their own message");
+        Assert.AreEqual("Invisible message", callerEcho.Message);
+    }
+
+    [Test]
+    public async Task SendMessage_ShadowBan_InExemptRoom_Broadcasts()
+    {
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        await _chatHub.SendMessage("Clan message");
+
+        Assert.AreEqual(1, _groupSendCount, "Shadow-banned user in exempt room must broadcast normally");
+        Assert.AreEqual(1, _chatHistory.GetMessages("clan AB").Count);
+        Assert.AreEqual("Clan message", _chatHistory.GetMessages("clan AB")[0].Message);
+    }
+
+    [Test]
+    public async Task SendMessage_NoBan_NormalUser_Broadcasts()
+    {
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.None);
+
+        await _chatHub.SendMessage("Normal message");
+
+        Assert.AreEqual(1, _groupSendCount);
+        Assert.AreEqual(1, _chatHistory.GetMessages("W3C Lounge").Count);
+    }
+
+    [Test]
+    public async Task SendMessage_ExpiredMute_TreatedAsNoBan_Broadcasts()
+    {
+        // Expired mute — endDate is in the past
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "peter#123",
+            endDate = DateTime.UtcNow.AddDays(-1).ToString("O"),
+            author = "admin#1",
+            reason = "expired ban",
+            isShadowBan = false
+        });
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.None);
+
+        await _chatHub.SendMessage("Should broadcast");
+
+        Assert.AreEqual(1, _groupSendCount, "Expired ban must not restrict sending");
+        Assert.AreEqual(1, _chatHistory.GetMessages("W3C Lounge").Count);
+    }
+
+    [Test]
+    public async Task SendMessage_UnbannedUser_InAllRoomTypes_Broadcasts()
+    {
+        _connectionMapping.Add("TestId", "2 vs 2", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.None);
+
+        await _chatHub.SendMessage("Ladder message");
+
+        Assert.AreEqual(1, _groupSendCount, "Unbanned user must broadcast in any room");
+    }
+
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
     [TestCase("W3C Lounge",      ExpectedResult = true)]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -932,6 +932,179 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             "Dropped message must not enter history");
     }
 
+    // ── Task 6 tests ────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ConnectionMapping_GetUsersOfRoomForViewer_ShadowBanInBannedRoom_HiddenFromOthers()
+    {
+        var mapping = new ConnectionMapping();
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        var shadowUser = new ChatUser("shadow#2", false, null, new ProfilePicture(), null, null);
+
+        mapping.Add("conn-normal", "W3C Lounge", normalUser);
+        mapping.Add("conn-shadow", "W3C Lounge", shadowUser);
+        mapping.SetMute("conn-shadow", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        // Normal user viewing — shadow user must be hidden
+        var visibleToNormal = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-normal");
+        Assert.AreEqual(1, visibleToNormal.Count);
+        Assert.AreEqual("normal#1", visibleToNormal[0].BattleTag);
+
+        // Shadow user viewing themselves — they see both
+        var visibleToShadow = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-shadow");
+        Assert.AreEqual(2, visibleToShadow.Count);
+    }
+
+    [Test]
+    public void ConnectionMapping_GetUsersOfRoomForViewer_ShadowBanInExemptRoom_Visible()
+    {
+        var mapping = new ConnectionMapping();
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        var shadowUser = new ChatUser("shadow#2", false, null, new ProfilePicture(), null, null);
+
+        mapping.Add("conn-normal", "clan AB", normalUser);
+        mapping.Add("conn-shadow", "clan AB", shadowUser);
+        mapping.SetMute("conn-shadow", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        // In exempt room, shadow user is fully visible to normal viewer
+        var visibleToNormal = mapping.GetUsersOfRoomForViewer("clan AB", "conn-normal");
+        Assert.AreEqual(2, visibleToNormal.Count);
+    }
+
+    [Test]
+    public void ConnectionMapping_GetUsersOfRoomForViewer_FullBan_NotShadowHidden()
+    {
+        var mapping = new ConnectionMapping();
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        var fullBanUser = new ChatUser("banned#3", false, null, new ProfilePicture(), null, null);
+
+        // Full-banned users should never be in a banned room (rejected at SwitchRoom),
+        // but if they somehow are, they appear as-is — only Shadow status is presence-hidden.
+        mapping.Add("conn-normal", "W3C Lounge", normalUser);
+        mapping.Add("conn-banned", "W3C Lounge", fullBanUser);
+        mapping.SetMute("conn-banned", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
+
+        // Full-banned user is NOT shadow-hidden; they simply shouldn't be here.
+        var visibleToNormal = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-normal");
+        Assert.AreEqual(2, visibleToNormal.Count);
+    }
+
+    [Test]
+    public void ConnectionMapping_GetUsersOfRoomForViewer_ExpiredShadowBan_NotHidden()
+    {
+        // An EXPIRED shadow ban must NOT cause hiding — expiry-aware via GetEffectiveMuteStatus.
+        var mapping = new ConnectionMapping();
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        var expiredShadowUser = new ChatUser("expired#4", false, null, new ProfilePicture(), null, null);
+
+        mapping.Add("conn-normal", "W3C Lounge", normalUser);
+        mapping.Add("conn-expired", "W3C Lounge", expiredShadowUser);
+        // Shadow ban that ended in the past
+        mapping.SetMute("conn-expired", MuteStatus.Shadow, DateTime.UtcNow.AddDays(-1));
+
+        // Expired shadow ban → user IS visible to others (ban has expired)
+        var visibleToNormal = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-normal");
+        Assert.AreEqual(2, visibleToNormal.Count,
+            "User with EXPIRED shadow ban must not be hidden — expiry-aware filtering");
+    }
+
+    [Test]
+    public void ConnectionMapping_GetUsersOfRoomForViewer_NoBan_AllVisible()
+    {
+        var mapping = new ConnectionMapping();
+        var user1 = new ChatUser("user#1", false, null, new ProfilePicture(), null, null);
+        var user2 = new ChatUser("user#2", false, null, new ProfilePicture(), null, null);
+
+        mapping.Add("conn-1", "W3C Lounge", user1);
+        mapping.Add("conn-2", "W3C Lounge", user2);
+        // No SetMute calls — both are cache misses (treated as None)
+
+        var visibleToUser1 = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-1");
+        Assert.AreEqual(2, visibleToUser1.Count,
+            "Normal (unbanned) users must never be excluded from the user list");
+    }
+
+    [Test]
+    public async Task SwitchRoom_ShadowBan_CallerReceivesStartChat_SeesSelf_OthersExcluded()
+    {
+        // Full integration: when a shadow-banned user ghost-joins a banned room,
+        // the StartChat sent to them (the viewer) must include themselves but not other shadow users.
+        await AddShadowBan("peter#123");
+
+        // Add another shadow-banned user already in "1 vs 1"
+        var otherShadowUser = new ChatUser("shadow-other#5", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("OtherShadowConn", "1 vs 1", otherShadowUser);
+        _connectionMapping.SetMute("OtherShadowConn", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        // A normal user also in "1 vs 1"
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("NormalConn", "1 vs 1", normalUser);
+
+        // Shadow-banned user starts in W3C Lounge, switches to "1 vs 1"
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        List<ChatUser> startChatUsers = null;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "StartChat" && args.Length >= 1)
+                    startChatUsers = args[0] as List<ChatUser>;
+            })
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.SwitchRoom("1 vs 1");
+
+        Assert.IsNotNull(startChatUsers, "Shadow-banned user must receive StartChat on ghost-join");
+        // peter#123 (the viewer) must see themselves
+        Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "peter#123"),
+            "Shadow-banned viewer must see themselves in usersOfRoom");
+        // normal#1 must be visible (not shadow-banned)
+        Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "normal#1"),
+            "Normal user must be visible to the shadow-banned viewer");
+        // shadow-other#5 must be hidden from peter (also shadow-banned, not the viewer)
+        Assert.IsFalse(startChatUsers.Any(u => u.BattleTag == "shadow-other#5"),
+            "Other shadow-banned users must be hidden from the shadow-banned viewer");
+    }
+
+    [Test]
+    public async Task Login_ShadowBan_StartChat_FiltersOtherShadowUsers()
+    {
+        // Integration: on login, shadow-banned user's StartChat (in the default room, a banned room)
+        // must hide other shadow users but show themselves and normal users.
+        await AddShadowBan("peter#123");
+
+        // Another shadow user already in W3C Lounge
+        var otherShadow = new ChatUser("other-shadow#9", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("OtherShadowConn", "W3C Lounge", otherShadow);
+        _connectionMapping.SetMute("OtherShadowConn", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        // A normal user also in W3C Lounge
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("NormalConn", "W3C Lounge", normalUser);
+
+        List<ChatUser> startChatUsers = null;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "StartChat" && args.Length >= 1)
+                    startChatUsers = args[0] as List<ChatUser>;
+            })
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        Assert.IsNotNull(startChatUsers, "Shadow-banned user must receive StartChat on login");
+        Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "peter#123"),
+            "Shadow-banned viewer must see themselves");
+        Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "normal#1"),
+            "Normal user must be visible to shadow-banned viewer");
+        Assert.IsFalse(startChatUsers.Any(u => u.BattleTag == "other-shadow#9"),
+            "Other shadow-banned users must be hidden");
+    }
+
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
     [TestCase("W3C Lounge",      ExpectedResult = true)]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -168,11 +168,16 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     [TestCase("Castle Fight",    ExpectedResult = true)]
     [TestCase("Risk Europe",     ExpectedResult = true)]
     [TestCase("Mini Dota",       ExpectedResult = true)]
+    // Mixed-case variants of banned rooms must still be caught (case-insensitive ban check)
+    [TestCase("w3c lounge",      ExpectedResult = true)]
+    [TestCase("1 VS 1",          ExpectedResult = true)]
+    [TestCase("LEGION TD",       ExpectedResult = true)]
     [TestCase("clan AB",         ExpectedResult = false)]
     [TestCase("clan XYZ",        ExpectedResult = false)]
     [TestCase("game-lobby-42",   ExpectedResult = false)]
     [TestCase("custom_lobby",    ExpectedResult = false)]
     [TestCase("",                ExpectedResult = false)]
+    [TestCase(null,              ExpectedResult = false)]
     public bool IsBannedRoom_ClassifiesCorrectly(string room)
     {
         return DefaultChatRooms.IsBannedRoom(room);

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -143,7 +143,12 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         mapping.SetMuteStatus("conn1", MuteStatus.Full);
 
         mapping.Remove("conn1");
-        // After re-add (e.g. SwitchRoom) status is back to None
+
+        // Direct assertion: Remove must clear the cached status immediately,
+        // before any re-Add — guards against a Remove that silently does nothing.
+        Assert.AreEqual(MuteStatus.None, mapping.GetMuteStatus("conn1"));
+
+        // After re-add (e.g. SwitchRoom) status is still None
         mapping.Add("conn1", "clan AB", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
 
         Assert.AreEqual(MuteStatus.None, mapping.GetMuteStatus("conn1"));

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -321,6 +321,29 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             "UserEntered must not be broadcast for full-banned user with no clan");
     }
 
+    [Test]
+    public async Task OnDisconnected_FullBanNoClan_NoThrow()
+    {
+        // Lifecycle regression: a full-banned, no-clan user is connected but seated in NO room.
+        // Disconnecting must not throw (no NRE on a null room) and must not broadcast UserLeft,
+        // since there is no room/group to notify.
+        await AddFullBan("peter#123");
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        // Track any group send after login (StartChat goes to caller, not group).
+        var groupSendsAfterLogin = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => groupSendsAfterLogin++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        Assert.DoesNotThrowAsync(async () => await _chatHub.OnDisconnectedAsync(null),
+            "Disconnecting a full-banned no-clan user (no room) must not throw");
+        Assert.AreEqual(0, groupSendsAfterLogin,
+            "No group broadcast (UserLeft) must fire for a user seated in no room");
+    }
+
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
     [TestCase("W3C Lounge",      ExpectedResult = true)]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -500,6 +500,36 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task SwitchRoom_FullBan_NoClan_ExemptThenBanned_StillRejected()
+    {
+        // SECURITY regression (full-ban bypass): a no-clan full-banned connection starts as a
+        // cache MISS. A FIRST switch into an EXEMPT room ("clan AB") is allowed and would write a
+        // cache-None entry. A SECOND switch into a BANNED room must STILL re-resolve the DB and
+        // reject — it must not trust the cache-None written by the exempt switch.
+        await AddFullBan("peter#123");
+        // Seated in a room but with NO cached mute (cache MISS), reproducing the no-clan login path.
+        _connectionMapping.Add("TestId", "clan SEED", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        // First switch: into an EXEMPT room — allowed, and (pre-fix) caches None.
+        await _chatHub.SwitchRoom("clan AB");
+        Assert.AreEqual("clan AB", _connectionMapping.GetRoom("TestId"),
+            "Switch into an exempt room must be allowed");
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        // Second switch: into a BANNED room — must re-resolve the ban and reject.
+        await _chatHub.SwitchRoom("W3C Lounge");
+
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("clan AB", room,
+            "Full-banned user must NOT enter a banned room after a prior exempt switch (cache-None must not bypass the ban)");
+        Assert.IsFalse(_connectionMapping.GetUsersOfRoom("clan AB").Count == 0,
+            "User must remain seated in the exempt room");
+        Assert.IsFalse(abortCalled, "Rejected SwitchRoom must not call Context.Abort() (G1)");
+    }
+
+    [Test]
     public async Task SwitchRoom_ShadowBan_IntoBannedRoom_GhostJoin_NoUserEnteredBroadcast()
     {
         await AddShadowBan("peter#123");

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -691,8 +691,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task SwitchRoom_ShadowBan_IntoBannedRoom_GhostJoin_NoUserEnteredBroadcast()
+    public async Task SwitchRoom_ShadowBan_IntoPublicRoom_BroadcastsUserEntered()
     {
+        // T3: shadow users are full members — NO presence-hiding. UserEntered fires unconditionally
+        // when joining a public room (the only remaining shadow effect is the SendMessage drop).
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
         _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
@@ -706,14 +708,13 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         await _chatHub.SwitchRoom("1 vs 1");
 
-        Assert.AreEqual(0, userEnteredCount, "Shadow-banned user must NOT trigger UserEntered in a banned room");
+        Assert.AreEqual(1, userEnteredCount, "Shadow-banned user MUST broadcast UserEntered (no presence-hiding)");
     }
 
     [Test]
-    public async Task SwitchRoom_ShadowBan_IntoBannedRoom_UserIsMovedIntoGroup()
+    public async Task SwitchRoom_ShadowBan_IntoPublicRoom_UserIsMovedIntoGroup()
     {
-        // Ghost-join: shadow-banned user IS added to the group (can receive messages)
-        // even though UserEntered is suppressed.
+        // Shadow-banned user IS added to the new room (can receive messages) — a normal member move.
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
         _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
@@ -726,7 +727,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task SwitchRoom_ShadowBan_IntoBannedRoom_CallerReceivesStartChat()
+    public async Task SwitchRoom_ShadowBan_IntoPublicRoom_CallerReceivesStartChat_FullMemberList()
     {
         await AddShadowBan("peter#123");
 
@@ -750,17 +751,18 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         await _chatHub.SwitchRoom("1 vs 1");
 
-        // Shadow-banned user sees themselves in the list (their own view is unfiltered)
-        Assert.IsNotNull(startChatUsers, "Shadow-banned user must receive a StartChat on ghost-join");
+        // T3: the caller receives the FULL member list — themselves AND every other member.
+        Assert.IsNotNull(startChatUsers, "Shadow-banned user must receive a StartChat on join");
         Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "peter#123"),
             "Shadow-banned user must see themselves in usersOfRoom");
+        Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "normal#1"),
+            "Shadow-banned user must see other members in usersOfRoom (no presence-hiding)");
     }
 
     [Test]
-    public async Task SwitchRoom_ShadowBan_IntoBannedRoom_UserLeftSuppressed()
+    public async Task SwitchRoom_ShadowBan_IntoPublicRoom_BroadcastsUserLeftOnOldRoom()
     {
-        // Ghost-join: when switching rooms, the old-room UserLeft should also be suppressed
-        // for a shadow user moving into a banned room (they were already "invisible")
+        // T3: shadow users are full members — leaving the old room fires UserLeft unconditionally.
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
         _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
@@ -774,8 +776,8 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         await _chatHub.SwitchRoom("1 vs 1");
 
-        Assert.AreEqual(0, userLeftCount,
-            "Shadow-banned user ghost-joining a banned room must NOT trigger UserLeft on the old room");
+        Assert.AreEqual(1, userLeftCount,
+            "Shadow-banned user MUST trigger UserLeft on the old room (no presence-hiding)");
     }
 
     [Test]
@@ -802,11 +804,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task SwitchRoom_ShadowBan_ExemptToBanned_StillBroadcastsUserLeft()
+    public async Task SwitchRoom_ShadowBan_ExemptToPublic_BothLeaveAndEnterFire()
     {
-        // Cross-category: shadow user was VISIBLE in an exempt room, so leaving it must still
-        // broadcast UserLeft (else a stale ghost lingers in the exempt room's user list).
-        // The target is banned, so the enter must be suppressed (ghost-join).
+        // T3: no presence-hiding. Both the old-room UserLeft and the target-room UserEntered fire
+        // unconditionally, regardless of room category.
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "clan XYZ", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
         _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
@@ -825,18 +826,14 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         await _chatHub.SwitchRoom("W3C Lounge");
 
-        Assert.AreEqual(1, userLeftCount,
-            "Shadow user leaving an EXEMPT room (where they were visible) must broadcast UserLeft");
-        Assert.AreEqual(0, userEnteredCount,
-            "Shadow user ghost-joining a BANNED target room must NOT broadcast UserEntered");
+        Assert.AreEqual(1, userLeftCount, "Leaving the old room must broadcast UserLeft");
+        Assert.AreEqual(1, userEnteredCount, "Joining the public target room must broadcast UserEntered");
     }
 
     [Test]
-    public async Task SwitchRoom_ShadowBan_BannedToExempt_SuppressesUserLeft()
+    public async Task SwitchRoom_ShadowBan_PublicToExempt_BothLeaveAndEnterFire()
     {
-        // Cross-category: shadow user was a GHOST in a banned room (no one saw them enter),
-        // so leaving it must NOT broadcast UserLeft. The target is exempt, so they become
-        // visible and the enter must fire.
+        // T3: no presence-hiding. Both UserLeft (old public room) and UserEntered (exempt target) fire.
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
         _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
@@ -855,10 +852,8 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         await _chatHub.SwitchRoom("clan XYZ");
 
-        Assert.AreEqual(0, userLeftCount,
-            "Shadow user leaving a BANNED room (where they were a ghost) must NOT broadcast UserLeft");
-        Assert.AreEqual(1, userEnteredCount,
-            "Shadow user entering an EXEMPT target room must broadcast UserEntered (becomes visible)");
+        Assert.AreEqual(1, userLeftCount, "Leaving the old public room must broadcast UserLeft");
+        Assert.AreEqual(1, userEnteredCount, "Joining the exempt target room must broadcast UserEntered");
     }
 
     [Test]
@@ -1271,8 +1266,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     // ── Task 6 tests ────────────────────────────────────────────────────────────
 
     [Test]
-    public void ConnectionMapping_GetUsersOfRoomForViewer_ShadowBanInBannedRoom_HiddenFromOthers()
+    public void ConnectionMapping_GetUsersOfRoom_ShadowBanInBannedRoom_VisibleToAll()
     {
+        // T3: shadow users are full room members — NO presence-hiding. They appear in usersOfRoom
+        // for everyone (the only remaining shadow effect is the SendMessage drop).
         var mapping = new ConnectionMapping();
         var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
         var shadowUser = new ChatUser("shadow#2", false, null, new ProfilePicture(), null, null);
@@ -1281,25 +1278,15 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         mapping.Add("conn-shadow", "W3C Lounge", shadowUser);
         mapping.SetMute("conn-shadow", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
-        // Normal user viewing — shadow user must be hidden
-        var visibleToNormal = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-normal");
-        Assert.AreEqual(1, visibleToNormal.Count);
-        Assert.AreEqual("normal#1", visibleToNormal[0].BattleTag);
-        var tagsVisibleToNormal = visibleToNormal.Select(u => u.BattleTag).ToList();
-        Assert.IsFalse(tagsVisibleToNormal.Contains("shadow#2"),
-            "Non-viewer must NOT see the shadow-banned user's battleTag");
-        Assert.IsTrue(tagsVisibleToNormal.Contains("normal#1"),
-            "Non-viewer must see the normal user's battleTag");
-
-        // Shadow user viewing themselves — they see both
-        var visibleToShadow = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-shadow");
-        Assert.AreEqual(2, visibleToShadow.Count);
-        Assert.IsTrue(visibleToShadow.Any(u => u.BattleTag == "shadow#2"),
-            "Shadow-banned viewer must see their own battleTag");
+        var users = mapping.GetUsersOfRoom("W3C Lounge");
+        var tags = users.Select(u => u.BattleTag).ToList();
+        Assert.AreEqual(2, users.Count, "Shadow user must be a visible member of the room");
+        CollectionAssert.Contains(tags, "shadow#2", "Shadow-banned user must be visible to others");
+        CollectionAssert.Contains(tags, "normal#1");
     }
 
     [Test]
-    public void ConnectionMapping_GetUsersOfRoomForViewer_ShadowBanInExemptRoom_Visible()
+    public void ConnectionMapping_GetUsersOfRoom_ShadowBanInExemptRoom_VisibleToAll()
     {
         var mapping = new ConnectionMapping();
         var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
@@ -1309,50 +1296,29 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         mapping.Add("conn-shadow", "clan AB", shadowUser);
         mapping.SetMute("conn-shadow", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
-        // In exempt room, shadow user is fully visible to normal viewer
-        var visibleToNormal = mapping.GetUsersOfRoomForViewer("clan AB", "conn-normal");
-        Assert.AreEqual(2, visibleToNormal.Count);
+        var users = mapping.GetUsersOfRoom("clan AB");
+        Assert.AreEqual(2, users.Count, "All users (incl. shadow) are visible in exempt rooms too");
     }
 
     [Test]
-    public void ConnectionMapping_GetUsersOfRoomForViewer_FullBan_NotShadowHidden()
+    public void ConnectionMapping_GetUsersOfRoom_FullBan_Visible()
     {
         var mapping = new ConnectionMapping();
         var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
         var fullBanUser = new ChatUser("banned#3", false, null, new ProfilePicture(), null, null);
 
-        // Full-banned users should never be in a banned room (rejected at SwitchRoom),
-        // but if they somehow are, they appear as-is — only Shadow status is presence-hidden.
+        // Full-banned users should never be in a public room (rejected at SwitchRoom),
+        // but if they somehow are, they appear as-is — there is no presence-hiding at all.
         mapping.Add("conn-normal", "W3C Lounge", normalUser);
         mapping.Add("conn-banned", "W3C Lounge", fullBanUser);
         mapping.SetMute("conn-banned", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
-        // Full-banned user is NOT shadow-hidden; they simply shouldn't be here.
-        var visibleToNormal = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-normal");
-        Assert.AreEqual(2, visibleToNormal.Count);
+        var users = mapping.GetUsersOfRoom("W3C Lounge");
+        Assert.AreEqual(2, users.Count);
     }
 
     [Test]
-    public void ConnectionMapping_GetUsersOfRoomForViewer_ExpiredShadowBan_NotHidden()
-    {
-        // An EXPIRED shadow ban must NOT cause hiding — expiry-aware via GetEffectiveMuteStatus.
-        var mapping = new ConnectionMapping();
-        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
-        var expiredShadowUser = new ChatUser("expired#4", false, null, new ProfilePicture(), null, null);
-
-        mapping.Add("conn-normal", "W3C Lounge", normalUser);
-        mapping.Add("conn-expired", "W3C Lounge", expiredShadowUser);
-        // Shadow ban that ended in the past
-        mapping.SetMute("conn-expired", MuteStatus.Shadow, DateTime.UtcNow.AddDays(-1));
-
-        // Expired shadow ban → user IS visible to others (ban has expired)
-        var visibleToNormal = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-normal");
-        Assert.AreEqual(2, visibleToNormal.Count,
-            "User with EXPIRED shadow ban must not be hidden — expiry-aware filtering");
-    }
-
-    [Test]
-    public void ConnectionMapping_GetUsersOfRoomForViewer_NoBan_AllVisible()
+    public void ConnectionMapping_GetUsersOfRoom_NoBan_AllVisible()
     {
         var mapping = new ConnectionMapping();
         var user1 = new ChatUser("user#1", false, null, new ProfilePicture(), null, null);
@@ -1360,18 +1326,17 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         mapping.Add("conn-1", "W3C Lounge", user1);
         mapping.Add("conn-2", "W3C Lounge", user2);
-        // No SetMute calls — both are cache misses (treated as None)
 
-        var visibleToUser1 = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-1");
-        Assert.AreEqual(2, visibleToUser1.Count,
+        var users = mapping.GetUsersOfRoom("W3C Lounge");
+        Assert.AreEqual(2, users.Count,
             "Normal (unbanned) users must never be excluded from the user list");
     }
 
     [Test]
-    public async Task SwitchRoom_ShadowBan_CallerReceivesStartChat_SeesSelf_OthersExcluded()
+    public async Task SwitchRoom_ShadowBan_CallerReceivesStartChat_SeesAllMembers()
     {
-        // Full integration: when a shadow-banned user ghost-joins a banned room,
-        // the StartChat sent to them (the viewer) must include themselves but not other shadow users.
+        // T3: when a shadow-banned user joins a public room, the StartChat sent to them includes
+        // EVERY member — themselves, normal users, AND other shadow users (no presence-hiding).
         await AddShadowBan("peter#123");
 
         // Add another shadow-banned user already in "1 vs 1"
@@ -1399,23 +1364,20 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         await _chatHub.SwitchRoom("1 vs 1");
 
-        Assert.IsNotNull(startChatUsers, "Shadow-banned user must receive StartChat on ghost-join");
-        // peter#123 (the viewer) must see themselves
+        Assert.IsNotNull(startChatUsers, "Shadow-banned user must receive StartChat on join");
         Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "peter#123"),
             "Shadow-banned viewer must see themselves in usersOfRoom");
-        // normal#1 must be visible (not shadow-banned)
         Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "normal#1"),
             "Normal user must be visible to the shadow-banned viewer");
-        // shadow-other#5 must be hidden from peter (also shadow-banned, not the viewer)
-        Assert.IsFalse(startChatUsers.Any(u => u.BattleTag == "shadow-other#5"),
-            "Other shadow-banned users must be hidden from the shadow-banned viewer");
+        Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "shadow-other#5"),
+            "Other shadow-banned users must ALSO be visible (no presence-hiding)");
     }
 
     [Test]
-    public async Task Login_ShadowBan_StartChat_FiltersOtherShadowUsers()
+    public async Task Login_ShadowBan_StartChat_ShowsAllMembers()
     {
-        // Integration: on login, shadow-banned user's StartChat (in the default room, a banned room)
-        // must hide other shadow users but show themselves and normal users.
+        // T3: on login, the shadow-banned user's StartChat shows EVERY member of the room — themselves,
+        // normal users, AND other shadow users (no presence-hiding).
         await AddShadowBan("peter#123");
 
         // Another shadow user already in W3C Lounge
@@ -1444,8 +1406,8 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             "Shadow-banned viewer must see themselves");
         Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "normal#1"),
             "Normal user must be visible to shadow-banned viewer");
-        Assert.IsFalse(startChatUsers.Any(u => u.BattleTag == "other-shadow#9"),
-            "Other shadow-banned users must be hidden");
+        Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "other-shadow#9"),
+            "Other shadow-banned users must ALSO be visible (no presence-hiding)");
     }
 
     // ── Task 7 tests ────────────────────────────────────────────────────────────
@@ -1768,8 +1730,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     // ── Task 8 tests ────────────────────────────────────────────────────────────
 
     [Test]
-    public async Task OnDisconnectedAsync_ShadowBan_InBannedRoom_NoUserLeftBroadcast()
+    public async Task OnDisconnectedAsync_ShadowBan_InPublicRoom_BroadcastsUserLeft()
     {
+        // T3: shadow users are full members — disconnecting from a public room broadcasts UserLeft
+        // unconditionally (no presence-hiding).
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
         _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
@@ -1783,8 +1747,8 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         await _chatHub.OnDisconnectedAsync(null);
 
-        Assert.AreEqual(0, userLeftCount,
-            "Shadow-banned user leaving a banned room must NOT broadcast UserLeft");
+        Assert.AreEqual(1, userLeftCount,
+            "Shadow-banned user leaving a public room MUST broadcast UserLeft (no presence-hiding)");
     }
 
     [Test]
@@ -1957,10 +1921,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
-    public void ShadowBan_UsersOfRoom_OtherMembersDoNotSeeTheShadowUser()
+    public void ShadowBan_UsersOfRoom_AllMembersSeeTheShadowUser()
     {
-        // Integration: the ConnectionMapping used by the hub correctly hides shadow users
-        // from normal members in banned rooms.
+        // T3: the ConnectionMapping room member list contains the shadow user for EVERYONE — there is
+        // no presence-hiding (the only remaining shadow effect is the SendMessage drop).
         var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
         var shadowUser = new ChatUser("shadow#2", false, null, new ProfilePicture(), null, null);
 
@@ -1968,16 +1932,11 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping.Add("ShadowConn", "W3C Lounge", shadowUser);
         _connectionMapping.SetMute("ShadowConn", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
-        // Normal user's view must not include the shadow-banned user
-        var visibleToNormal = _connectionMapping.GetUsersOfRoomForViewer("W3C Lounge", "NormalConn");
-        Assert.AreEqual(1, visibleToNormal.Count,
-            "Normal user must see exactly 1 member (shadow user is hidden)");
-        Assert.AreEqual("normal#1", visibleToNormal[0].BattleTag);
-
-        // Shadow user's own view must include themselves
-        var visibleToShadow = _connectionMapping.GetUsersOfRoomForViewer("W3C Lounge", "ShadowConn");
-        Assert.AreEqual(2, visibleToShadow.Count,
-            "Shadow-banned user must see both themselves and the normal user");
+        var users = _connectionMapping.GetUsersOfRoom("W3C Lounge");
+        var tags = users.Select(u => u.BattleTag).ToList();
+        Assert.AreEqual(2, users.Count, "Both members are visible (no presence-hiding)");
+        CollectionAssert.Contains(tags, "normal#1");
+        CollectionAssert.Contains(tags, "shadow#2", "Shadow user is a visible member to everyone");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -42,7 +42,8 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping = new ConnectionMapping();
         _chatHistory = new ChatHistory();
         _settingsRepository = new SettingsRepository(MongoClient);
-        _reconcileHarness = new MuteReconciliationTestHarness(_connectionMapping);
+        // Wire ApplyBanAsync to the real repo so hub BanUser persists to (and is removable from) the DB.
+        _reconcileHarness = new MuteReconciliationTestHarness(_connectionMapping, _muteRepository);
 
         var chatAuthService = new Mock<IChatAuthenticationService>();
         chatAuthService.Setup(m => m.GetUser(It.IsAny<string>()))

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -153,4 +153,28 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         Assert.AreEqual(MuteStatus.None, mapping.GetMuteStatus("conn1"));
     }
+
+    // ── Task 2 tests ────────────────────────────────────────────────────────────
+
+    [TestCase("W3C Lounge",      ExpectedResult = true)]
+    [TestCase("1 vs 1",          ExpectedResult = true)]
+    [TestCase("2 vs 2",          ExpectedResult = true)]
+    [TestCase("4 vs 4",          ExpectedResult = true)]
+    [TestCase("FFA",             ExpectedResult = true)]
+    [TestCase("Legion TD",       ExpectedResult = true)]
+    [TestCase("Survival Chaos",  ExpectedResult = true)]
+    [TestCase("Direct Strike",   ExpectedResult = true)]
+    [TestCase("Warhammer",       ExpectedResult = true)]
+    [TestCase("Castle Fight",    ExpectedResult = true)]
+    [TestCase("Risk Europe",     ExpectedResult = true)]
+    [TestCase("Mini Dota",       ExpectedResult = true)]
+    [TestCase("clan AB",         ExpectedResult = false)]
+    [TestCase("clan XYZ",        ExpectedResult = false)]
+    [TestCase("game-lobby-42",   ExpectedResult = false)]
+    [TestCase("custom_lobby",    ExpectedResult = false)]
+    [TestCase("",                ExpectedResult = false)]
+    public bool IsBannedRoom_ClassifiesCorrectly(string room)
+    {
+        return DefaultChatRooms.IsBannedRoom(room);
+    }
 }

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1205,6 +1205,131 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         public void Emit(Serilog.Events.LogEvent logEvent) => onEmit(logEvent);
     }
 
+    // ── T1 max message length (1024) ──────────────────────────────────────────
+
+    [Test]
+    public async Task SendMessage_ExactlyMaxLength_Broadcasts()
+    {
+        LoginNormal("peter#123");
+        var message = new string('a', 1024);
+
+        await _chatHub.SendMessage(message);
+
+        Assert.AreEqual(1, _groupSendCount, "A message of exactly 1024 chars must broadcast");
+        Assert.AreEqual(1, _chatHistory.GetMessages("W3C Lounge").Count);
+    }
+
+    [Test]
+    public async Task SendMessage_OneOverMaxLength_Rejected()
+    {
+        LoginNormal("peter#123");
+        var message = new string('a', 1025);
+
+        await _chatHub.SendMessage(message);
+
+        Assert.AreEqual(0, _groupSendCount, "A 1025-char message must be rejected (not broadcast)");
+        Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"), "Over-length message must not enter history");
+    }
+
+    [Test]
+    public async Task SendMessage_FarOverMaxLength_RejectedWithoutAbort()
+    {
+        LoginNormal("peter#123");
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+        var message = new string('a', 5000);
+
+        await _chatHub.SendMessage(message);
+
+        Assert.AreEqual(0, _groupSendCount, "A 5000-char message must be rejected");
+        Assert.IsFalse(abortCalled, "Over-length rejection must never call Context.Abort() (G1)");
+    }
+
+    [Test]
+    public async Task SendMessage_OverMaxLength_LogsWarningWithBattleTag()
+    {
+        LoginNormal("peter#123");
+        var capturedLogs = new List<string>();
+        var sink = new DelegatingLogSink(evt => capturedLogs.Add(evt.RenderMessage()));
+        var originalLogger = Serilog.Log.Logger;
+        Serilog.Log.Logger = new Serilog.LoggerConfiguration()
+            .MinimumLevel.Information()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            await _chatHub.SendMessage(new string('a', 2000));
+
+            var rejectLog = capturedLogs.FirstOrDefault(l => l.Contains("exceeds"));
+            Assert.IsNotNull(rejectLog, "Over-length send must emit a warning log");
+            StringAssert.Contains("peter#123", rejectLog, "Over-length warning must include the battleTag");
+        }
+        finally
+        {
+            Serilog.Log.Logger = originalLogger;
+            (Serilog.Log.Logger as IDisposable)?.Dispose();
+        }
+    }
+
+    // ── T2 battletag in rejection logs ────────────────────────────────────────
+
+    [Test]
+    public async Task SendMessage_NullUser_LogsConnectionIdOnly_NoBattleTag()
+    {
+        // Unauthenticated connection (no RegisterUser/Add) → GetUser null → log carries ConnectionId,
+        // and has no battletag '#' marker.
+        var capturedLogs = new List<string>();
+        var sink = new DelegatingLogSink(evt => capturedLogs.Add(evt.RenderMessage()));
+        var originalLogger = Serilog.Log.Logger;
+        Serilog.Log.Logger = new Serilog.LoggerConfiguration()
+            .MinimumLevel.Information()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            await _chatHub.SendMessage("hello");
+
+            var rejectLog = capturedLogs.FirstOrDefault(l => l.Contains("rejected"));
+            Assert.IsNotNull(rejectLog, "Unauthenticated send must emit a rejection log");
+            StringAssert.Contains("TestId", rejectLog, "Null-user rejection log must include the ConnectionId");
+            StringAssert.DoesNotContain("#", rejectLog, "Null-user rejection log must NOT carry a battletag");
+        }
+        finally
+        {
+            Serilog.Log.Logger = originalLogger;
+            (Serilog.Log.Logger as IDisposable)?.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task SendMessage_NoRoom_UserPresent_LogsBattleTag()
+    {
+        // User registered (T4) but seated in NO room → room-null rejection log carries the battletag.
+        _connectionMapping.RegisterUser("TestId", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        var capturedLogs = new List<string>();
+        var sink = new DelegatingLogSink(evt => capturedLogs.Add(evt.RenderMessage()));
+        var originalLogger = Serilog.Log.Logger;
+        Serilog.Log.Logger = new Serilog.LoggerConfiguration()
+            .MinimumLevel.Information()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            await _chatHub.SendMessage("hello");
+
+            Assert.AreEqual(0, _groupSendCount, "No-room send must be rejected (not broadcast)");
+            var rejectLog = capturedLogs.FirstOrDefault(l => l.Contains("no room membership"));
+            Assert.IsNotNull(rejectLog, "No-room send must emit a rejection log");
+            StringAssert.Contains("peter#123", rejectLog, "No-room rejection log must include the battleTag");
+        }
+        finally
+        {
+            Serilog.Log.Logger = originalLogger;
+            (Serilog.Log.Logger as IDisposable)?.Dispose();
+        }
+    }
+
     [Test]
     public async Task SendMessage_CachedBan_Expired_InBannedRoom_Broadcasts()
     {

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1516,6 +1516,28 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         Assert.AreEqual(1, userLeftCount, "Normal user disconnect must broadcast UserLeft");
     }
 
+    [Test]
+    public async Task OnDisconnectedAsync_ShadowBan_Expired_BroadcastsUserLeft()
+    {
+        // Expiry regression: a cached Shadow ban whose endDate has passed must NOT suppress UserLeft.
+        // GetEffectiveMuteStatus resolves an expired shadow ban to None, so the user was visible —
+        // their UserLeft must broadcast on disconnect, even in a banned room.
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(-1));
+
+        int userLeftCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserLeft", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userLeftCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.OnDisconnectedAsync(null);
+
+        Assert.AreEqual(1, userLeftCount,
+            "Expired shadow ban must NOT suppress UserLeft — user was visible, so UserLeft must broadcast");
+    }
+
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
     [TestCase("W3C Lounge",      ExpectedResult = true)]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1283,6 +1283,49 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task BanUser_LiveUser_FullBan_InExemptRoom_AlsoSendsPlayerBannedFromChat()
+    {
+        // R7/G5: a user full-banned while sitting in an EXEMPT room (clan/lobby) must STILL
+        // receive PlayerBannedFromChat — they must clearly and persistently know they're banned,
+        // independent of channel. The signal is NOT gated on the room being a banned room.
+        var liveUser = new ChatUser("victim#123", false, "AB", new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "clan AB", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var victimProxy = new Mock<ISingleClientProxy>();
+        string signalSent = null;
+        LoungeMute muteInSignal = null;
+        victimProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "PlayerBannedFromChat")
+                {
+                    signalSent = method;
+                    muteInSignal = args[0] as LoungeMute;
+                }
+            })
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
+
+        Assert.AreEqual("PlayerBannedFromChat", signalSent,
+            "Full-banned live user in an EXEMPT room must still receive PlayerBannedFromChat (R7/G5)");
+        Assert.IsNotNull(muteInSignal, "PlayerBannedFromChat payload must include the LoungeMute");
+        Assert.AreEqual("victim#123", muteInSignal.battleTag);
+        Assert.IsFalse(abortCalled,
+            "Context.Abort() must NOT be called when signalling a full ban in an exempt room (G1)");
+    }
+
+    [Test]
     public async Task BanUser_LiveUser_ShadowBan_SendsNoSignalToTarget()
     {
         // Shadow ban: illusion preserved — no PlayerBannedFromChat sent to target
@@ -1401,7 +1444,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task BanUser_UserNotConnected_NoException()
+    public void BanUser_UserNotConnected_NoException()
     {
         // Banning a user who is not currently connected — should complete without error
         var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
@@ -1409,8 +1452,8 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
 
-        Assert.DoesNotThrowAsync(async () =>
-            await _chatHub.BanUser("offline#999", "reason", false, endDate));
+        Assert.DoesNotThrowAsync(() =>
+            _chatHub.BanUser("offline#999", "reason", false, endDate));
     }
 
     // ── Task 2 tests ────────────────────────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1,0 +1,151 @@
+// W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Mutes;
+using W3ChampionsChatService.Settings;
+
+namespace W3ChampionsChatService.Tests;
+
+public class ChatBanRoomScopeTests : IntegrationTestBase
+{
+    private ChatHub _chatHub;
+    private MuteRepository _muteRepository;
+    private Mock<IHubCallerClients> _clients;
+    private Mock<HubCallerContext> _hubCallerContext;
+    private ConnectionMapping _connectionMapping;
+    private ChatHistory _chatHistory;
+    private SettingsRepository _settingsRepository;
+    private Mock<ISingleClientProxy> _callerProxy;
+    private Mock<IClientProxy> _groupProxy;
+
+    // Captured signal tracking
+    private string _lastCallerMethod;
+    private object[] _lastCallerArgs;
+    private string _lastGroupMethod;
+    private object[] _lastGroupArgs;
+    private int _groupSendCount;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _muteRepository = new MuteRepository(MongoClient);
+        _clients = new Mock<IHubCallerClients>();
+        _hubCallerContext = new Mock<HubCallerContext>();
+        _connectionMapping = new ConnectionMapping();
+        _chatHistory = new ChatHistory();
+        _settingsRepository = new SettingsRepository(MongoClient);
+
+        var chatAuthService = new Mock<IChatAuthenticationService>();
+        chatAuthService.Setup(m => m.GetUser(It.IsAny<string>()))
+            .ReturnsAsync(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        _chatHub = new ChatHub(
+            chatAuthService.Object,
+            _muteRepository,
+            _settingsRepository,
+            _connectionMapping,
+            _chatHistory,
+            null);
+
+        _lastCallerMethod = null;
+        _lastCallerArgs = null;
+        _lastGroupMethod = null;
+        _lastGroupArgs = null;
+        _groupSendCount = 0;
+
+        _callerProxy = new Mock<ISingleClientProxy>();
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                _lastCallerMethod = method;
+                _lastCallerArgs = args;
+            })
+            .Returns(Task.CompletedTask);
+
+        _groupProxy = new Mock<IClientProxy>();
+        _groupProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                _lastGroupMethod = method;
+                _lastGroupArgs = args;
+                _groupSendCount++;
+            })
+            .Returns(Task.CompletedTask);
+
+        _clients.Setup(c => c.Caller).Returns(_callerProxy.Object);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+        _chatHub.Clients = _clients.Object;
+
+        _hubCallerContext.Setup(c => c.ConnectionId).Returns("TestId");
+        _chatHub.Context = _hubCallerContext.Object;
+        _chatHub.Groups = new Mock<IGroupManager>().Object;
+    }
+
+    // ── Task 1 test ────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ConnectionMapping_MuteStatus_DefaultIsNone()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+
+        var status = mapping.GetMuteStatus("conn1");
+
+        Assert.AreEqual(MuteStatus.None, status);
+    }
+
+    [Test]
+    public void ConnectionMapping_SetMuteStatus_Roundtrips()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+
+        mapping.SetMuteStatus("conn1", MuteStatus.Shadow);
+
+        Assert.AreEqual(MuteStatus.Shadow, mapping.GetMuteStatus("conn1"));
+    }
+
+    [Test]
+    public void ConnectionMapping_SetMuteStatus_Full_Roundtrips()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+
+        mapping.SetMuteStatus("conn1", MuteStatus.Full);
+
+        Assert.AreEqual(MuteStatus.Full, mapping.GetMuteStatus("conn1"));
+    }
+
+    [Test]
+    public void ConnectionMapping_GetMuteStatus_UnknownConnection_ReturnsNone()
+    {
+        var mapping = new ConnectionMapping();
+
+        var status = mapping.GetMuteStatus("no-such-conn");
+
+        Assert.AreEqual(MuteStatus.None, status);
+    }
+
+    [Test]
+    public void ConnectionMapping_Remove_ClearsMuteStatus()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+        mapping.SetMuteStatus("conn1", MuteStatus.Full);
+
+        mapping.Remove("conn1");
+        // After re-add (e.g. SwitchRoom) status is back to None
+        mapping.Add("conn1", "clan AB", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+
+        Assert.AreEqual(MuteStatus.None, mapping.GetMuteStatus("conn1"));
+    }
+}

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -154,6 +154,173 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         Assert.AreEqual(MuteStatus.None, mapping.GetMuteStatus("conn1"));
     }
 
+    // ── Task 3 helper methods ─────────────────────────────────────────────────
+
+    private async Task AddFullBan(string battleTag, int daysFromNow = 1)
+    {
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = battleTag,
+            endDate = DateTime.UtcNow.AddDays(daysFromNow).ToString("O"),
+            author = "admin#1",
+            reason = "test ban",
+            isShadowBan = false
+        });
+    }
+
+    private async Task AddShadowBan(string battleTag, int daysFromNow = 1)
+    {
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = battleTag,
+            endDate = DateTime.UtcNow.AddDays(daysFromNow).ToString("O"),
+            author = "admin#1",
+            reason = "test shadow ban",
+            isShadowBan = true
+        });
+    }
+
+    // ── Task 3 tests ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Login_FullBan_DoesNotAbortConnection()
+    {
+        await AddFullBan("peter#123");
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        Assert.IsFalse(abortCalled, "Context.Abort() must NOT be called for full-banned users");
+    }
+
+    [Test]
+    public async Task Login_FullBan_SendsPlayerBannedFromChat()
+    {
+        await AddFullBan("peter#123");
+
+        string callerMethodReceived = null;
+        LoungeMute muteReceived = null;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "PlayerBannedFromChat")
+                {
+                    callerMethodReceived = method;
+                    muteReceived = args[0] as LoungeMute;
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        Assert.AreEqual("PlayerBannedFromChat", callerMethodReceived);
+        Assert.IsNotNull(muteReceived);
+        Assert.AreEqual("peter#123", muteReceived.battleTag);
+    }
+
+    [Test]
+    public async Task Login_FullBan_StartChatExcludesBannedRooms()
+    {
+        await AddFullBan("peter#123");
+
+        List<string> roomListReceived = null;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "StartChat" && args.Length >= 4)
+                {
+                    roomListReceived = args[3] as List<string>;
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        Assert.IsNotNull(roomListReceived, "StartChat must still be sent");
+        foreach (var bannedRoom in DefaultChatRooms.Rooms)
+        {
+            Assert.IsFalse(roomListReceived.Contains(bannedRoom),
+                $"Banned room '{bannedRoom}' must not appear in full-banned user's channel list");
+        }
+    }
+
+    [Test]
+    public async Task Login_FullBan_WithClanTag_SeatedInClanRoom()
+    {
+        await AddFullBan("peter#123");
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+
+        // Must be in "clan AB", not in any banned room
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("clan AB", room);
+        Assert.IsFalse(DefaultChatRooms.IsBannedRoom(room));
+    }
+
+    [Test]
+    public async Task Login_FullBan_NoClan_NotSeatedInAnyRoom()
+    {
+        await AddFullBan("peter#123");
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        // No clan → not added to any room
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.IsNull(room, "Full-banned user with no clan must not be seated in any room");
+    }
+
+    [Test]
+    public async Task Login_FullBan_NoClan_StillEmitsStartChat()
+    {
+        // G3: even a full-banned user with no clan/no room must receive a StartChat so legacy
+        // clients can initialize. The payload is an empty-room payload (null room).
+        await AddFullBan("peter#123");
+
+        bool startChatSent = false;
+        string roomArg = "unset";
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "StartChat")
+                {
+                    startChatSent = true;
+                    roomArg = args.Length >= 3 ? args[2] as string : "missing";
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        Assert.IsTrue(startChatSent, "Full-banned user with no clan must still receive a StartChat (G3)");
+        Assert.IsNull(roomArg, "Empty-room StartChat payload must use a null room");
+    }
+
+    [Test]
+    public async Task Login_FullBan_NoBannedUserEntered_Broadcast()
+    {
+        // A second user (normal) is already in W3C Lounge; full-banned user should NOT trigger UserEntered there
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("OtherConn", "W3C Lounge", normalUser);
+
+        var groupUserEnteredCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserEntered", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => groupUserEnteredCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await AddFullBan("peter#123");
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        Assert.AreEqual(0, groupUserEnteredCount,
+            "UserEntered must not be broadcast for full-banned user with no clan");
+    }
+
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
     [TestCase("W3C Lounge",      ExpectedResult = true)]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1538,6 +1538,255 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             "Expired shadow ban must NOT suppress UserLeft — user was visible, so UserLeft must broadcast");
     }
 
+    // ── Task 9 tests — expiry regression ─────────────────────────────────────────
+
+    [Test]
+    public async Task ExpiredFullBan_LoginConnectsNormally()
+    {
+        // An expired full ban must not restrict connect at all:
+        // no abort, no PlayerBannedFromChat, user seated in default room.
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "peter#123",
+            endDate = DateTime.UtcNow.AddDays(-1).ToString("O"),
+            author = "admin#1",
+            reason = "old ban",
+            isShadowBan = false
+        });
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        bool bannedSignalSent = false;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync("PlayerBannedFromChat", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => bannedSignalSent = true)
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        Assert.IsFalse(abortCalled, "Expired ban must not abort connection");
+        Assert.IsFalse(bannedSignalSent, "Expired ban must not send PlayerBannedFromChat");
+
+        // Must be seated in the default room (not blocked from entering)
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("W3C Lounge", room, "Expired-ban user must be seated in the default room");
+    }
+
+    [Test]
+    public async Task ExpiredFullBan_SwitchRoomToBannedRoom_IsAllowed()
+    {
+        // Expired ban → cached as None → SwitchRoom into a banned room must succeed.
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "peter#123",
+            endDate = DateTime.UtcNow.AddDays(-1).ToString("O"),
+            author = "admin#1",
+            reason = "old ban",
+            isShadowBan = false
+        });
+
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        // Expired: correctly cached as None (not Full)
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
+
+        await _chatHub.SwitchRoom("W3C Lounge");
+
+        Assert.AreEqual("W3C Lounge", _connectionMapping.GetRoom("TestId"),
+            "Expired ban must not block joining a banned room via SwitchRoom");
+    }
+
+    [Test]
+    public async Task ExpiredShadowBan_SendMessage_CachedExpiredEndDate_Broadcasts()
+    {
+        // Cached Shadow ban whose EndDate is in the past → treated as None at the cache level,
+        // so SendMessage must broadcast without consulting the DB.
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        // Cache a shadow ban that has already expired
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(-1));
+        // DB has NO active ban (IntegrationTestBase drops the DB before each test).
+
+        await _chatHub.SendMessage("Should broadcast now");
+
+        Assert.AreEqual(1, _groupSendCount,
+            "Cached shadow ban with expired EndDate must not restrict sending — message must broadcast");
+        Assert.AreEqual(1, _chatHistory.GetMessages("W3C Lounge").Count,
+            "Message from expired shadow-ban must enter history");
+    }
+
+    // ── Task 10 tests — §15 integration sweep ────────────────────────────────────
+
+    [Test]
+    public async Task UnbannedUser_SwitchRoom_ToAllRoomTypes_Allowed()
+    {
+        // An unbanned user must be able to switch freely between banned rooms, clan rooms, and lobbies.
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
+
+        await _chatHub.SwitchRoom("1 vs 1");
+        Assert.AreEqual("1 vs 1", _connectionMapping.GetRoom("TestId"),
+            "Unbanned user must be allowed into a banned room");
+
+        await _chatHub.SwitchRoom("clan AB");
+        Assert.AreEqual("clan AB", _connectionMapping.GetRoom("TestId"),
+            "Unbanned user must be allowed into a clan room");
+
+        await _chatHub.SwitchRoom("game-lobby-1");
+        Assert.AreEqual("game-lobby-1", _connectionMapping.GetRoom("TestId"),
+            "Unbanned user must be allowed into a lobby room");
+    }
+
+    [Test]
+    public async Task MembershipInvariant_UserNotInAnyRoom_SendRejected()
+    {
+        // R6: a user that has NO room membership must not be able to broadcast a message.
+        // ConnectionMapping has no entry for TestId at all.
+        await _chatHub.SendMessage("Ghost message");
+
+        Assert.AreEqual(0, _groupSendCount,
+            "User with no room membership must not be able to broadcast (R6 membership invariant)");
+    }
+
+    [Test]
+    public void ShadowBan_UsersOfRoom_OtherMembersDoNotSeeTheShadowUser()
+    {
+        // Integration: the ConnectionMapping used by the hub correctly hides shadow users
+        // from normal members in banned rooms.
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        var shadowUser = new ChatUser("shadow#2", false, null, new ProfilePicture(), null, null);
+
+        _connectionMapping.Add("NormalConn", "W3C Lounge", normalUser);
+        _connectionMapping.Add("ShadowConn", "W3C Lounge", shadowUser);
+        _connectionMapping.SetMute("ShadowConn", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        // Normal user's view must not include the shadow-banned user
+        var visibleToNormal = _connectionMapping.GetUsersOfRoomForViewer("W3C Lounge", "NormalConn");
+        Assert.AreEqual(1, visibleToNormal.Count,
+            "Normal user must see exactly 1 member (shadow user is hidden)");
+        Assert.AreEqual("normal#1", visibleToNormal[0].BattleTag);
+
+        // Shadow user's own view must include themselves
+        var visibleToShadow = _connectionMapping.GetUsersOfRoomForViewer("W3C Lounge", "ShadowConn");
+        Assert.AreEqual(2, visibleToShadow.Count,
+            "Shadow-banned user must see both themselves and the normal user");
+    }
+
+    [Test]
+    public async Task FullBan_PersistedDefaultChatIsBannedRoom_OverriddenToSafe()
+    {
+        // Edge case (§15): a full-banned user whose persisted DefaultChat is a banned room
+        // must NOT be seated in that banned room at connect. They must be placed in their clan
+        // room instead (default settings have DefaultChat = "W3C Lounge").
+        await AddFullBan("peter#123");
+
+        // Default ChatSettings has DefaultChat = "W3C Lounge" (a banned room).
+        // The user has ClanTag "AB" → must end up in "clan AB", not "W3C Lounge".
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("clan AB", room,
+            "Full-banned user's persisted DefaultChat (a banned room) must be overridden to their clan room");
+        Assert.IsFalse(DefaultChatRooms.IsBannedRoom(room),
+            "The seat room after login must not be a banned room");
+    }
+
+    // ── Task 11 tests — spec §16 backward-compatibility guardrails ────────────────
+
+    [Test]
+    public async Task Compat_SwitchRoom_FullBanRejected_DoesNotAbort_KeepsCurrentRoom()
+    {
+        // G1/G2: rejecting a full-banned join must not call Context.Abort() AND must leave the
+        // user in their current valid room (return BEFORE any Remove/Add).
+        await AddFullBan("peter#123");
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        Assert.DoesNotThrowAsync(async () => await _chatHub.SwitchRoom("W3C Lounge"),
+            "Rejected SwitchRoom must return gracefully, not throw (G2)");
+        Assert.IsFalse(abortCalled, "G1: SwitchRoom rejection must never call Context.Abort()");
+        Assert.AreEqual("clan AB", _connectionMapping.GetRoom("TestId"),
+            "G2: rejected SwitchRoom must keep the user in their current valid room");
+    }
+
+    [Test]
+    public async Task Compat_SendMessage_FullBanInBannedRoom_DoesNotAbort_NoBroadcast()
+    {
+        // G1/G2: rejecting a full-banned send must not call Context.Abort(), not throw, and
+        // must leave the user's room membership intact.
+        await AddFullBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        Assert.DoesNotThrowAsync(async () => await _chatHub.SendMessage("blocked"),
+            "Rejected SendMessage must return gracefully, not throw (G2)");
+        Assert.IsFalse(abortCalled, "G1: SendMessage rejection must never call Context.Abort()");
+        Assert.AreEqual(0, _groupSendCount, "Rejected message must not be broadcast");
+        Assert.AreEqual("W3C Lounge", _connectionMapping.GetRoom("TestId"),
+            "G2: rejected SendMessage must not corrupt the user's room membership");
+    }
+
+    [Test]
+    public void Compat_SendMessage_NoRoom_MembershipReject_DoesNotAbort()
+    {
+        // G1/G2: membership-before-send rejection (null room) must not call Context.Abort() or throw.
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        Assert.DoesNotThrowAsync(async () => await _chatHub.SendMessage("ghost"),
+            "Membership-reject SendMessage must return gracefully, not throw (G2)");
+        Assert.IsFalse(abortCalled, "G1: membership rejection must never call Context.Abort()");
+        Assert.AreEqual(0, _groupSendCount,
+            "No broadcast for membership-rejected message");
+    }
+
+    [Test]
+    public async Task Compat_Login_FullBanNoClan_StillEmitsStartChat_NoAbort()
+    {
+        // G1 + G3: a full-banned user with no clan must connect without abort AND receive a
+        // StartChat so a legacy client can initialize from it.
+        await AddFullBan("peter#123");
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        bool startChatSent = false;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync("StartChat", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => startChatSent = true)
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        Assert.IsFalse(abortCalled, "G1: full-ban connect must never call Context.Abort()");
+        Assert.IsTrue(startChatSent,
+            "G3: connect must always emit a StartChat, even for full-ban with no clan/no room");
+    }
+
+    [Test]
+    public async Task Compat_Login_FullBan_StillSendsLegacyPlayerBannedFromChat()
+    {
+        // G5: legacy clients depend on PlayerBannedFromChat to render their in-channel ban notice.
+        // This must still flow at connect regardless of whether the user has a clan.
+        await AddFullBan("peter#123");
+
+        bool bannedSignalSent = false;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync("PlayerBannedFromChat", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => bannedSignalSent = true)
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+
+        Assert.IsTrue(bannedSignalSent,
+            "G5: full-ban connect must still emit the legacy PlayerBannedFromChat event");
+    }
+
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
     [TestCase("W3C Lounge",      ExpectedResult = true)]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -94,65 +94,118 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     // ── Task 1 test ────────────────────────────────────────────────────────────
 
     [Test]
-    public void ConnectionMapping_MuteStatus_DefaultIsNone()
+    public void ConnectionMapping_Mute_DefaultIsCacheMiss()
     {
+        // A connection that has never had SetMute called must be a MISS (TryGetMute returns false).
         var mapping = new ConnectionMapping();
         mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
 
-        var status = mapping.GetMuteStatus("conn1");
+        var hasCached = mapping.TryGetMute("conn1", out _);
+
+        Assert.IsFalse(hasCached, "A connection with no SetMute call must be a cache MISS");
+    }
+
+    [Test]
+    public void ConnectionMapping_SetMute_Shadow_Roundtrips()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+        var endDate = DateTime.UtcNow.AddDays(1);
+
+        mapping.SetMute("conn1", MuteStatus.Shadow, endDate);
+
+        Assert.IsTrue(mapping.TryGetMute("conn1", out var cached), "Cache entry must exist after SetMute");
+        Assert.AreEqual(MuteStatus.Shadow, cached.Status);
+        Assert.AreEqual(endDate, cached.EndDate);
+        Assert.AreEqual(MuteStatus.Shadow, mapping.GetEffectiveMuteStatus("conn1", DateTime.UtcNow));
+    }
+
+    [Test]
+    public void ConnectionMapping_SetMute_Full_Roundtrips()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+        var endDate = DateTime.UtcNow.AddDays(1);
+
+        mapping.SetMute("conn1", MuteStatus.Full, endDate);
+
+        Assert.IsTrue(mapping.TryGetMute("conn1", out var cached), "Cache entry must exist after SetMute");
+        Assert.AreEqual(MuteStatus.Full, cached.Status);
+        Assert.AreEqual(endDate, cached.EndDate);
+        Assert.AreEqual(MuteStatus.Full, mapping.GetEffectiveMuteStatus("conn1", DateTime.UtcNow));
+    }
+
+    [Test]
+    public void ConnectionMapping_GetEffectiveMuteStatus_UnknownConnection_ReturnsNone()
+    {
+        var mapping = new ConnectionMapping();
+
+        var status = mapping.GetEffectiveMuteStatus("no-such-conn", DateTime.UtcNow);
 
         Assert.AreEqual(MuteStatus.None, status);
     }
 
     [Test]
-    public void ConnectionMapping_SetMuteStatus_Roundtrips()
+    public void ConnectionMapping_TryGetMute_UnknownConnection_ReturnsFalse()
     {
         var mapping = new ConnectionMapping();
-        mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
 
-        mapping.SetMuteStatus("conn1", MuteStatus.Shadow);
+        var found = mapping.TryGetMute("no-such-conn", out _);
 
-        Assert.AreEqual(MuteStatus.Shadow, mapping.GetMuteStatus("conn1"));
+        Assert.IsFalse(found, "TryGetMute must return false for an unknown connection (cache MISS)");
     }
 
     [Test]
-    public void ConnectionMapping_SetMuteStatus_Full_Roundtrips()
+    public void ConnectionMapping_GetEffectiveMuteStatus_ExpiredBan_ReturnsNone()
     {
+        // A cached ban whose EndDate is in the past must be treated as None.
         var mapping = new ConnectionMapping();
         mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+        var expiredEnd = DateTime.UtcNow.AddDays(-1);
+        mapping.SetMute("conn1", MuteStatus.Full, expiredEnd);
 
-        mapping.SetMuteStatus("conn1", MuteStatus.Full);
+        var status = mapping.GetEffectiveMuteStatus("conn1", DateTime.UtcNow);
 
-        Assert.AreEqual(MuteStatus.Full, mapping.GetMuteStatus("conn1"));
+        Assert.AreEqual(MuteStatus.None, status,
+            "Cached ban with EndDate in the past must be treated as None (expired)");
     }
 
     [Test]
-    public void ConnectionMapping_GetMuteStatus_UnknownConnection_ReturnsNone()
+    public void ConnectionMapping_SetMute_None_IsAHitWithNoneStatus()
     {
+        // An explicitly-resolved unbanned connection (SetMute None) must be a cache HIT
+        // that returns None — distinguishes "never resolved" (MISS) from "resolved, no ban".
         var mapping = new ConnectionMapping();
+        mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
 
-        var status = mapping.GetMuteStatus("no-such-conn");
+        mapping.SetMute("conn1", MuteStatus.None, DateTime.MinValue);
 
-        Assert.AreEqual(MuteStatus.None, status);
+        Assert.IsTrue(mapping.TryGetMute("conn1", out var cached), "SetMute(None) must produce a cache HIT");
+        Assert.AreEqual(MuteStatus.None, cached.Status);
+        Assert.AreEqual(MuteStatus.None, mapping.GetEffectiveMuteStatus("conn1", DateTime.UtcNow));
     }
 
     [Test]
-    public void ConnectionMapping_Remove_ClearsMuteStatus()
+    public void ConnectionMapping_Remove_ClearsMuteEntry()
     {
         var mapping = new ConnectionMapping();
         mapping.Add("conn1", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
-        mapping.SetMuteStatus("conn1", MuteStatus.Full);
+        mapping.SetMute("conn1", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
         mapping.Remove("conn1");
 
-        // Direct assertion: Remove must clear the cached status immediately,
+        // Direct assertion: Remove must clear the cached entry immediately,
         // before any re-Add — guards against a Remove that silently does nothing.
-        Assert.AreEqual(MuteStatus.None, mapping.GetMuteStatus("conn1"));
+        Assert.IsFalse(mapping.TryGetMute("conn1", out _),
+            "Remove must clear the mute cache entry (cache MISS after Remove)");
+        Assert.AreEqual(MuteStatus.None, mapping.GetEffectiveMuteStatus("conn1", DateTime.UtcNow),
+            "GetEffectiveMuteStatus must return None after Remove (MISS → None)");
 
-        // After re-add (e.g. SwitchRoom) status is still None
+        // After re-add (e.g. SwitchRoom re-populates) status comes back only after explicit SetMute
         mapping.Add("conn1", "clan AB", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
 
-        Assert.AreEqual(MuteStatus.None, mapping.GetMuteStatus("conn1"));
+        Assert.IsFalse(mapping.TryGetMute("conn1", out _),
+            "After Remove+re-Add with no SetMute, cache must still be a MISS");
     }
 
     // ── Task 3 helper methods ─────────────────────────────────────────────────
@@ -350,7 +403,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     private void LoginNormal(string battleTag = "peter#123", string clanTag = null)
     {
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser(battleTag, false, clanTag, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.None);
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
     }
 
     [Test]
@@ -359,7 +412,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         await AddFullBan("peter#123");
         // Seat user in a non-banned room as if they connected with a clan
         _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
         await _chatHub.SwitchRoom("W3C Lounge");
 
@@ -377,7 +430,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     {
         await AddFullBan("peter#123");
         _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
         await _chatHub.SwitchRoom(bannedRoom);
 
@@ -390,7 +443,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     {
         await AddFullBan("peter#123");
         _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
         await _chatHub.SwitchRoom("clan XYZ");
 
@@ -403,7 +456,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     {
         await AddFullBan("peter#123");
         _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
         await _chatHub.SwitchRoom("game-lobby-9999");
 
@@ -417,7 +470,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // G1: rejected SwitchRoom must NEVER call Context.Abort()
         await AddFullBan("peter#123");
         _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
@@ -435,7 +488,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // SwitchRoom must lazily resolve from DB and still reject the move into a banned room.
         await AddFullBan("peter#123");
         // Seated in a room but with no cached MuteStatus (default None), reproducing the
-        // no-clan full-ban login path where SetMuteStatus was never called.
+        // no-clan full-ban login path where SetMute was never called.
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
 
         await _chatHub.SwitchRoom("1 vs 1");
@@ -451,7 +504,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     {
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         int userEnteredCount = 0;
         _groupProxy
@@ -472,7 +525,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // even though UserEntered is suppressed.
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         await _chatHub.SwitchRoom("1 vs 1");
 
@@ -492,7 +545,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         // Shadow-banned user joins from "W3C Lounge"
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         List<ChatUser> startChatUsers = null;
         _callerProxy
@@ -519,7 +572,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // for a shadow user moving into a banned room (they were already "invisible")
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         int userLeftCount = 0;
         _groupProxy
@@ -539,7 +592,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     {
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         int userEnteredCount = 0;
         _groupProxy
@@ -565,7 +618,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // The target is banned, so the enter must be suppressed (ghost-join).
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "clan XYZ", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         int userLeftCount = 0;
         int userEnteredCount = 0;
@@ -595,7 +648,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // visible and the enter must fire.
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         int userLeftCount = 0;
         int userEnteredCount = 0;
@@ -658,7 +711,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // Full-banned user somehow ends up in a banned room (defense-in-depth)
         await AddFullBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
@@ -675,7 +728,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     {
         await AddFullBan("peter#123");
         _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
 
         await _chatHub.SendMessage("Hello clan");
 
@@ -689,7 +742,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     {
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         ChatMessage callerEcho = null;
         _callerProxy
@@ -714,7 +767,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     {
         await AddShadowBan("peter#123");
         _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
 
         await _chatHub.SendMessage("Clan message");
 
@@ -727,7 +780,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     public async Task SendMessage_NoBan_NormalUser_Broadcasts()
     {
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.None);
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
 
         await _chatHub.SendMessage("Normal message");
 
@@ -748,7 +801,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             isShadowBan = false
         });
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.None);
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
 
         await _chatHub.SendMessage("Should broadcast");
 
@@ -760,11 +813,93 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     public async Task SendMessage_UnbannedUser_InAllRoomTypes_Broadcasts()
     {
         _connectionMapping.Add("TestId", "2 vs 2", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        _connectionMapping.SetMuteStatus("TestId", MuteStatus.None);
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
 
         await _chatHub.SendMessage("Ladder message");
 
         Assert.AreEqual(1, _groupSendCount, "Unbanned user must broadcast in any room");
+    }
+
+    // ── New tests pinning cache-endDate behavior (spec §7) ────────────────────
+
+    [Test]
+    public async Task SendMessage_CacheMiss_ActiveDbBan_InBannedRoom_Enforced()
+    {
+        // Lazy-resolve success path: no cache entry (MISS) + active ban in DB + banned room → enforced.
+        // This covers the no-clan full-ban login edge case where SetMute was never called at login.
+        await AddFullBan("peter#123");
+        // Manually add the user to a banned room WITHOUT calling SetMute (simulates the no-clan login path).
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        // Do NOT call SetMute — leave a MISS.
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        await _chatHub.SendMessage("Should be rejected");
+
+        Assert.IsFalse(abortCalled, "Context.Abort() must not be called");
+        Assert.AreEqual(0, _groupSendCount,
+            "Cache-miss lazy-resolved full-ban in banned room must reject the message");
+        Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"),
+            "Rejected message must not enter history");
+    }
+
+    [Test]
+    public async Task SendMessage_CachedBan_Expired_InBannedRoom_Broadcasts()
+    {
+        // Cache shows a ban but its EndDate <= now → treated as expired → message broadcasts.
+        // Verifies expiry is honored from the cached endDate without any DB read.
+        // (No active ban in DB either, so if there WERE a DB read it would also return None —
+        //  but the point is the cache alone is sufficient.)
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        // Set a full-ban cache entry with an expiry in the PAST.
+        var expiredEndDate = DateTime.UtcNow.AddDays(-1);
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, expiredEndDate);
+
+        await _chatHub.SendMessage("Should broadcast after expiry");
+
+        Assert.AreEqual(1, _groupSendCount,
+            "Cached ban with expired EndDate must be treated as no ban — message must broadcast");
+        Assert.AreEqual(1, _chatHistory.GetMessages("W3C Lounge").Count,
+            "Message from expired-ban user must be added to history");
+    }
+
+    [Test]
+    public async Task SendMessage_CachedNonNone_ActiveBan_InBannedRoom_NoRepositoryCall()
+    {
+        // Cache HIT with non-None active ban → zero repository calls (spec §7 "no per-message DB read").
+        //
+        // Proof strategy: the live DB has NO ban for "peter#123" (SetUp drops the DB).
+        // If SendMessage consulted the DB it would find no ban and broadcast the message.
+        // Because the cache has an active shadow ban, the message is DROPPED instead.
+        // A dropped message (group count = 0) proves the decision came from the cache alone,
+        // not from a DB read (which would have returned None → broadcast).
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        // Cache a shadow ban with a future EndDate — non-None HIT, no DB read should occur.
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+        // DB has NO ban (SetUp already wiped the database).
+
+        ChatMessage callerEcho = null;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "ReceiveMessage" && args.Length > 0)
+                    callerEcho = args[0] as ChatMessage;
+            })
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.SendMessage("Hello lounge");
+
+        // If the DB had been consulted it would return None (no ban in DB) → message would broadcast.
+        // The message was DROPPED (group=0, echo to caller) → proves the cached shadow ban was the
+        // authoritative source, fulfilling spec §7 "no per-message DB read" for cached non-None bans.
+        Assert.AreEqual(0, _groupSendCount,
+            "Cached non-None active ban must drop the message with ZERO DB reads (spec §7)");
+        Assert.IsNotNull(callerEcho,
+            "Shadow-banned user must still receive an echo of their own message");
+        Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"),
+            "Dropped message must not enter history");
     }
 
     // ── Task 2 tests ────────────────────────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -434,13 +434,9 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // (because they had no clan), so their MuteStatus is None in cache.
         // SwitchRoom must lazily resolve from DB and still reject the move into a banned room.
         await AddFullBan("peter#123");
-        // NOT calling _connectionMapping.SetMuteStatus — simulating the "no clan at login" path.
-        // The user is seated nowhere yet (simulating them calling SwitchRoom to try to join W3C Lounge).
-        // We DON'T add them to the mapping at all — GetUser returns null, lazy resolution must still work.
-        // Actually: the user must be seated somewhere for SwitchRoom to have a user object.
-        // Simulate: user connected but is in the mapping with None mute status (cache miss).
+        // Seated in a room but with no cached MuteStatus (default None), reproducing the
+        // no-clan full-ban login path where SetMuteStatus was never called.
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        // MuteStatus is None (default — cache miss, as if they came via the no-clan full-ban login path)
 
         await _chatHub.SwitchRoom("1 vs 1");
 
@@ -559,6 +555,66 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             "Shadow-banned user entering an exempt room must broadcast UserEntered normally");
         var room = _connectionMapping.GetRoom("TestId");
         Assert.AreEqual("clan XYZ", room);
+    }
+
+    [Test]
+    public async Task SwitchRoom_ShadowBan_ExemptToBanned_StillBroadcastsUserLeft()
+    {
+        // Cross-category: shadow user was VISIBLE in an exempt room, so leaving it must still
+        // broadcast UserLeft (else a stale ghost lingers in the exempt room's user list).
+        // The target is banned, so the enter must be suppressed (ghost-join).
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "clan XYZ", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        int userLeftCount = 0;
+        int userEnteredCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserLeft", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userLeftCount++)
+            .Returns(Task.CompletedTask);
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserEntered", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userEnteredCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.SwitchRoom("W3C Lounge");
+
+        Assert.AreEqual(1, userLeftCount,
+            "Shadow user leaving an EXEMPT room (where they were visible) must broadcast UserLeft");
+        Assert.AreEqual(0, userEnteredCount,
+            "Shadow user ghost-joining a BANNED target room must NOT broadcast UserEntered");
+    }
+
+    [Test]
+    public async Task SwitchRoom_ShadowBan_BannedToExempt_SuppressesUserLeft()
+    {
+        // Cross-category: shadow user was a GHOST in a banned room (no one saw them enter),
+        // so leaving it must NOT broadcast UserLeft. The target is exempt, so they become
+        // visible and the enter must fire.
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        int userLeftCount = 0;
+        int userEnteredCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserLeft", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userLeftCount++)
+            .Returns(Task.CompletedTask);
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserEntered", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userEnteredCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.SwitchRoom("clan XYZ");
+
+        Assert.AreEqual(0, userLeftCount,
+            "Shadow user leaving a BANNED room (where they were a ghost) must NOT broadcast UserLeft");
+        Assert.AreEqual(1, userEnteredCount,
+            "Shadow user entering an EXEMPT target room must broadcast UserEntered (becomes visible)");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1326,6 +1326,67 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task BanUser_LiveUser_MultipleConnections_AllReconciled()
+    {
+        // A user can be connected from multiple clients (multiple connection ids). A full ban
+        // must reconcile EVERY live connection: each cache flips to Full AND each receives
+        // PlayerBannedFromChat. No Context.Abort() on any of them.
+        var conn1User = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        var conn2User = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn1", "W3C Lounge", conn1User);
+        _connectionMapping.SetMute("VictimConn1", MuteStatus.None, DateTime.MinValue);
+        _connectionMapping.Add("VictimConn2", "1 vs 1", conn2User);
+        _connectionMapping.SetMute("VictimConn2", MuteStatus.None, DateTime.MinValue);
+
+        var victim1Signals = 0;
+        var victim1Proxy = new Mock<ISingleClientProxy>();
+        victim1Proxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, _, _) =>
+            {
+                if (method == "PlayerBannedFromChat") victim1Signals++;
+            })
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn1")).Returns(victim1Proxy.Object);
+
+        var victim2Signals = 0;
+        var victim2Proxy = new Mock<ISingleClientProxy>();
+        victim2Proxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, _, _) =>
+            {
+                if (method == "PlayerBannedFromChat") victim2Signals++;
+            })
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client("VictimConn2")).Returns(victim2Proxy.Object);
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
+
+        // Both caches updated to Full
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn1", out var cached1));
+        Assert.AreEqual(MuteStatus.Full, cached1.Status,
+            "First connection's cache must be reconciled to Full");
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn2", out var cached2));
+        Assert.AreEqual(MuteStatus.Full, cached2.Status,
+            "Second connection's cache must be reconciled to Full");
+
+        // Both connections received exactly one PlayerBannedFromChat
+        Assert.AreEqual(1, victim1Signals,
+            "First connection must receive PlayerBannedFromChat");
+        Assert.AreEqual(1, victim2Signals,
+            "Second connection must receive PlayerBannedFromChat");
+
+        Assert.IsFalse(abortCalled, "Context.Abort() must NOT be called on any connection (G1)");
+    }
+
+    [Test]
     public async Task BanUser_LiveUser_ShadowBan_SendsNoSignalToTarget()
     {
         // Shadow ban: illusion preserved — no PlayerBannedFromChat sent to target

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -22,6 +22,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     private ConnectionMapping _connectionMapping;
     private ChatHistory _chatHistory;
     private SettingsRepository _settingsRepository;
+    private MuteReconciliationTestHarness _reconcileHarness;
     private Mock<ISingleClientProxy> _callerProxy;
     private Mock<IClientProxy> _groupProxy;
 
@@ -41,6 +42,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping = new ConnectionMapping();
         _chatHistory = new ChatHistory();
         _settingsRepository = new SettingsRepository(MongoClient);
+        _reconcileHarness = new MuteReconciliationTestHarness(_connectionMapping);
 
         var chatAuthService = new Mock<IChatAuthenticationService>();
         chatAuthService.Setup(m => m.GetUser(It.IsAny<string>()))
@@ -52,6 +54,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             _settingsRepository,
             _connectionMapping,
             _chatHistory,
+            _reconcileHarness.Service,
             null);
 
         _lastCallerMethod = null;
@@ -524,6 +527,28 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task SwitchRoom_FullBan_NoClan_RejectedByNullUserGuard()
+    {
+        // A no-clan full-banned user is seated in NO room, so GetUser returns null for their
+        // connection. A SwitchRoom attempt is therefore rejected by SwitchRoom's `user == null`
+        // early-return — NOT by the cache gate (the cache seed is defense-in-depth). The user must
+        // remain in no room and the call must be graceful (no abort, no throw).
+        await AddFullBan("peter#123");
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        Assert.IsNull(_connectionMapping.GetRoom("TestId"), "Precondition: no-clan full-ban user is in no room");
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        Assert.DoesNotThrowAsync(async () => await _chatHub.SwitchRoom("1 vs 1"),
+            "SwitchRoom with no user must return gracefully, not throw");
+
+        Assert.IsNull(_connectionMapping.GetRoom("TestId"),
+            "No-clan full-ban user must remain in no room after a SwitchRoom attempt (rejected by null-user guard)");
+        Assert.IsFalse(abortCalled, "Null-user SwitchRoom must never call Context.Abort() (G1)");
+    }
+
+    [Test]
     public async Task SwitchRoom_FullBan_ExemptThenPublic_StillRejected()
     {
         // SECURITY regression (full-ban bypass): a full-banned connection seeded with Full at login.
@@ -920,21 +945,28 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     /// <summary>
-    /// A <see cref="MuteRepository"/> spy that counts <see cref="MuteRepository.GetMutedPlayer"/>
-    /// calls so a test can assert the send/switch hot paths perform ZERO mute-repository reads.
+    /// An <see cref="IMuteRepository"/> spy (decorator over a real <see cref="MuteRepository"/>) that
+    /// counts <see cref="IMuteRepository.GetMutedPlayer"/> calls so a test can assert the send/switch
+    /// hot paths perform ZERO mute-repository reads.
     /// </summary>
-    private sealed class CountingMuteRepository(MongoDB.Driver.MongoClient client) : MuteRepository(client)
+    private sealed class CountingMuteRepository(MongoDB.Driver.MongoClient client) : IMuteRepository
     {
+        private readonly MuteRepository _inner = new(client);
+
         public int GetMutedPlayerCallCount { get; private set; }
 
-        public override Task<LoungeMute> GetMutedPlayer(string battleTag)
+        public Task<LoungeMute> GetMutedPlayer(string battleTag)
         {
             GetMutedPlayerCallCount++;
-            return base.GetMutedPlayer(battleTag);
+            return _inner.GetMutedPlayer(battleTag);
         }
+
+        public Task AddLoungeMute(LoungeMuteRequest loungeMuteRequest) => _inner.AddLoungeMute(loungeMuteRequest);
+        public Task<System.Collections.Generic.List<LoungeMute>> GetLoungeMutes() => _inner.GetLoungeMutes();
+        public Task<MongoDB.Driver.DeleteResult> DeleteLoungeMute(string battleTag) => _inner.DeleteLoungeMute(battleTag);
     }
 
-    private ChatHub BuildHubWithRepository(MuteRepository repository)
+    private ChatHub BuildHubWithRepository(IMuteRepository repository)
     {
         var chatAuthService = new Mock<IChatAuthenticationService>();
         chatAuthService.Setup(m => m.GetUser(It.IsAny<string>()))
@@ -946,6 +978,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             _settingsRepository,
             _connectionMapping,
             _chatHistory,
+            _reconcileHarness.Service,
             null)
         {
             Clients = _clients.Object,
@@ -1314,13 +1347,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
         _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
 
-        // Mock Clients.Client so the PlayerBannedFromChat send doesn't NRE
-        var victimProxy = new Mock<ISingleClientProxy>();
-        victimProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
-
-        // Admin performs ban
+        // Admin performs ban (the reconcile signal goes through the MuteReconciliationService harness).
         var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
         _hubCallerContext.Setup(c => c.ConnectionId).Returns("TestId");
@@ -1362,12 +1389,6 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
         _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
 
-        // Mock Clients.Client so the PlayerBannedFromChat send doesn't NRE
-        var victimProxy = new Mock<ISingleClientProxy>();
-        victimProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
-
         var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
 
@@ -1384,27 +1405,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     [Test]
     public async Task BanUser_LiveUser_FullBan_InBannedRoom_SendsPlayerBannedFromChat()
     {
-        // Live user sitting in W3C Lounge (a banned room)
+        // Live user sitting in W3C Lounge (a public room)
         var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
         _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
-
-        // Separate client proxy for the victim connection
-        var victimProxy = new Mock<ISingleClientProxy>();
-        string signalSent = null;
-        object payloadInSignal = null;
-        victimProxy
-            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((method, args, _) =>
-            {
-                if (method == "PlayerBannedFromChat")
-                {
-                    signalSent = method;
-                    payloadInSignal = args[0];
-                }
-            })
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
 
         var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
@@ -1412,7 +1416,9 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
         await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
 
-        Assert.AreEqual("PlayerBannedFromChat", signalSent,
+        // The reconcile signal flows through MuteReconciliationService (IHubContext), captured by the harness.
+        var payloadInSignal = _reconcileHarness.PayloadFor("VictimConn", "PlayerBannedFromChat");
+        Assert.AreEqual(1, _reconcileHarness.SignalCount("VictimConn", "PlayerBannedFromChat"),
             "Live fully-banned user in a public room must receive PlayerBannedFromChat");
         // SECURITY: the slimmed payload carries ONLY the expiry — never the LoungeMute.
         Assert.IsNotInstanceOf<LoungeMute>(payloadInSignal,
@@ -1427,12 +1433,6 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
         _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
-
-        var victimProxy = new Mock<ISingleClientProxy>();
-        victimProxy
-            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
 
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
@@ -1456,12 +1456,6 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
         _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
 
-        var victimProxy = new Mock<ISingleClientProxy>();
-        victimProxy
-            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
-
         var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
 
@@ -1484,22 +1478,6 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping.Add("VictimConn", "clan AB", liveUser);
         _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
 
-        var victimProxy = new Mock<ISingleClientProxy>();
-        string signalSent = null;
-        object payloadInSignal = null;
-        victimProxy
-            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((method, args, _) =>
-            {
-                if (method == "PlayerBannedFromChat")
-                {
-                    signalSent = method;
-                    payloadInSignal = args[0];
-                }
-            })
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
-
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
 
@@ -1509,7 +1487,8 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
         await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
 
-        Assert.AreEqual("PlayerBannedFromChat", signalSent,
+        var payloadInSignal = _reconcileHarness.PayloadFor("VictimConn", "PlayerBannedFromChat");
+        Assert.AreEqual(1, _reconcileHarness.SignalCount("VictimConn", "PlayerBannedFromChat"),
             "Full-banned live user in an EXEMPT room must still receive PlayerBannedFromChat (R7/G5)");
         // SECURITY: the slimmed payload carries ONLY the expiry — never the LoungeMute.
         Assert.IsNotInstanceOf<LoungeMute>(payloadInSignal,
@@ -1532,28 +1511,6 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping.Add("VictimConn2", "1 vs 1", conn2User);
         _connectionMapping.SetMute("VictimConn2", MuteStatus.None, DateTime.MinValue);
 
-        var victim1Signals = 0;
-        var victim1Proxy = new Mock<ISingleClientProxy>();
-        victim1Proxy
-            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((method, _, _) =>
-            {
-                if (method == "PlayerBannedFromChat") victim1Signals++;
-            })
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn1")).Returns(victim1Proxy.Object);
-
-        var victim2Signals = 0;
-        var victim2Proxy = new Mock<ISingleClientProxy>();
-        victim2Proxy
-            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((method, _, _) =>
-            {
-                if (method == "PlayerBannedFromChat") victim2Signals++;
-            })
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn2")).Returns(victim2Proxy.Object);
-
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
 
@@ -1571,10 +1528,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         Assert.AreEqual(MuteStatus.Full, cached2.Status,
             "Second connection's cache must be reconciled to Full");
 
-        // Both connections received exactly one PlayerBannedFromChat
-        Assert.AreEqual(1, victim1Signals,
+        // Both connections received exactly one PlayerBannedFromChat (via the reconcile harness)
+        Assert.AreEqual(1, _reconcileHarness.SignalCount("VictimConn1", "PlayerBannedFromChat"),
             "First connection must receive PlayerBannedFromChat");
-        Assert.AreEqual(1, victim2Signals,
+        Assert.AreEqual(1, _reconcileHarness.SignalCount("VictimConn2", "PlayerBannedFromChat"),
             "Second connection must receive PlayerBannedFromChat");
 
         Assert.IsFalse(abortCalled, "Context.Abort() must NOT be called on any connection (G1)");
@@ -1588,21 +1545,13 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
         _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
 
-        var victimProxy = new Mock<ISingleClientProxy>();
-        int victimSignalCount = 0;
-        victimProxy
-            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((_, _, _) => victimSignalCount++)
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
-
         var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("TestId", "W3C Lounge", adminUser);
 
         var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
         await _chatHub.BanUser("victim#123", "spam", true, endDate);
 
-        Assert.AreEqual(0, victimSignalCount,
+        Assert.AreEqual(0, _reconcileHarness.SignalsFor("VictimConn").Count,
             "Shadow ban must send NO signal to the target (illusion preserved)");
     }
 
@@ -1614,12 +1563,6 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
         _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
-
-        var victimProxy = new Mock<ISingleClientProxy>();
-        victimProxy
-            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-        _clients.Setup(c => c.Client("VictimConn")).Returns(victimProxy.Object);
 
         var adminUser = new ChatUser("admin#1", true, null, new ProfilePicture(), null, null);
         _connectionMapping.Add("TestId", "W3C Lounge", adminUser);

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -210,6 +210,71 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             "After Remove+re-Add with no SetMute, cache must still be a MISS");
     }
 
+    // ── T4 connection-level user tracking ─────────────────────────────────────
+
+    [Test]
+    public void ConnectionMapping_RegisterUser_GetUserNonNull_GetRoomNull()
+    {
+        var mapping = new ConnectionMapping();
+        var user = new ChatUser("p#1", false, null, new ProfilePicture(), null, null);
+
+        mapping.RegisterUser("conn1", user);
+
+        Assert.AreSame(user, mapping.GetUser("conn1"), "GetUser must return the registered user");
+        Assert.IsNull(mapping.GetRoom("conn1"), "RegisterUser must NOT seat the connection in any room");
+    }
+
+    [Test]
+    public void ConnectionMapping_RegisterUser_NoRoom_GetConnectionIdsForUser_FindsIt()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.RegisterUser("conn1", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+
+        var ids = mapping.GetConnectionIdsForUser("p#1");
+
+        CollectionAssert.Contains(ids, "conn1",
+            "GetConnectionIdsForUser must find a no-room (RegisterUser-only) connection");
+    }
+
+    [Test]
+    public void ConnectionMapping_RegisterUser_ThenRemove_GetUserNull()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.RegisterUser("conn1", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+
+        mapping.Remove("conn1");
+
+        Assert.IsNull(mapping.GetUser("conn1"), "Remove must clear the registered user");
+        CollectionAssert.DoesNotContain(mapping.GetConnectionIdsForUser("p#1"), "conn1",
+            "Remove must drop the connection from GetConnectionIdsForUser");
+    }
+
+    [Test]
+    public void ConnectionMapping_Add_ThenGetUser_StillWorks()
+    {
+        // Regression: Add must also register the connection→user mapping.
+        var mapping = new ConnectionMapping();
+        var user = new ChatUser("p#1", false, null, new ProfilePicture(), null, null);
+        mapping.Add("conn1", "W3C Lounge", user);
+
+        Assert.AreSame(user, mapping.GetUser("conn1"), "Add must register the user for GetUser");
+        Assert.AreEqual("W3C Lounge", mapping.GetRoom("conn1"));
+    }
+
+    [Test]
+    public void ConnectionMapping_GetConnectionIdsForUser_FindsRoomSeatedAndNoRoomConns()
+    {
+        var mapping = new ConnectionMapping();
+        mapping.Add("roomConn", "W3C Lounge", new ChatUser("p#1", false, null, new ProfilePicture(), null, null));
+        mapping.RegisterUser("noRoomConn", new ChatUser("P#1", false, null, new ProfilePicture(), null, null));
+
+        var ids = mapping.GetConnectionIdsForUser("p#1");
+
+        CollectionAssert.Contains(ids, "roomConn", "Room-seated connection must be found");
+        CollectionAssert.Contains(ids, "noRoomConn", "No-room connection must be found (case-insensitive)");
+        Assert.AreEqual(2, ids.Count);
+    }
+
     // ── Task 3 helper methods ─────────────────────────────────────────────────
 
     private async Task AddFullBan(string battleTag, int daysFromNow = 1)
@@ -527,12 +592,47 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task SwitchRoom_FullBan_NoClan_RejectedByNullUserGuard()
+    public async Task Login_FullBan_NoClan_GetUser_NonNull()
     {
-        // A no-clan full-banned user is seated in NO room, so GetUser returns null for their
-        // connection. A SwitchRoom attempt is therefore rejected by SwitchRoom's `user == null`
-        // early-return — NOT by the cache gate (the cache seed is defense-in-depth). The user must
-        // remain in no room and the call must be graceful (no abort, no throw).
+        // T4: the no-clan full-ban login path registers the connection→user mapping, so GetUser is
+        // authoritative (non-null) even though the user is seated in no room.
+        await AddFullBan("peter#123");
+
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        var user = _connectionMapping.GetUser("TestId");
+        Assert.IsNotNull(user, "No-clan full-ban login must register the user (GetUser non-null)");
+        Assert.AreEqual("peter#123", user.BattleTag);
+        Assert.IsNull(_connectionMapping.GetRoom("TestId"), "User is still seated in no room");
+    }
+
+    [Test]
+    public async Task SwitchRoom_FullBan_NoClan_IntoPublicRoom_RejectedByCacheGate()
+    {
+        // T4 + cache gate: a no-clan full-banned user now has a non-null user (registered at login),
+        // so SwitchRoom is NOT rejected by the user==null guard. Switching into a PUBLIC room is
+        // instead rejected by the Full→public cache gate; the user stays in no room, gracefully.
+        await AddFullBan("peter#123");
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        Assert.IsNotNull(_connectionMapping.GetUser("TestId"), "Precondition: user is registered (non-null)");
+        Assert.IsNull(_connectionMapping.GetRoom("TestId"), "Precondition: no-clan full-ban user is in no room");
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        Assert.DoesNotThrowAsync(async () => await _chatHub.SwitchRoom("1 vs 1"),
+            "SwitchRoom into a public room must return gracefully, not throw");
+
+        Assert.IsNull(_connectionMapping.GetRoom("TestId"),
+            "Full-banned user must remain in no room — public target rejected by the Full→public cache gate");
+        Assert.IsFalse(abortCalled, "Rejected SwitchRoom must never call Context.Abort() (G1)");
+    }
+
+    [Test]
+    public async Task Login_FullBan_NoClan_SwitchRoomToExempt_IsAllowed()
+    {
+        // T4: a no-clan full-banned user (registered, no room) CAN switch into an exempt clan/lobby
+        // room — the cache gate only blocks public targets. No abort/throw.
         await AddFullBan("peter#123");
         await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
         Assert.IsNull(_connectionMapping.GetRoom("TestId"), "Precondition: no-clan full-ban user is in no room");
@@ -540,12 +640,23 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
 
-        Assert.DoesNotThrowAsync(async () => await _chatHub.SwitchRoom("1 vs 1"),
-            "SwitchRoom with no user must return gracefully, not throw");
+        Assert.DoesNotThrowAsync(async () => await _chatHub.SwitchRoom("clan XYZ"),
+            "SwitchRoom into an exempt room must return gracefully, not throw");
 
-        Assert.IsNull(_connectionMapping.GetRoom("TestId"),
-            "No-clan full-ban user must remain in no room after a SwitchRoom attempt (rejected by null-user guard)");
-        Assert.IsFalse(abortCalled, "Null-user SwitchRoom must never call Context.Abort() (G1)");
+        Assert.AreEqual("clan XYZ", _connectionMapping.GetRoom("TestId"),
+            "No-clan full-ban user must be allowed into an exempt (clan/lobby) room");
+        Assert.IsFalse(abortCalled, "Allowed SwitchRoom must never call Context.Abort() (G1)");
+    }
+
+    [Test]
+    public void UpdateUserProfilePicture_NullUser_DoesNotThrow()
+    {
+        // T4 boyscout: an unregistered connection has no user — UpdateUserProfilePicture must return
+        // gracefully instead of NRE-ing on a null user.
+        // (No login/registration for "TestId" → GetUser returns null.)
+        Assert.DoesNotThrowAsync(() =>
+            _chatHub.UpdateUserProfilePicture("W3C Lounge", new ProfilePicture()),
+            "UpdateUserProfilePicture with no registered user must not throw");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1,6 +1,7 @@
 // W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -342,6 +343,242 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             "Disconnecting a full-banned no-clan user (no room) must not throw");
         Assert.AreEqual(0, groupSendsAfterLogin,
             "No group broadcast (UserLeft) must fire for a user seated in no room");
+    }
+
+    // ── Task 4 tests ────────────────────────────────────────────────────────────
+
+    private void LoginNormal(string battleTag = "peter#123", string clanTag = null)
+    {
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser(battleTag, false, clanTag, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.None);
+    }
+
+    [Test]
+    public async Task SwitchRoom_FullBan_IntoBannedRoom_IsRejected()
+    {
+        await AddFullBan("peter#123");
+        // Seat user in a non-banned room as if they connected with a clan
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+
+        await _chatHub.SwitchRoom("W3C Lounge");
+
+        // Still in clan AB, not moved to W3C Lounge
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("clan AB", room, "Full-banned user must not be moved into a banned room");
+    }
+
+    [TestCase("W3C Lounge")]
+    [TestCase("1 vs 1")]
+    [TestCase("2 vs 2")]
+    [TestCase("FFA")]
+    [TestCase("Legion TD")]
+    public async Task SwitchRoom_FullBan_IntoEachBannedRoom_IsRejected(string bannedRoom)
+    {
+        await AddFullBan("peter#123");
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+
+        await _chatHub.SwitchRoom(bannedRoom);
+
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("clan AB", room, $"Full-banned user must not join banned room '{bannedRoom}'");
+    }
+
+    [Test]
+    public async Task SwitchRoom_FullBan_IntoClanRoom_IsAllowed()
+    {
+        await AddFullBan("peter#123");
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+
+        await _chatHub.SwitchRoom("clan XYZ");
+
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("clan XYZ", room, "Full-banned user must be allowed to join a clan room");
+    }
+
+    [Test]
+    public async Task SwitchRoom_FullBan_IntoLobbyRoom_IsAllowed()
+    {
+        await AddFullBan("peter#123");
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+
+        await _chatHub.SwitchRoom("game-lobby-9999");
+
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("game-lobby-9999", room, "Full-banned user must be allowed to join a lobby room");
+    }
+
+    [Test]
+    public async Task SwitchRoom_FullBan_IntoBannedRoom_NoContextAbort()
+    {
+        // G1: rejected SwitchRoom must NEVER call Context.Abort()
+        await AddFullBan("peter#123");
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Full);
+
+        bool abortCalled = false;
+        _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
+
+        await _chatHub.SwitchRoom("W3C Lounge");
+
+        Assert.IsFalse(abortCalled, "Context.Abort() must NOT be called on a rejected SwitchRoom (G1)");
+    }
+
+    [Test]
+    public async Task SwitchRoom_FullBan_NoClanInMapping_LazilReresolvesFromDB_IsRejected()
+    {
+        // Edge case: full-banned user with no clan was NOT in the ConnectionMapping at login
+        // (because they had no clan), so their MuteStatus is None in cache.
+        // SwitchRoom must lazily resolve from DB and still reject the move into a banned room.
+        await AddFullBan("peter#123");
+        // NOT calling _connectionMapping.SetMuteStatus — simulating the "no clan at login" path.
+        // The user is seated nowhere yet (simulating them calling SwitchRoom to try to join W3C Lounge).
+        // We DON'T add them to the mapping at all — GetUser returns null, lazy resolution must still work.
+        // Actually: the user must be seated somewhere for SwitchRoom to have a user object.
+        // Simulate: user connected but is in the mapping with None mute status (cache miss).
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        // MuteStatus is None (default — cache miss, as if they came via the no-clan full-ban login path)
+
+        await _chatHub.SwitchRoom("1 vs 1");
+
+        // Should be rejected: lazy re-resolve hits DB, finds full ban, and returns early
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("W3C Lounge", room,
+            "Full-banned user (lazy resolved) must not be moved into a banned room");
+    }
+
+    [Test]
+    public async Task SwitchRoom_ShadowBan_IntoBannedRoom_GhostJoin_NoUserEnteredBroadcast()
+    {
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        int userEnteredCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserEntered", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userEnteredCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.SwitchRoom("1 vs 1");
+
+        Assert.AreEqual(0, userEnteredCount, "Shadow-banned user must NOT trigger UserEntered in a banned room");
+    }
+
+    [Test]
+    public async Task SwitchRoom_ShadowBan_IntoBannedRoom_UserIsMovedIntoGroup()
+    {
+        // Ghost-join: shadow-banned user IS added to the group (can receive messages)
+        // even though UserEntered is suppressed.
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        await _chatHub.SwitchRoom("1 vs 1");
+
+        // Connection mapping must reflect the new room
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("1 vs 1", room, "Shadow-banned user must be physically added to the room in the mapping");
+    }
+
+    [Test]
+    public async Task SwitchRoom_ShadowBan_IntoBannedRoom_CallerReceivesStartChat()
+    {
+        await AddShadowBan("peter#123");
+
+        // Add a normal user to "1 vs 1" first
+        var normalUser = new ChatUser("normal#1", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("OtherConn", "1 vs 1", normalUser);
+
+        // Shadow-banned user joins from "W3C Lounge"
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        List<ChatUser> startChatUsers = null;
+        _callerProxy
+            .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) =>
+            {
+                if (method == "StartChat" && args.Length >= 1)
+                    startChatUsers = args[0] as List<ChatUser>;
+            })
+            .Returns(Task.CompletedTask);
+
+        await _chatHub.SwitchRoom("1 vs 1");
+
+        // Shadow-banned user sees themselves in the list (their own view is unfiltered)
+        Assert.IsNotNull(startChatUsers, "Shadow-banned user must receive a StartChat on ghost-join");
+        Assert.IsTrue(startChatUsers.Any(u => u.BattleTag == "peter#123"),
+            "Shadow-banned user must see themselves in usersOfRoom");
+    }
+
+    [Test]
+    public async Task SwitchRoom_ShadowBan_IntoBannedRoom_UserLeftSuppressed()
+    {
+        // Ghost-join: when switching rooms, the old-room UserLeft should also be suppressed
+        // for a shadow user moving into a banned room (they were already "invisible")
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        int userLeftCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserLeft", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userLeftCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.SwitchRoom("1 vs 1");
+
+        Assert.AreEqual(0, userLeftCount,
+            "Shadow-banned user ghost-joining a banned room must NOT trigger UserLeft on the old room");
+    }
+
+    [Test]
+    public async Task SwitchRoom_ShadowBan_IntoExemptRoom_NormalJoin()
+    {
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMuteStatus("TestId", MuteStatus.Shadow);
+
+        int userEnteredCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserEntered", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userEnteredCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.SwitchRoom("clan XYZ");
+
+        // UserEntered should fire normally for exempt rooms
+        Assert.AreEqual(1, userEnteredCount,
+            "Shadow-banned user entering an exempt room must broadcast UserEntered normally");
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("clan XYZ", room);
+    }
+
+    [Test]
+    public async Task SwitchRoom_UnbannedUser_NormalSwitch_BroadcastsUserEntered()
+    {
+        // Normal (unbanned) user switching rooms: standard behavior unchanged
+        LoginNormal("peter#123");
+
+        int userEnteredCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserEntered", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userEnteredCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.SwitchRoom("1 vs 1");
+
+        Assert.AreEqual(1, userEnteredCount, "Unbanned user SwitchRoom must broadcast UserEntered");
+        var room = _connectionMapping.GetRoom("TestId");
+        Assert.AreEqual("1 vs 1", room);
     }
 
     // ── Task 2 tests ────────────────────────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
 using NUnit.Framework;
-using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Mutes;
 using W3ChampionsChatService.Settings;
@@ -234,6 +233,29 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         });
     }
 
+    /// <summary>
+    /// Asserts the slimmed PlayerBannedFromChat payload exposes ONLY an <c>endDate</c> property
+    /// (a future DateTime) and leaks neither <c>reason</c> nor <c>isShadowBan</c> to the client.
+    /// The payload is an anonymous type, so it is inspected via reflection.
+    /// </summary>
+    private static void AssertPlayerBannedPayloadIsEndDateOnly(object payload)
+    {
+        Assert.IsNotNull(payload, "PlayerBannedFromChat payload must not be null");
+        var type = payload.GetType();
+        var props = type.GetProperties().Select(p => p.Name).ToList();
+
+        Assert.Contains("endDate", props,
+            "PlayerBannedFromChat payload must carry an endDate (backward-compat with old clients)");
+        Assert.IsFalse(props.Contains("reason"),
+            "SECURITY: PlayerBannedFromChat payload must NOT leak the moderation reason");
+        Assert.IsFalse(props.Contains("isShadowBan"),
+            "SECURITY: PlayerBannedFromChat payload must NOT leak the isShadowBan flag");
+
+        var endDate = (DateTime)type.GetProperty("endDate").GetValue(payload);
+        Assert.Greater(endDate, DateTime.UtcNow,
+            "The endDate in the payload must be the (future) ban expiry");
+    }
+
     // ── Task 3 tests ────────────────────────────────────────────────────────────
 
     [Test]
@@ -255,7 +277,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         await AddFullBan("peter#123");
 
         string callerMethodReceived = null;
-        LoungeMute muteReceived = null;
+        object payloadReceived = null;
         _callerProxy
             .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback<string, object[], CancellationToken>((method, args, _) =>
@@ -263,7 +285,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
                 if (method == "PlayerBannedFromChat")
                 {
                     callerMethodReceived = method;
-                    muteReceived = args[0] as LoungeMute;
+                    payloadReceived = args[0];
                 }
             })
             .Returns(Task.CompletedTask);
@@ -271,8 +293,11 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
 
         Assert.AreEqual("PlayerBannedFromChat", callerMethodReceived);
-        Assert.IsNotNull(muteReceived);
-        Assert.AreEqual("peter#123", muteReceived.battleTag);
+        Assert.IsNotNull(payloadReceived);
+        // SECURITY: the slimmed payload carries ONLY the expiry — not the full LoungeMute.
+        Assert.IsNotInstanceOf<LoungeMute>(payloadReceived,
+            "PlayerBannedFromChat must NOT send the full LoungeMute (leaks reason/isShadowBan)");
+        AssertPlayerBannedPayloadIsEndDateOnly(payloadReceived);
     }
 
     [Test]
@@ -309,10 +334,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
 
-        // Must be in "clan AB", not in any banned room
+        // Must be in "clan AB", not in any public room
         var room = _connectionMapping.GetRoom("TestId");
         Assert.AreEqual("clan AB", room);
-        Assert.IsFalse(DefaultChatRooms.IsBannedRoom(room));
+        Assert.IsFalse(DefaultChatRooms.IsPublicRoom(room));
     }
 
     [Test]
@@ -481,51 +506,51 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task SwitchRoom_FullBan_NoClanInMapping_LazilReresolvesFromDB_IsRejected()
+    public async Task Login_FullBan_NoClan_SeedsCacheWithFullStatus()
     {
-        // Edge case: full-banned user with no clan was NOT in the ConnectionMapping at login
-        // (because they had no clan), so their MuteStatus is None in cache.
-        // SwitchRoom must lazily resolve from DB and still reject the move into a banned room.
+        // §7 rework: the no-clan full-ban LOGIN path now seeds the per-connection mute cache
+        // authoritatively (Full) even though the user is seated in no room. This is what lets a
+        // later SendMessage enforce the ban from the cache with zero DB reads (see
+        // SendMessage_FullBan_NoClanLogin_EnforcesWithZeroMuteRepositoryCalls).
         await AddFullBan("peter#123");
-        // Seated in a room but with no cached MuteStatus (default None), reproducing the
-        // no-clan full-ban login path where SetMute was never called.
-        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
 
-        await _chatHub.SwitchRoom("1 vs 1");
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
 
-        // Should be rejected: lazy re-resolve hits DB, finds full ban, and returns early
-        var room = _connectionMapping.GetRoom("TestId");
-        Assert.AreEqual("W3C Lounge", room,
-            "Full-banned user (lazy resolved) must not be moved into a banned room");
+        Assert.IsNull(_connectionMapping.GetRoom("TestId"), "No-clan full-ban user must be seated in no room");
+        Assert.IsTrue(_connectionMapping.TryGetMute("TestId", out var seeded),
+            "Login must seed the cache even when the user is seated in no room");
+        Assert.AreEqual(MuteStatus.Full, seeded.Status, "No-clan full-ban login must cache Full status");
+        Assert.Greater(seeded.EndDate, DateTime.UtcNow, "Cached endDate must be the (future) ban expiry");
     }
 
     [Test]
-    public async Task SwitchRoom_FullBan_NoClan_ExemptThenBanned_StillRejected()
+    public async Task SwitchRoom_FullBan_ExemptThenPublic_StillRejected()
     {
-        // SECURITY regression (full-ban bypass): a no-clan full-banned connection starts as a
-        // cache MISS. A FIRST switch into an EXEMPT room ("clan AB") is allowed and would write a
-        // cache-None entry. A SECOND switch into a BANNED room must STILL re-resolve the DB and
-        // reject — it must not trust the cache-None written by the exempt switch.
+        // SECURITY regression (full-ban bypass): a full-banned connection seeded with Full at login.
+        // A FIRST switch into an EXEMPT room ("clan AB") is allowed and the cached Full survives.
+        // A SECOND switch into a PUBLIC room must STILL reject from the cache — switching through an
+        // exempt room must not downgrade the cached ban.
         await AddFullBan("peter#123");
-        // Seated in a room but with NO cached mute (cache MISS), reproducing the no-clan login path.
-        _connectionMapping.Add("TestId", "clan SEED", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        // Seat the user via the real login path (clan → seated in clan room, cache seeded Full).
+        await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        Assert.AreEqual("clan AB", _connectionMapping.GetRoom("TestId"), "Full-ban with clan seats in clan room");
+        // Prove enforcement is cache-only: remove the DB ban so any DB read would allow the move.
+        await _muteRepository.DeleteLoungeMute("peter#123");
 
-        // First switch: into an EXEMPT room — allowed, and (pre-fix) caches None.
-        await _chatHub.SwitchRoom("clan AB");
-        Assert.AreEqual("clan AB", _connectionMapping.GetRoom("TestId"),
+        // First switch: into another EXEMPT room — allowed; the cached Full status must survive.
+        await _chatHub.SwitchRoom("clan XYZ");
+        Assert.AreEqual("clan XYZ", _connectionMapping.GetRoom("TestId"),
             "Switch into an exempt room must be allowed");
 
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
 
-        // Second switch: into a BANNED room — must re-resolve the ban and reject.
+        // Second switch: into a PUBLIC room — must reject from the surviving cached Full.
         await _chatHub.SwitchRoom("W3C Lounge");
 
         var room = _connectionMapping.GetRoom("TestId");
-        Assert.AreEqual("clan AB", room,
-            "Full-banned user must NOT enter a banned room after a prior exempt switch (cache-None must not bypass the ban)");
-        Assert.IsFalse(_connectionMapping.GetUsersOfRoom("clan AB").Count == 0,
-            "User must remain seated in the exempt room");
+        Assert.AreEqual("clan XYZ", room,
+            "Full-banned user must NOT enter a public room after a prior exempt switch (cached ban must survive)");
         Assert.IsFalse(abortCalled, "Rejected SwitchRoom must not call Context.Abort() (G1)");
     }
 
@@ -853,14 +878,15 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     // ── New tests pinning cache-endDate behavior (spec §7) ────────────────────
 
     [Test]
-    public async Task SendMessage_CacheMiss_ActiveDbBan_InBannedRoom_Enforced()
+    public async Task SendMessage_FullBan_LoginSeedsCache_EnforcedWithoutDbRead()
     {
-        // Lazy-resolve success path: no cache entry (MISS) + active ban in DB + banned room → enforced.
-        // This covers the no-clan full-ban login edge case where SetMute was never called at login.
-        await AddFullBan("peter#123");
-        // Manually add the user to a banned room WITHOUT calling SetMute (simulates the no-clan login path).
+        // §7 rework: SendMessage consults the per-connection cache ONLY — never the DB.
+        // A full-banned user seated in a public room (e.g. a stale membership) is enforced from
+        // the cache. Proof of "no DB read": the DB has NO ban for this user (SetUp wipes the DB),
+        // yet the cached Full status still rejects the message — a DB read would have allowed it.
         _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
-        // Do NOT call SetMute — leave a MISS.
+        _connectionMapping.SetMute("TestId", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
+        // DB has NO ban (SetUp dropped the database) — only the cache knows about the ban.
 
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
@@ -869,9 +895,175 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         Assert.IsFalse(abortCalled, "Context.Abort() must not be called");
         Assert.AreEqual(0, _groupSendCount,
-            "Cache-miss lazy-resolved full-ban in banned room must reject the message");
+            "Cached full-ban in a public room must reject the message (enforced from cache, no DB read)");
         Assert.IsEmpty(_chatHistory.GetMessages("W3C Lounge"),
             "Rejected message must not enter history");
+    }
+
+    [Test]
+    public async Task SendMessage_CacheMiss_OutOfBandDbBan_InPublicRoom_NotEnforced_AcceptedTradeoff()
+    {
+        // ACCEPTED TRADE-OFF (§7): the send hot path consults the cache ONLY, never the DB.
+        // An out-of-band ban written straight to Mongo (NOT via the BanUser hub) is NOT reflected
+        // in the cache, so it does NOT take effect until the user's next reconnect (which re-seeds
+        // the cache at login). Here we simulate an unseeded connection (cache MISS) with a DB ban:
+        // the message must BROADCAST — proving SendMessage does not re-query the DB per send.
+        await AddFullBan("peter#123");
+        // Seat the user WITHOUT seeding the cache (cache MISS) — models a never-reconnected connection.
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        await _chatHub.SendMessage("Out-of-band ban not yet effective");
+
+        Assert.AreEqual(1, _groupSendCount,
+            "Out-of-band DB ban (cache MISS) must NOT be enforced on the send hot path — accepted trade-off");
+        Assert.AreEqual(1, _chatHistory.GetMessages("W3C Lounge").Count);
+    }
+
+    /// <summary>
+    /// A <see cref="MuteRepository"/> spy that counts <see cref="MuteRepository.GetMutedPlayer"/>
+    /// calls so a test can assert the send/switch hot paths perform ZERO mute-repository reads.
+    /// </summary>
+    private sealed class CountingMuteRepository(MongoDB.Driver.MongoClient client) : MuteRepository(client)
+    {
+        public int GetMutedPlayerCallCount { get; private set; }
+
+        public override Task<LoungeMute> GetMutedPlayer(string battleTag)
+        {
+            GetMutedPlayerCallCount++;
+            return base.GetMutedPlayer(battleTag);
+        }
+    }
+
+    private ChatHub BuildHubWithRepository(MuteRepository repository)
+    {
+        var chatAuthService = new Mock<IChatAuthenticationService>();
+        chatAuthService.Setup(m => m.GetUser(It.IsAny<string>()))
+            .ReturnsAsync(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        var hub = new ChatHub(
+            chatAuthService.Object,
+            repository,
+            _settingsRepository,
+            _connectionMapping,
+            _chatHistory,
+            null)
+        {
+            Clients = _clients.Object,
+            Context = _hubCallerContext.Object,
+            Groups = new Mock<IGroupManager>().Object,
+        };
+        return hub;
+    }
+
+    [Test]
+    public async Task SendMessage_UnmutedUser_InPublicRoom_MakesZeroMuteRepositoryCalls()
+    {
+        // §7 contract: the SendMessage hot path consults the per-connection cache ONLY.
+        // An unmuted user sending in a public room must NOT hit the mute repository at all.
+        var countingRepo = new CountingMuteRepository(MongoClient);
+        var hub = BuildHubWithRepository(countingRepo);
+
+        // Seat an unmuted user in a public room with an explicit cached None (as login would seed).
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
+
+        await hub.SendMessage("hello world");
+
+        Assert.AreEqual(0, countingRepo.GetMutedPlayerCallCount,
+            "SendMessage must make ZERO mute-repository reads on the hot path (§7 cache-only)");
+        Assert.AreEqual(1, _groupSendCount, "Unmuted message must broadcast to the room");
+    }
+
+    [Test]
+    public async Task SwitchRoom_UnmutedUser_MakesZeroMuteRepositoryCalls()
+    {
+        // §7 contract: SwitchRoom consults the per-connection cache ONLY — no mute-repository read.
+        var countingRepo = new CountingMuteRepository(MongoClient);
+        var hub = BuildHubWithRepository(countingRepo);
+
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
+
+        await hub.SwitchRoom("1 vs 1");
+
+        Assert.AreEqual(0, countingRepo.GetMutedPlayerCallCount,
+            "SwitchRoom must make ZERO mute-repository reads on the hot path (§7 cache-only)");
+        Assert.AreEqual("1 vs 1", _connectionMapping.GetRoom("TestId"),
+            "Unmuted user must be moved into the target room");
+    }
+
+    [Test]
+    public async Task SendMessage_FullBan_NoClanLogin_EnforcesWithZeroMuteRepositoryCalls()
+    {
+        // §7 + no-clan login seeding: after login (one DB read to resolve the ban), the cache is
+        // seeded. A subsequent SendMessage in a public room must enforce the ban with ZERO further
+        // mute-repository reads — the only DB read happens at login, never on the send hot path.
+        var countingRepo = new CountingMuteRepository(MongoClient);
+        // Persist a full ban via the (non-spy) repo so the login resolve finds it.
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "peter#123",
+            endDate = DateTime.UtcNow.AddDays(1).ToString("O"),
+            author = "admin#1",
+            reason = "test ban",
+            isShadowBan = false
+        });
+        var hub = BuildHubWithRepository(countingRepo);
+
+        // No-clan full-ban login: seats in no room, seeds the cache with Full.
+        await hub.LoginAsAuthenticated(new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        Assert.AreEqual(1, countingRepo.GetMutedPlayerCallCount,
+            "Login resolves the ban with exactly one mute-repository read");
+
+        // Seat the cached full-banned user into a public room to exercise the SendMessage gate.
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+
+        await hub.SendMessage("should be rejected");
+
+        Assert.AreEqual(1, countingRepo.GetMutedPlayerCallCount,
+            "SendMessage must NOT add any mute-repository read beyond the single login resolve (§7)");
+        Assert.AreEqual(0, _groupSendCount,
+            "Cached full-ban must reject the message in a public room");
+    }
+
+    [Test]
+    public async Task SendMessage_ShadowBan_InPublicRoom_LogsDropWithMessageContent()
+    {
+        // §3: a shadow-banned user's silently dropped message must be logged INCLUDING the content
+        // (BattleTag, room, AND the attempted message) so moderators can audit shadow activity.
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        var capturedLogs = new List<string>();
+        var sink = new DelegatingLogSink(evt => capturedLogs.Add(evt.RenderMessage()));
+        var originalLogger = Serilog.Log.Logger;
+        Serilog.Log.Logger = new Serilog.LoggerConfiguration()
+            .MinimumLevel.Information()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+        try
+        {
+            const string secretMessage = "shadow-drop-audit-marker-42";
+            await _chatHub.SendMessage(secretMessage);
+
+            Assert.AreEqual(0, _groupSendCount, "Shadow-banned message must not broadcast to the room");
+            var dropLog = capturedLogs.FirstOrDefault(l => l.Contains("dropped"));
+            Assert.IsNotNull(dropLog, "Shadow-banned drop must emit a log line");
+            StringAssert.Contains("peter#123", dropLog, "Drop log must include the BattleTag");
+            StringAssert.Contains("W3C Lounge", dropLog, "Drop log must include the room");
+            StringAssert.Contains(secretMessage, dropLog, "Drop log must include the attempted message content");
+        }
+        finally
+        {
+            Serilog.Log.Logger = originalLogger;
+            (Serilog.Log.Logger as IDisposable)?.Dispose();
+        }
+    }
+
+    /// <summary>A Serilog sink that forwards each event to a callback (for asserting log content).</summary>
+    private sealed class DelegatingLogSink(Action<Serilog.Events.LogEvent> onEmit) : Serilog.Core.ILogEventSink
+    {
+        public void Emit(Serilog.Events.LogEvent logEvent) => onEmit(logEvent);
     }
 
     [Test]
@@ -1200,7 +1392,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         // Separate client proxy for the victim connection
         var victimProxy = new Mock<ISingleClientProxy>();
         string signalSent = null;
-        LoungeMute muteInSignal = null;
+        object payloadInSignal = null;
         victimProxy
             .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback<string, object[], CancellationToken>((method, args, _) =>
@@ -1208,7 +1400,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
                 if (method == "PlayerBannedFromChat")
                 {
                     signalSent = method;
-                    muteInSignal = args[0] as LoungeMute;
+                    payloadInSignal = args[0];
                 }
             })
             .Returns(Task.CompletedTask);
@@ -1221,11 +1413,11 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
 
         Assert.AreEqual("PlayerBannedFromChat", signalSent,
-            "Live fully-banned user in a banned room must receive PlayerBannedFromChat");
-        Assert.IsNotNull(muteInSignal,
-            "PlayerBannedFromChat payload must include the LoungeMute");
-        Assert.AreEqual("victim#123", muteInSignal.battleTag,
-            "LoungeMute in signal must have the correct battleTag");
+            "Live fully-banned user in a public room must receive PlayerBannedFromChat");
+        // SECURITY: the slimmed payload carries ONLY the expiry — never the LoungeMute.
+        Assert.IsNotInstanceOf<LoungeMute>(payloadInSignal,
+            "PlayerBannedFromChat must NOT send the full LoungeMute (leaks reason/isShadowBan)");
+        AssertPlayerBannedPayloadIsEndDateOnly(payloadInSignal);
     }
 
     [Test]
@@ -1294,7 +1486,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         var victimProxy = new Mock<ISingleClientProxy>();
         string signalSent = null;
-        LoungeMute muteInSignal = null;
+        object payloadInSignal = null;
         victimProxy
             .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
             .Callback<string, object[], CancellationToken>((method, args, _) =>
@@ -1302,7 +1494,7 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
                 if (method == "PlayerBannedFromChat")
                 {
                     signalSent = method;
-                    muteInSignal = args[0] as LoungeMute;
+                    payloadInSignal = args[0];
                 }
             })
             .Returns(Task.CompletedTask);
@@ -1319,8 +1511,10 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
         Assert.AreEqual("PlayerBannedFromChat", signalSent,
             "Full-banned live user in an EXEMPT room must still receive PlayerBannedFromChat (R7/G5)");
-        Assert.IsNotNull(muteInSignal, "PlayerBannedFromChat payload must include the LoungeMute");
-        Assert.AreEqual("victim#123", muteInSignal.battleTag);
+        // SECURITY: the slimmed payload carries ONLY the expiry — never the LoungeMute.
+        Assert.IsNotInstanceOf<LoungeMute>(payloadInSignal,
+            "PlayerBannedFromChat must NOT send the full LoungeMute (leaks reason/isShadowBan)");
+        AssertPlayerBannedPayloadIsEndDateOnly(payloadInSignal);
         Assert.IsFalse(abortCalled,
             "Context.Abort() must NOT be called when signalling a full ban in an exempt room (G1)");
     }
@@ -1733,22 +1927,22 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task FullBan_PersistedDefaultChatIsBannedRoom_OverriddenToSafe()
+    public async Task FullBan_PersistedDefaultChatIsPublicRoom_OverriddenToSafe()
     {
-        // Edge case (§15): a full-banned user whose persisted DefaultChat is a banned room
-        // must NOT be seated in that banned room at connect. They must be placed in their clan
+        // Edge case (§15): a full-banned user whose persisted DefaultChat is a public room
+        // must NOT be seated in that public room at connect. They must be placed in their clan
         // room instead (default settings have DefaultChat = "W3C Lounge").
         await AddFullBan("peter#123");
 
-        // Default ChatSettings has DefaultChat = "W3C Lounge" (a banned room).
+        // Default ChatSettings has DefaultChat = "W3C Lounge" (a public room).
         // The user has ClanTag "AB" → must end up in "clan AB", not "W3C Lounge".
         await _chatHub.LoginAsAuthenticated(new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
 
         var room = _connectionMapping.GetRoom("TestId");
         Assert.AreEqual("clan AB", room,
-            "Full-banned user's persisted DefaultChat (a banned room) must be overridden to their clan room");
-        Assert.IsFalse(DefaultChatRooms.IsBannedRoom(room),
-            "The seat room after login must not be a banned room");
+            "Full-banned user's persisted DefaultChat (a public room) must be overridden to their clan room");
+        Assert.IsFalse(DefaultChatRooms.IsPublicRoom(room),
+            "The seat room after login must not be a public room");
     }
 
     // ── Task 11 tests — spec §16 backward-compatibility guardrails ────────────────
@@ -1850,30 +2044,30 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
 
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
-    [TestCase("W3C Lounge",      ExpectedResult = true)]
-    [TestCase("1 vs 1",          ExpectedResult = true)]
-    [TestCase("2 vs 2",          ExpectedResult = true)]
-    [TestCase("4 vs 4",          ExpectedResult = true)]
-    [TestCase("FFA",             ExpectedResult = true)]
-    [TestCase("Legion TD",       ExpectedResult = true)]
-    [TestCase("Survival Chaos",  ExpectedResult = true)]
-    [TestCase("Direct Strike",   ExpectedResult = true)]
-    [TestCase("Warhammer",       ExpectedResult = true)]
-    [TestCase("Castle Fight",    ExpectedResult = true)]
-    [TestCase("Risk Europe",     ExpectedResult = true)]
-    [TestCase("Mini Dota",       ExpectedResult = true)]
-    // Mixed-case variants of banned rooms must still be caught (case-insensitive ban check)
-    [TestCase("w3c lounge",      ExpectedResult = true)]
-    [TestCase("1 VS 1",          ExpectedResult = true)]
-    [TestCase("LEGION TD",       ExpectedResult = true)]
-    [TestCase("clan AB",         ExpectedResult = false)]
-    [TestCase("clan XYZ",        ExpectedResult = false)]
-    [TestCase("game-lobby-42",   ExpectedResult = false)]
-    [TestCase("custom_lobby",    ExpectedResult = false)]
-    [TestCase("",                ExpectedResult = false)]
-    [TestCase(null,              ExpectedResult = false)]
-    public bool IsBannedRoom_ClassifiesCorrectly(string room)
+    [TestCase("W3C Lounge", ExpectedResult = true)]
+    [TestCase("1 vs 1", ExpectedResult = true)]
+    [TestCase("2 vs 2", ExpectedResult = true)]
+    [TestCase("4 vs 4", ExpectedResult = true)]
+    [TestCase("FFA", ExpectedResult = true)]
+    [TestCase("Legion TD", ExpectedResult = true)]
+    [TestCase("Survival Chaos", ExpectedResult = true)]
+    [TestCase("Direct Strike", ExpectedResult = true)]
+    [TestCase("Warhammer", ExpectedResult = true)]
+    [TestCase("Castle Fight", ExpectedResult = true)]
+    [TestCase("Risk Europe", ExpectedResult = true)]
+    [TestCase("Mini Dota", ExpectedResult = true)]
+    // Mixed-case variants of public rooms must still be caught (case-insensitive check)
+    [TestCase("w3c lounge", ExpectedResult = true)]
+    [TestCase("1 VS 1", ExpectedResult = true)]
+    [TestCase("LEGION TD", ExpectedResult = true)]
+    [TestCase("clan AB", ExpectedResult = false)]
+    [TestCase("clan XYZ", ExpectedResult = false)]
+    [TestCase("game-lobby-42", ExpectedResult = false)]
+    [TestCase("custom_lobby", ExpectedResult = false)]
+    [TestCase("", ExpectedResult = false)]
+    [TestCase(null, ExpectedResult = false)]
+    public bool IsPublicRoom_ClassifiesCorrectly(string room)
     {
-        return DefaultChatRooms.IsBannedRoom(room);
+        return DefaultChatRooms.IsPublicRoom(room);
     }
 }

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -1456,6 +1456,66 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
             _chatHub.BanUser("offline#999", "reason", false, endDate));
     }
 
+    // ── Task 8 tests ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task OnDisconnectedAsync_ShadowBan_InBannedRoom_NoUserLeftBroadcast()
+    {
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        int userLeftCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserLeft", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userLeftCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.OnDisconnectedAsync(null);
+
+        Assert.AreEqual(0, userLeftCount,
+            "Shadow-banned user leaving a banned room must NOT broadcast UserLeft");
+    }
+
+    [Test]
+    public async Task OnDisconnectedAsync_ShadowBan_InExemptRoom_UserLeftBroadcast()
+    {
+        await AddShadowBan("peter#123");
+        _connectionMapping.Add("TestId", "clan AB", new ChatUser("peter#123", false, "AB", new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.Shadow, DateTime.UtcNow.AddDays(1));
+
+        int userLeftCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserLeft", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userLeftCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.OnDisconnectedAsync(null);
+
+        Assert.AreEqual(1, userLeftCount,
+            "Shadow-banned user leaving an exempt room must broadcast UserLeft normally");
+    }
+
+    [Test]
+    public async Task OnDisconnectedAsync_NormalUser_BroadcastsUserLeft()
+    {
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("peter#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("TestId", MuteStatus.None, DateTime.MinValue);
+
+        int userLeftCount = 0;
+        _groupProxy
+            .Setup(x => x.SendCoreAsync("UserLeft", It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => userLeftCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        await _chatHub.OnDisconnectedAsync(null);
+
+        Assert.AreEqual(1, userLeftCount, "Normal user disconnect must broadcast UserLeft");
+    }
+
     // ── Task 2 tests ────────────────────────────────────────────────────────────
 
     [TestCase("W3C Lounge",      ExpectedResult = true)]

--- a/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
+++ b/W3ChampionsChatService.Tests/ChatBanRoomScopeTests.cs
@@ -949,10 +949,17 @@ public class ChatBanRoomScopeTests : IntegrationTestBase
         var visibleToNormal = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-normal");
         Assert.AreEqual(1, visibleToNormal.Count);
         Assert.AreEqual("normal#1", visibleToNormal[0].BattleTag);
+        var tagsVisibleToNormal = visibleToNormal.Select(u => u.BattleTag).ToList();
+        Assert.IsFalse(tagsVisibleToNormal.Contains("shadow#2"),
+            "Non-viewer must NOT see the shadow-banned user's battleTag");
+        Assert.IsTrue(tagsVisibleToNormal.Contains("normal#1"),
+            "Non-viewer must see the normal user's battleTag");
 
         // Shadow user viewing themselves — they see both
         var visibleToShadow = mapping.GetUsersOfRoomForViewer("W3C Lounge", "conn-shadow");
         Assert.AreEqual(2, visibleToShadow.Count);
+        Assert.IsTrue(visibleToShadow.Any(u => u.BattleTag == "shadow#2"),
+            "Shadow-banned viewer must see their own battleTag");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
@@ -47,7 +47,7 @@ public class ChatHubDeletionTests : IntegrationTestBase
             _settingsRepository,
             _connectionMapping,
             _chatHistory,
-            new MuteReconciliationTestHarness(_connectionMapping).Service,
+            new MuteReconciliationTestHarness(_connectionMapping, _muteRepository).Service,
             null);
 
         _clients.Setup(c => c.All).Returns(_mockAllProxy.Object);

--- a/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
@@ -47,6 +47,7 @@ public class ChatHubDeletionTests : IntegrationTestBase
             _settingsRepository,
             _connectionMapping,
             _chatHistory,
+            new MuteReconciliationTestHarness(_connectionMapping).Service,
             null);
 
         _clients.Setup(c => c.All).Returns(_mockAllProxy.Object);

--- a/W3ChampionsChatService.Tests/ChatHubPermissionFilterTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPermissionFilterTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
 using NUnit.Framework;
@@ -15,22 +17,18 @@ namespace W3ChampionsChatService.Tests;
 /// moderator-only hub methods. Verifies the resolution mechanism against the actual
 /// <see cref="IW3CAuthenticationService"/> / <see cref="W3CUserAuthentication"/> API
 /// (GetUserByToken → IsAdmin + Permissions).
+/// <para>
+/// These tests drive the REAL token source the filter uses in production:
+/// <c>invocationContext.Context.GetHttpContext()</c>, which reads the connection's
+/// <see cref="IHttpContextFeature"/>. They do NOT mock <c>IHttpContextAccessor</c> — that accessor
+/// is null for hub-method invocations over a live socket, so a test relying on it would be a false
+/// green. A revert to IHttpContextAccessor makes these tests fail (the token resolves to null →
+/// HubException even for a moderator).
+/// </para>
 /// </summary>
 public class ChatHubPermissionFilterTests
 {
     private const string FakeToken = "fake.jwt.token";
-
-    private static IHttpContextAccessor ContextAccessorWithToken(string token)
-    {
-        var httpContext = new DefaultHttpContext();
-        if (token != null)
-        {
-            httpContext.Request.QueryString = new QueryString($"?access_token={token}");
-        }
-        var accessor = new Mock<IHttpContextAccessor>();
-        accessor.Setup(a => a.HttpContext).Returns(httpContext);
-        return accessor.Object;
-    }
 
     private static W3CUserAuthentication Moderator() => new()
     {
@@ -57,21 +55,46 @@ public class ChatHubPermissionFilterTests
         Permissions = new HashSet<EPermission> { EPermission.Maps },
     };
 
-    private static HubInvocationContext BuildContext(string hubMethodName)
+    /// <summary>
+    /// Builds a HubInvocationContext whose <c>Context.GetHttpContext()</c> returns a DefaultHttpContext
+    /// carrying <paramref name="token"/> in <c>Request.Query["access_token"]</c> — exactly how SignalR
+    /// exposes the handshake HttpContext during a hub-method invocation. Pass <c>token = null</c> to
+    /// simulate a connection with an HttpContext that has no access_token. Pass
+    /// <paramref name="withHttpContext"/> = false to simulate no HttpContext at all (GetHttpContext null).
+    /// </summary>
+    private static HubInvocationContext BuildContext(string hubMethodName, string token = FakeToken, bool withHttpContext = true)
     {
         var methodInfo = typeof(ChatHub).GetMethod(hubMethodName)
             ?? throw new InvalidOperationException($"ChatHub has no method '{hubMethodName}'");
         var hub = new Mock<Hub>().Object;
-        var callerContext = new Mock<HubCallerContext>().Object;
         var serviceProvider = new Mock<IServiceProvider>().Object;
-        return new HubInvocationContext(callerContext, serviceProvider, hub, methodInfo, Array.Empty<object>());
+
+        // The connection's feature collection is where GetHttpContext() reads the HttpContext from
+        // (SignalR uses the IHttpContextFeature from Microsoft.AspNetCore.Http.Connections.Features).
+        var features = new FeatureCollection();
+        if (withHttpContext)
+        {
+            var httpContext = new DefaultHttpContext();
+            if (token != null)
+            {
+                httpContext.Request.QueryString = new QueryString($"?access_token={token}");
+            }
+            var httpContextFeature = new Mock<IHttpContextFeature>();
+            httpContextFeature.Setup(f => f.HttpContext).Returns(httpContext);
+            features.Set<IHttpContextFeature>(httpContextFeature.Object);
+        }
+
+        var callerContext = new Mock<HubCallerContext>();
+        callerContext.Setup(c => c.Features).Returns(features);
+
+        return new HubInvocationContext(callerContext.Object, serviceProvider, hub, methodInfo, Array.Empty<object>());
     }
 
-    private static ChatHubPermissionFilter BuildFilter(W3CUserAuthentication resolved, string token = FakeToken)
+    private static ChatHubPermissionFilter BuildFilter(W3CUserAuthentication resolved)
     {
         var authService = new Mock<IW3CAuthenticationService>();
         authService.Setup(a => a.GetUserByToken(It.IsAny<string>())).Returns(resolved);
-        return new ChatHubPermissionFilter(authService.Object, ContextAccessorWithToken(token));
+        return new ChatHubPermissionFilter(authService.Object);
     }
 
     private static ValueTask<object> PassThrough(HubInvocationContext _) => new((object)"ok");
@@ -128,13 +151,44 @@ public class ChatHubPermissionFilterTests
     [Test]
     public void MissingToken_ProtectedMethod_ThrowsHubException()
     {
-        // No token in the query → GetUserByToken returns null (auth failure) → rejected.
-        var authService = new Mock<IW3CAuthenticationService>();
-        authService.Setup(a => a.GetUserByToken(It.IsAny<string>())).Returns((W3CUserAuthentication)null);
-        var filter = new ChatHubPermissionFilter(authService.Object, ContextAccessorWithToken(null));
-        var ctx = BuildContext("BanUser");
+        // HttpContext present but no access_token in the query → GetUserByToken returns null → rejected.
+        var filter = BuildFilter(resolved: null);
+        var ctx = BuildContext("BanUser", token: null);
 
         Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
             "A missing/invalid token must be rejected from a protected method");
+    }
+
+    [Test]
+    public void NoHttpContextOnConnection_ProtectedMethod_ThrowsHubException()
+    {
+        // GetHttpContext() returns null (no IHttpContextFeature) → token null → GetUserByToken null →
+        // rejected (fail-closed). Guards against an NRE and proves the filter reads from the connection.
+        var filter = BuildFilter(resolved: null);
+        var ctx = BuildContext("BanUser", withHttpContext: false);
+
+        Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
+            "A connection with no HttpContext must be rejected (fail-closed)");
+    }
+
+    [Test]
+    public async Task Moderator_TokenComesFromConnectionHttpContext_NotAccessor()
+    {
+        // Regression guard: the moderator is allowed ONLY because the token is read from
+        // Context.GetHttpContext() (the connection's IHttpContextFeature). A revert to
+        // IHttpContextAccessor would yield a null token here → HubException → this test fails.
+        string capturedToken = null;
+        var authService = new Mock<IW3CAuthenticationService>();
+        authService.Setup(a => a.GetUserByToken(It.IsAny<string>()))
+            .Callback<string>(t => capturedToken = t)
+            .Returns(Moderator());
+        var filter = new ChatHubPermissionFilter(authService.Object);
+        var ctx = BuildContext("BanUser", token: "moderator-token-xyz");
+
+        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
+
+        Assert.AreEqual("ok", result, "Moderator must pass when the token is read from the connection HttpContext");
+        Assert.AreEqual("moderator-token-xyz", capturedToken,
+            "The filter must resolve the token from Context.GetHttpContext().Request.Query[\"access_token\"]");
     }
 }

--- a/W3ChampionsChatService.Tests/ChatHubPermissionFilterTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPermissionFilterTests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Chats;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// SECURITY tests for <see cref="ChatHubPermissionFilter"/> — the real Moderation gate on the
+/// moderator-only hub methods. Verifies the resolution mechanism against the actual
+/// <see cref="IW3CAuthenticationService"/> / <see cref="W3CUserAuthentication"/> API
+/// (GetUserByToken → IsAdmin + Permissions).
+/// </summary>
+public class ChatHubPermissionFilterTests
+{
+    private const string FakeToken = "fake.jwt.token";
+
+    private static IHttpContextAccessor ContextAccessorWithToken(string token)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (token != null)
+        {
+            httpContext.Request.QueryString = new QueryString($"?access_token={token}");
+        }
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.Setup(a => a.HttpContext).Returns(httpContext);
+        return accessor.Object;
+    }
+
+    private static W3CUserAuthentication Moderator() => new()
+    {
+        BattleTag = "admin#1",
+        Name = "admin",
+        IsAdmin = true,
+        Permissions = new HashSet<EPermission> { EPermission.Moderation },
+    };
+
+    private static W3CUserAuthentication NonModerator() => new()
+    {
+        BattleTag = "user#2",
+        Name = "user",
+        IsAdmin = false,
+        Permissions = new HashSet<EPermission>(),
+    };
+
+    // Admin but WITHOUT the Moderation permission — must still be rejected.
+    private static W3CUserAuthentication AdminWithoutModeration() => new()
+    {
+        BattleTag = "admin#3",
+        Name = "admin3",
+        IsAdmin = true,
+        Permissions = new HashSet<EPermission> { EPermission.Maps },
+    };
+
+    private static HubInvocationContext BuildContext(string hubMethodName)
+    {
+        var methodInfo = typeof(ChatHub).GetMethod(hubMethodName)
+            ?? throw new InvalidOperationException($"ChatHub has no method '{hubMethodName}'");
+        var hub = new Mock<Hub>().Object;
+        var callerContext = new Mock<HubCallerContext>().Object;
+        var serviceProvider = new Mock<IServiceProvider>().Object;
+        return new HubInvocationContext(callerContext, serviceProvider, hub, methodInfo, Array.Empty<object>());
+    }
+
+    private static ChatHubPermissionFilter BuildFilter(W3CUserAuthentication resolved, string token = FakeToken)
+    {
+        var authService = new Mock<IW3CAuthenticationService>();
+        authService.Setup(a => a.GetUserByToken(It.IsAny<string>())).Returns(resolved);
+        return new ChatHubPermissionFilter(authService.Object, ContextAccessorWithToken(token));
+    }
+
+    private static ValueTask<object> PassThrough(HubInvocationContext _) => new((object)"ok");
+
+    [TestCase("BanUser")]
+    [TestCase("DeleteMessage")]
+    [TestCase("PurgeMessagesFromUser")]
+    public void NonModerator_ProtectedMethod_ThrowsHubException(string method)
+    {
+        var filter = BuildFilter(NonModerator());
+        var ctx = BuildContext(method);
+
+        Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
+            $"A non-moderator must be rejected from {method}");
+    }
+
+    [TestCase("BanUser")]
+    [TestCase("DeleteMessage")]
+    [TestCase("PurgeMessagesFromUser")]
+    public void AdminWithoutModerationPermission_ProtectedMethod_ThrowsHubException(string method)
+    {
+        var filter = BuildFilter(AdminWithoutModeration());
+        var ctx = BuildContext(method);
+
+        Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
+            $"An admin WITHOUT the Moderation permission must be rejected from {method}");
+    }
+
+    [TestCase("BanUser")]
+    [TestCase("DeleteMessage")]
+    [TestCase("PurgeMessagesFromUser")]
+    public async Task Moderator_ProtectedMethod_PassesThrough(string method)
+    {
+        var filter = BuildFilter(Moderator());
+        var ctx = BuildContext(method);
+
+        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
+
+        Assert.AreEqual("ok", result, $"A moderator must be allowed to invoke {method}");
+    }
+
+    [Test]
+    public async Task NonModerator_UnprotectedMethod_PassesThrough()
+    {
+        // SendMessage is NOT a protected method — a non-moderator must pass straight through.
+        var filter = BuildFilter(NonModerator());
+        var ctx = BuildContext("SendMessage");
+
+        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
+
+        Assert.AreEqual("ok", result, "An unprotected method must pass through for any authenticated user");
+    }
+
+    [Test]
+    public void MissingToken_ProtectedMethod_ThrowsHubException()
+    {
+        // No token in the query → GetUserByToken returns null (auth failure) → rejected.
+        var authService = new Mock<IW3CAuthenticationService>();
+        authService.Setup(a => a.GetUserByToken(It.IsAny<string>())).Returns((W3CUserAuthentication)null);
+        var filter = new ChatHubPermissionFilter(authService.Object, ContextAccessorWithToken(null));
+        var ctx = BuildContext("BanUser");
+
+        Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
+            "A missing/invalid token must be rejected from a protected method");
+    }
+}

--- a/W3ChampionsChatService.Tests/ChatHubPermissionFilterTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPermissionFilterTests.cs
@@ -13,59 +13,61 @@ using W3ChampionsChatService.Chats;
 namespace W3ChampionsChatService.Tests;
 
 /// <summary>
-/// SECURITY tests for <see cref="ChatHubPermissionFilter"/> — the real Moderation gate on the
-/// moderator-only hub methods. Verifies the resolution mechanism against the actual
+/// SECURITY tests for <see cref="ChatHubPermissionFilter"/> — the generic, ATTRIBUTE-DRIVEN gate on
+/// hub methods. The required permission is whatever the invoked method declares via
+/// <c>[UserHasPermission(...)]</c>; the filter reads it off <c>invocationContext.HubMethod</c> via
+/// reflection (no hardcoded method-name list). The auth resolution is verified against the real
 /// <see cref="IW3CAuthenticationService"/> / <see cref="W3CUserAuthentication"/> API
 /// (GetUserByToken → IsAdmin + Permissions).
 /// <para>
-/// These tests drive the REAL token source the filter uses in production:
+/// The token is driven through the REAL source the filter uses in production:
 /// <c>invocationContext.Context.GetHttpContext()</c>, which reads the connection's
-/// <see cref="IHttpContextFeature"/>. They do NOT mock <c>IHttpContextAccessor</c> — that accessor
-/// is null for hub-method invocations over a live socket, so a test relying on it would be a false
-/// green. A revert to IHttpContextAccessor makes these tests fail (the token resolves to null →
-/// HubException even for a moderator).
+/// <see cref="IHttpContextFeature"/>. These tests do NOT mock <c>IHttpContextAccessor</c> — that
+/// accessor is null for hub-method invocations over a live socket, so a test relying on it would be a
+/// false green. A revert to IHttpContextAccessor makes the token-source regression test fail.
 /// </para>
 /// </summary>
 public class ChatHubPermissionFilterTests
 {
     private const string FakeToken = "fake.jwt.token";
 
-    private static W3CUserAuthentication Moderator() => new()
+    /// <summary>
+    /// A purpose-built hub whose methods declare different (or no) <c>[UserHasPermission]</c>
+    /// attributes — so the tests can prove the required permission genuinely comes from the attribute,
+    /// not a constant baked into the filter. Methods are never invoked (the filter's `next` is mocked).
+    /// </summary>
+    private class TestHub : Hub
     {
-        BattleTag = "admin#1",
-        Name = "admin",
-        IsAdmin = true,
-        Permissions = new HashSet<EPermission> { EPermission.Moderation },
-    };
+        [UserHasPermission(EPermission.Moderation)]
+        public void RequiresModeration() { }
 
-    private static W3CUserAuthentication NonModerator() => new()
+        [UserHasPermission(EPermission.Queue)]
+        public void RequiresQueue() { }
+
+        public void Unprotected() { }
+    }
+
+    private static W3CUserAuthentication User(bool isAdmin, params EPermission[] permissions) => new()
     {
-        BattleTag = "user#2",
+        BattleTag = "user#1",
         Name = "user",
-        IsAdmin = false,
-        Permissions = new HashSet<EPermission>(),
-    };
-
-    // Admin but WITHOUT the Moderation permission — must still be rejected.
-    private static W3CUserAuthentication AdminWithoutModeration() => new()
-    {
-        BattleTag = "admin#3",
-        Name = "admin3",
-        IsAdmin = true,
-        Permissions = new HashSet<EPermission> { EPermission.Maps },
+        IsAdmin = isAdmin,
+        Permissions = new HashSet<EPermission>(permissions),
     };
 
     /// <summary>
-    /// Builds a HubInvocationContext whose <c>Context.GetHttpContext()</c> returns a DefaultHttpContext
-    /// carrying <paramref name="token"/> in <c>Request.Query["access_token"]</c> — exactly how SignalR
-    /// exposes the handshake HttpContext during a hub-method invocation. Pass <c>token = null</c> to
-    /// simulate a connection with an HttpContext that has no access_token. Pass
-    /// <paramref name="withHttpContext"/> = false to simulate no HttpContext at all (GetHttpContext null).
+    /// Builds a HubInvocationContext for <paramref name="hubMethodName"/> on <typeparamref name="THub"/>
+    /// whose <c>Context.GetHttpContext()</c> returns a DefaultHttpContext carrying <paramref name="token"/>
+    /// in <c>Request.Query["access_token"]</c> — exactly how SignalR exposes the handshake HttpContext
+    /// during a hub-method invocation. Pass <c>token = null</c> to simulate a connection whose
+    /// HttpContext has no access_token; <paramref name="withHttpContext"/> = false simulates no
+    /// HttpContext at all (GetHttpContext returns null).
     /// </summary>
-    private static HubInvocationContext BuildContext(string hubMethodName, string token = FakeToken, bool withHttpContext = true)
+    private static HubInvocationContext BuildContext<THub>(string hubMethodName, string token = FakeToken, bool withHttpContext = true)
+        where THub : Hub
     {
-        var methodInfo = typeof(ChatHub).GetMethod(hubMethodName)
-            ?? throw new InvalidOperationException($"ChatHub has no method '{hubMethodName}'");
+        var methodInfo = typeof(THub).GetMethod(hubMethodName)
+            ?? throw new InvalidOperationException($"{typeof(THub).Name} has no method '{hubMethodName}'");
         var hub = new Mock<Hub>().Object;
         var serviceProvider = new Mock<IServiceProvider>().Object;
 
@@ -99,80 +101,140 @@ public class ChatHubPermissionFilterTests
 
     private static ValueTask<object> PassThrough(HubInvocationContext _) => new((object)"ok");
 
+    // ── The real ChatHub moderator methods carry [UserHasPermission(Moderation)] ──────────
+
     [TestCase("BanUser")]
     [TestCase("DeleteMessage")]
     [TestCase("PurgeMessagesFromUser")]
-    public void NonModerator_ProtectedMethod_ThrowsHubException(string method)
+    public void RealChatHub_ModeratorOnlyMethods_DeclareTheAttribute_AndAreEnforced(string method)
     {
-        var filter = BuildFilter(NonModerator());
-        var ctx = BuildContext(method);
+        // Drives the ACTUAL ChatHub method metadata: the attribute must be present (the filter reads it),
+        // and a non-moderator is rejected.
+        var attrs = typeof(ChatHub).GetMethod(method)
+            .GetCustomAttributes(typeof(UserHasPermissionAttribute), true);
+        Assert.IsNotEmpty(attrs, $"{method} must declare [UserHasPermission] (the filter enforces what it declares)");
+
+        var filter = BuildFilter(User(isAdmin: false));
+        var ctx = BuildContext<ChatHub>(method);
 
         Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
             $"A non-moderator must be rejected from {method}");
     }
 
-    [TestCase("BanUser")]
-    [TestCase("DeleteMessage")]
-    [TestCase("PurgeMessagesFromUser")]
-    public void AdminWithoutModerationPermission_ProtectedMethod_ThrowsHubException(string method)
+    // ── Attribute-driven enforcement (purpose-built TestHub) ──────────────────────────────
+
+    [Test]
+    public void AttributedMethod_NonModerator_ThrowsHubException()
     {
-        var filter = BuildFilter(AdminWithoutModeration());
-        var ctx = BuildContext(method);
+        var filter = BuildFilter(User(isAdmin: false));
+        var ctx = BuildContext<TestHub>(nameof(TestHub.RequiresModeration));
 
         Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
-            $"An admin WITHOUT the Moderation permission must be rejected from {method}");
-    }
-
-    [TestCase("BanUser")]
-    [TestCase("DeleteMessage")]
-    [TestCase("PurgeMessagesFromUser")]
-    public async Task Moderator_ProtectedMethod_PassesThrough(string method)
-    {
-        var filter = BuildFilter(Moderator());
-        var ctx = BuildContext(method);
-
-        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
-
-        Assert.AreEqual("ok", result, $"A moderator must be allowed to invoke {method}");
+            "A non-moderator must be rejected from a [UserHasPermission(Moderation)] method");
     }
 
     [Test]
-    public async Task NonModerator_UnprotectedMethod_PassesThrough()
+    public void AttributedMethod_AdminWithoutThatPermission_ThrowsHubException()
     {
-        // SendMessage is NOT a protected method — a non-moderator must pass straight through.
-        var filter = BuildFilter(NonModerator());
-        var ctx = BuildContext("SendMessage");
+        // Admin, but holds a DIFFERENT permission than the one the method declares → rejected.
+        var filter = BuildFilter(User(isAdmin: true, EPermission.Maps));
+        var ctx = BuildContext<TestHub>(nameof(TestHub.RequiresModeration));
 
-        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
-
-        Assert.AreEqual("ok", result, "An unprotected method must pass through for any authenticated user");
+        Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
+            "An admin without the declared permission must be rejected");
     }
 
     [Test]
-    public void MissingToken_ProtectedMethod_ThrowsHubException()
+    public async Task AttributedMethod_AdminWithDeclaredPermission_PassesThrough()
+    {
+        var filter = BuildFilter(User(isAdmin: true, EPermission.Moderation));
+        var ctx = BuildContext<TestHub>(nameof(TestHub.RequiresModeration));
+
+        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
+
+        Assert.AreEqual("ok", result, "An admin with the declared permission must pass through");
+    }
+
+    [Test]
+    public void AttributeDrivesTheRequiredPermission_NotAHardcodedModeration()
+    {
+        // The method declares Queue (not Moderation). A user holding ONLY Moderation must be REJECTED,
+        // proving the required permission comes from the attribute, not a Moderation constant in the filter.
+        var filter = BuildFilter(User(isAdmin: true, EPermission.Moderation));
+        var ctx = BuildContext<TestHub>(nameof(TestHub.RequiresQueue));
+
+        Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
+            "Holding Moderation must NOT satisfy a method that declares [UserHasPermission(Queue)]");
+    }
+
+    [Test]
+    public async Task AttributeDrivesTheRequiredPermission_HolderOfDeclaredPermissionPasses()
+    {
+        // Same Queue-declaring method: a user holding Queue passes — the attribute's permission is honored.
+        var filter = BuildFilter(User(isAdmin: true, EPermission.Queue));
+        var ctx = BuildContext<TestHub>(nameof(TestHub.RequiresQueue));
+
+        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
+
+        Assert.AreEqual("ok", result, "Holding the declared Queue permission must pass");
+    }
+
+    [Test]
+    public async Task UnattributedMethod_NonModerator_PassesThrough_NoAuthRequired()
+    {
+        // No [UserHasPermission] → unprotected → passes through WITHOUT any JWT decode.
+        var authService = new Mock<IW3CAuthenticationService>();
+        var filter = new ChatHubPermissionFilter(authService.Object);
+        var ctx = BuildContext<TestHub>(nameof(TestHub.Unprotected));
+
+        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
+
+        Assert.AreEqual("ok", result, "An unprotected method must pass through for anyone");
+        authService.Verify(a => a.GetUserByToken(It.IsAny<string>()), Times.Never,
+            "An unprotected method must NOT trigger a JWT decode");
+    }
+
+    [Test]
+    public async Task RealChatHub_SendMessage_IsUnprotected_PassesThrough()
+    {
+        // SendMessage on the real ChatHub carries no [UserHasPermission] → any user passes through.
+        var authService = new Mock<IW3CAuthenticationService>();
+        var filter = new ChatHubPermissionFilter(authService.Object);
+        var ctx = BuildContext<ChatHub>(nameof(ChatHub.SendMessage));
+
+        var result = await filter.InvokeMethodAsync(ctx, PassThrough);
+
+        Assert.AreEqual("ok", result, "SendMessage is unprotected and must pass through");
+        authService.Verify(a => a.GetUserByToken(It.IsAny<string>()), Times.Never);
+    }
+
+    // ── Token-source / fail-closed behavior (unchanged from the GetHttpContext fix) ───────
+
+    [Test]
+    public void MissingToken_AttributedMethod_ThrowsHubException()
     {
         // HttpContext present but no access_token in the query → GetUserByToken returns null → rejected.
         var filter = BuildFilter(resolved: null);
-        var ctx = BuildContext("BanUser", token: null);
+        var ctx = BuildContext<TestHub>(nameof(TestHub.RequiresModeration), token: null);
 
         Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
-            "A missing/invalid token must be rejected from a protected method");
+            "A missing/invalid token must be rejected from an attributed method");
     }
 
     [Test]
-    public void NoHttpContextOnConnection_ProtectedMethod_ThrowsHubException()
+    public void NoHttpContextOnConnection_AttributedMethod_ThrowsHubException()
     {
         // GetHttpContext() returns null (no IHttpContextFeature) → token null → GetUserByToken null →
         // rejected (fail-closed). Guards against an NRE and proves the filter reads from the connection.
         var filter = BuildFilter(resolved: null);
-        var ctx = BuildContext("BanUser", withHttpContext: false);
+        var ctx = BuildContext<TestHub>(nameof(TestHub.RequiresModeration), withHttpContext: false);
 
         Assert.ThrowsAsync<HubException>(async () => await filter.InvokeMethodAsync(ctx, PassThrough),
             "A connection with no HttpContext must be rejected (fail-closed)");
     }
 
     [Test]
-    public async Task Moderator_TokenComesFromConnectionHttpContext_NotAccessor()
+    public async Task Token_ComesFromConnectionHttpContext_NotAccessor()
     {
         // Regression guard: the moderator is allowed ONLY because the token is read from
         // Context.GetHttpContext() (the connection's IHttpContextFeature). A revert to
@@ -181,9 +243,9 @@ public class ChatHubPermissionFilterTests
         var authService = new Mock<IW3CAuthenticationService>();
         authService.Setup(a => a.GetUserByToken(It.IsAny<string>()))
             .Callback<string>(t => capturedToken = t)
-            .Returns(Moderator());
+            .Returns(User(isAdmin: true, EPermission.Moderation));
         var filter = new ChatHubPermissionFilter(authService.Object);
-        var ctx = BuildContext("BanUser", token: "moderator-token-xyz");
+        var ctx = BuildContext<TestHub>(nameof(TestHub.RequiresModeration), token: "moderator-token-xyz");
 
         var result = await filter.InvokeMethodAsync(ctx, PassThrough);
 

--- a/W3ChampionsChatService.Tests/ChatTests.cs
+++ b/W3ChampionsChatService.Tests/ChatTests.cs
@@ -52,7 +52,7 @@ public class ChatTests : IntegrationTestBase
             _settingsRepository,
             _connectionMapping,
             _chatHistory,
-            new MuteReconciliationTestHarness(_connectionMapping).Service,
+            new MuteReconciliationTestHarness(_connectionMapping, _muteRepository).Service,
             null);
 
         // Setup message capturing proxies

--- a/W3ChampionsChatService.Tests/ChatTests.cs
+++ b/W3ChampionsChatService.Tests/ChatTests.cs
@@ -152,34 +152,30 @@ public class ChatTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task BannedUser_CannotSendMessage()
+    public async Task BannedUser_SendMessageInBannedRoom_IsRejectedSilently()
     {
-        // Login before ban
+        // Login first (not yet banned)
         await LoginUser();
 
-        // Reset the group message flag after login
+        // Reset group flag after login
         _groupMessageSent = false;
 
-        // Setup muted player
-        var mute = new LoungeMuteRequest
+        // Ban the user
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
         {
             battleTag = "peter#123",
             endDate = DateTime.UtcNow.AddDays(1).ToString(),
             author = "modmoto#2809"
-        };
+        });
 
-        await _muteRepository.AddLoungeMute(mute);
-
-        // Set up tracking for Context.Abort()
+        // Ensure Abort is NOT called (new behavior)
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
 
-        // Send message
         await _chatHub.SendMessage("Hello world");
 
-        // Verify connection aborted and message not sent
-        Assert.IsTrue(abortCalled);
-        Assert.IsFalse(_groupMessageSent, "No message should be sent to the group for banned users");
+        Assert.IsFalse(abortCalled, "Context.Abort() must not be called from SendMessage");
+        Assert.IsFalse(_groupMessageSent, "No message should be broadcast to the group");
         Assert.AreEqual(0, _chatHistory.GetMessages("W3C Lounge").Count);
     }
 
@@ -271,30 +267,29 @@ public class ChatTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task BackwardsCompatibility_RegularMuteStillWorks()
+    public async Task BackwardsCompatibility_RegularMuteStillBlocks()
     {
         // Login before ban
         await LoginUser();
 
-        // Setup regular mute (without isShadowBan property)
-        var mute = new LoungeMuteRequest
+        _groupMessageSent = false;
+
+        // Regular mute (isShadowBan defaults to false)
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
         {
             battleTag = "peter#123",
             endDate = DateTime.UtcNow.AddDays(1).ToString(),
             author = "modmoto#2809"
             // isShadowBan defaults to false
-        };
+        });
 
-        await _muteRepository.AddLoungeMute(mute);
-
-        // Set up tracking for Context.Abort()
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);
 
-        // Send message should result in abort
         await _chatHub.SendMessage("Hello world");
 
-        Assert.IsTrue(abortCalled);
+        // No abort from SendMessage in the new design — full-ban enforces by dropping message
+        Assert.IsFalse(abortCalled, "Context.Abort() must not be called from SendMessage");
         Assert.IsFalse(_groupMessageSent);
         Assert.AreEqual(0, _chatHistory.GetMessages("W3C Lounge").Count);
     }

--- a/W3ChampionsChatService.Tests/ChatTests.cs
+++ b/W3ChampionsChatService.Tests/ChatTests.cs
@@ -52,6 +52,7 @@ public class ChatTests : IntegrationTestBase
             _settingsRepository,
             _connectionMapping,
             _chatHistory,
+            new MuteReconciliationTestHarness(_connectionMapping).Service,
             null);
 
         // Setup message capturing proxies

--- a/W3ChampionsChatService.Tests/ChatTests.cs
+++ b/W3ChampionsChatService.Tests/ChatTests.cs
@@ -160,13 +160,15 @@ public class ChatTests : IntegrationTestBase
         // Reset group flag after login
         _groupMessageSent = false;
 
-        // Ban the user
-        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
-        {
-            battleTag = "peter#123",
-            endDate = DateTime.UtcNow.AddDays(1).ToString(),
-            author = "modmoto#2809"
-        });
+        // Mock Clients.Client so BanUser's PlayerBannedFromChat send doesn't NRE.
+        var victimProxy = new Mock<ISingleClientProxy>();
+        victimProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client(It.IsAny<string>())).Returns(victimProxy.Object);
+
+        // Ban the user via the canonical in-band path (BanUser), which reconciles the live cache.
+        // §7: a direct out-of-band DB write would NOT be enforced until reconnect; BanUser is the path.
+        await _chatHub.BanUser("peter#123", "bad behavior", false, DateTime.UtcNow.AddDays(1).ToString("O"));
 
         // Ensure Abort is NOT called (new behavior)
         bool abortCalled = false;
@@ -242,16 +244,9 @@ public class ChatTests : IntegrationTestBase
         // Login before shadow ban
         await LoginUser();
 
-        // Setup shadow banned player
-        var mute = new LoungeMuteRequest
-        {
-            battleTag = "peter#123",
-            endDate = DateTime.UtcNow.AddDays(1).ToString(),
-            author = "modmoto#2809",
-            isShadowBan = true
-        };
-
-        await _muteRepository.AddLoungeMute(mute);
+        // Shadow-ban the user via the canonical in-band path (BanUser), which reconciles the live
+        // cache. §7: a direct out-of-band DB write would not be enforced on the send hot path.
+        await _chatHub.BanUser("peter#123", "spam", true, DateTime.UtcNow.AddDays(1).ToString("O"));
 
         // Send message
         await _chatHub.SendMessage("Hello world");
@@ -274,14 +269,15 @@ public class ChatTests : IntegrationTestBase
 
         _groupMessageSent = false;
 
-        // Regular mute (isShadowBan defaults to false)
-        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
-        {
-            battleTag = "peter#123",
-            endDate = DateTime.UtcNow.AddDays(1).ToString(),
-            author = "modmoto#2809"
-            // isShadowBan defaults to false
-        });
+        // Mock Clients.Client so BanUser's PlayerBannedFromChat send doesn't NRE.
+        var victimProxy = new Mock<ISingleClientProxy>();
+        victimProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Client(It.IsAny<string>())).Returns(victimProxy.Object);
+
+        // Regular (full) mute applied via the canonical in-band path (BanUser).
+        // §7: BanUser reconciles the live cache so enforcement is instant without a per-send DB read.
+        await _chatHub.BanUser("peter#123", "bad behavior", false, DateTime.UtcNow.AddDays(1).ToString("O"));
 
         bool abortCalled = false;
         _hubCallerContext.Setup(c => c.Abort()).Callback(() => abortCalled = true);

--- a/W3ChampionsChatService.Tests/ChatTests.cs
+++ b/W3ChampionsChatService.Tests/ChatTests.cs
@@ -152,7 +152,7 @@ public class ChatTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task BannedUser_SendMessageInBannedRoom_IsRejectedSilently()
+    public async Task BannedUser_SendMessage_IsRejectedSilently()
     {
         // Login first (not yet banned)
         await LoginUser();

--- a/W3ChampionsChatService.Tests/MuteReconciliationTestHarness.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTestHarness.cs
@@ -22,7 +22,7 @@ public sealed class MuteReconciliationTestHarness
     // connectionId -> list of (method, firstArg) sent to that connection's client proxy.
     private readonly Dictionary<string, List<(string Method, object Payload)>> _sends = new();
 
-    public MuteReconciliationTestHarness(ConnectionMapping connections)
+    public MuteReconciliationTestHarness(ConnectionMapping connections, IMuteRepository muteRepository = null)
     {
         var hubClients = new Mock<IHubClients>();
         hubClients
@@ -48,7 +48,12 @@ public sealed class MuteReconciliationTestHarness
         var hubContext = new Mock<IHubContext<ChatHub>>();
         hubContext.Setup(h => h.Clients).Returns(hubClients.Object);
 
-        Service = new MuteReconciliationService(connections, hubContext.Object);
+        // Default to a no-op mock repo so existing call sites that don't exercise ApplyBanAsync compile
+        // unchanged; tests that assert persistence pass a real MuteRepository.
+        Service = new MuteReconciliationService(
+            connections,
+            hubContext.Object,
+            muteRepository ?? new Mock<IMuteRepository>().Object);
     }
 
     /// <summary>All (method, payload) signals sent to <paramref name="connectionId"/>, in order.</summary>

--- a/W3ChampionsChatService.Tests/MuteReconciliationTestHarness.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTestHarness.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Mutes;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Test harness around <see cref="MuteReconciliationService"/>. It wires a mock
+/// <see cref="IHubContext{ChatHub}"/> over the supplied <see cref="ConnectionMapping"/> and
+/// captures every <c>SendAsync</c> made to a per-connection client proxy, keyed by connectionId,
+/// so a test can assert which connection received which signal (and its payload).
+/// </summary>
+public sealed class MuteReconciliationTestHarness
+{
+    public MuteReconciliationService Service { get; }
+
+    // connectionId -> list of (method, firstArg) sent to that connection's client proxy.
+    private readonly Dictionary<string, List<(string Method, object Payload)>> _sends = new();
+
+    public MuteReconciliationTestHarness(ConnectionMapping connections)
+    {
+        var hubClients = new Mock<IHubClients>();
+        hubClients
+            .Setup(c => c.Client(It.IsAny<string>()))
+            .Returns<string>(connId =>
+            {
+                var proxy = new Mock<ISingleClientProxy>();
+                proxy
+                    .Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+                    .Callback<string, object[], CancellationToken>((method, args, _) =>
+                    {
+                        if (!_sends.TryGetValue(connId, out var list))
+                        {
+                            list = new List<(string, object)>();
+                            _sends[connId] = list;
+                        }
+                        list.Add((method, args.Length > 0 ? args[0] : null));
+                    })
+                    .Returns(Task.CompletedTask);
+                return proxy.Object;
+            });
+
+        var hubContext = new Mock<IHubContext<ChatHub>>();
+        hubContext.Setup(h => h.Clients).Returns(hubClients.Object);
+
+        Service = new MuteReconciliationService(connections, hubContext.Object);
+    }
+
+    /// <summary>All (method, payload) signals sent to <paramref name="connectionId"/>, in order.</summary>
+    public IReadOnlyList<(string Method, object Payload)> SignalsFor(string connectionId) =>
+        _sends.TryGetValue(connectionId, out var list) ? list : Array.Empty<(string, object)>();
+
+    /// <summary>The first payload sent to <paramref name="connectionId"/> for <paramref name="method"/>, or null.</summary>
+    public object PayloadFor(string connectionId, string method)
+    {
+        if (_sends.TryGetValue(connectionId, out var list))
+        {
+            foreach (var (m, payload) in list)
+            {
+                if (m == method) return payload;
+            }
+        }
+        return null;
+    }
+
+    public int SignalCount(string connectionId, string method)
+    {
+        var count = 0;
+        if (_sends.TryGetValue(connectionId, out var list))
+        {
+            foreach (var (m, _) in list)
+            {
+                if (m == method) count++;
+            }
+        }
+        return count;
+    }
+}

--- a/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Mutes;
+using W3ChampionsChatService.Settings;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Closes the out-of-band-ban regression at the WRITE path: a ban/unban issued via the REST
+/// <see cref="MuteController"/> must reconcile the target's live connections (via
+/// <see cref="MuteReconciliationService"/>) so it takes effect immediately — exactly like the hub's
+/// <c>BanUser</c> — without a per-send DB read and without waiting for a reconnect.
+/// </summary>
+public class MuteReconciliationTests : IntegrationTestBase
+{
+    private MuteRepository _muteRepository;
+    private ConnectionMapping _connectionMapping;
+    private MuteReconciliationTestHarness _harness;
+    private MuteController _controller;
+
+    // For driving SendMessage on the victim's connection through a hub.
+    private ChatHub _chatHub;
+    private Mock<IHubCallerClients> _clients;
+    private Mock<HubCallerContext> _hubCallerContext;
+    private Mock<ISingleClientProxy> _callerProxy;
+    private Mock<IClientProxy> _groupProxy;
+    private int _groupSendCount;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _muteRepository = new MuteRepository(MongoClient);
+        _connectionMapping = new ConnectionMapping();
+        _harness = new MuteReconciliationTestHarness(_connectionMapping);
+        _controller = new MuteController(_muteRepository, _harness.Service);
+
+        var chatAuthService = new Mock<IChatAuthenticationService>();
+        chatAuthService.Setup(m => m.GetUser(It.IsAny<string>()))
+            .ReturnsAsync(new ChatUser("victim#123", false, null, new ProfilePicture(), null, null));
+
+        _chatHub = new ChatHub(
+            chatAuthService.Object,
+            _muteRepository,
+            new SettingsRepository(MongoClient),
+            _connectionMapping,
+            new ChatHistory(),
+            _harness.Service,
+            null);
+
+        _clients = new Mock<IHubCallerClients>();
+        _callerProxy = new Mock<ISingleClientProxy>();
+        _callerProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _groupSendCount = 0;
+        _groupProxy = new Mock<IClientProxy>();
+        _groupProxy.Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => _groupSendCount++)
+            .Returns(Task.CompletedTask);
+        _clients.Setup(c => c.Caller).Returns(_callerProxy.Object);
+        _clients.Setup(c => c.Group(It.IsAny<string>())).Returns(_groupProxy.Object);
+
+        _hubCallerContext = new Mock<HubCallerContext>();
+        _hubCallerContext.Setup(c => c.ConnectionId).Returns("VictimConn");
+        _chatHub.Clients = _clients.Object;
+        _chatHub.Context = _hubCallerContext.Object;
+        _chatHub.Groups = new Mock<IGroupManager>().Object;
+    }
+
+    [Test]
+    public async Task ControllerBan_FullBan_TakesEffectOnLiveConnection_WithoutDbRead()
+    {
+        // A live, unmuted user seated in a public room.
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        // Moderator issues a FULL ban via the REST controller.
+        var result = await _controller.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "victim#123",
+            endDate = DateTime.UtcNow.AddDays(1).ToString("O"),
+            author = "admin#1",
+            reason = "bad behavior",
+            isShadowBan = false
+        });
+        Assert.IsNotNull(result, "Controller POST must return a result");
+
+        // The live connection's cache must be reconciled to Full and receive PlayerBannedFromChat (expiry only).
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached));
+        Assert.AreEqual(MuteStatus.Full, cached.Status,
+            "Controller full ban must reconcile the live connection's cache to Full");
+        Assert.AreEqual(1, _harness.SignalCount("VictimConn", "PlayerBannedFromChat"),
+            "Controller full ban must push PlayerBannedFromChat to the live connection");
+
+        // Now wipe the DB so a DB read would find NO ban — proving enforcement is cache-only.
+        await _muteRepository.DeleteLoungeMute("victim#123");
+
+        await _chatHub.SendMessage("should be rejected");
+
+        Assert.AreEqual(0, _groupSendCount,
+            "After a controller ban, the next SendMessage in a public room is rejected from the cache (no DB read)");
+    }
+
+    [Test]
+    public async Task ControllerBan_ShadowBan_ReconcilesCache_SilentToTarget()
+    {
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        await _controller.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "victim#123",
+            endDate = DateTime.UtcNow.AddDays(1).ToString("O"),
+            author = "admin#1",
+            reason = "spam",
+            isShadowBan = true
+        });
+
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached));
+        Assert.AreEqual(MuteStatus.Shadow, cached.Status,
+            "Controller shadow ban must reconcile the live connection's cache to Shadow");
+        Assert.AreEqual(0, _harness.SignalsFor("VictimConn").Count,
+            "Controller shadow ban must send NO signal to the target (illusion preserved)");
+    }
+
+    [Test]
+    public async Task ControllerUnban_ClearsCache_UserCanSendAgain_WithoutReconnect()
+    {
+        // A live, fully-banned user seated in a public room.
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "victim#123",
+            endDate = DateTime.UtcNow.AddDays(1).ToString("O"),
+            author = "admin#1",
+            reason = "bad behavior",
+            isShadowBan = false
+        });
+
+        // Moderator deletes the mute via the REST controller.
+        await _controller.DeleteLoungeMute("victim#123");
+
+        // The live connection's cache must be cleared to None so the user can send again server-side.
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached));
+        Assert.AreEqual(MuteStatus.None, cached.Status,
+            "Controller unban must clear the live connection's cached mute to None");
+
+        await _chatHub.SendMessage("I can talk again");
+
+        Assert.AreEqual(1, _groupSendCount,
+            "After a controller unban, the user can send again in a public room without reconnecting");
+    }
+
+    [Test]
+    public async Task Service_ApplyMute_NoLiveConnection_DoesNotThrow()
+    {
+        // No connection for the target — applying a mute must be a graceful no-op.
+        Assert.DoesNotThrowAsync(() =>
+            _harness.Service.ApplyMuteToLiveConnections("ghost#1", MuteStatus.Full, DateTime.UtcNow.AddDays(1)));
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Service_ClearMute_NoLiveConnection_DoesNotThrow()
+    {
+        Assert.DoesNotThrowAsync(() => _harness.Service.ClearMuteOnLiveConnections("ghost#1"));
+        await Task.CompletedTask;
+    }
+
+    [Test]
+    public async Task Service_ApplyMute_FullBan_PayloadIsEndDateOnly()
+    {
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var endDate = DateTime.UtcNow.AddDays(3);
+        await _harness.Service.ApplyMuteToLiveConnections("victim#123", MuteStatus.Full, endDate);
+
+        var payload = _harness.PayloadFor("VictimConn", "PlayerBannedFromChat");
+        Assert.IsNotNull(payload, "Full ban must push PlayerBannedFromChat");
+        Assert.IsNotInstanceOf<LoungeMute>(payload,
+            "PlayerBannedFromChat must NOT send the full LoungeMute (leaks reason/isShadowBan)");
+        var props = payload.GetType().GetProperties();
+        Assert.AreEqual(1, props.Length, "Payload must expose exactly one property (endDate)");
+        Assert.AreEqual("endDate", props[0].Name, "The only payload property must be endDate");
+        Assert.AreEqual(endDate, (DateTime)props[0].GetValue(payload),
+            "Payload endDate must equal the ban expiry");
+    }
+}

--- a/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
@@ -37,7 +37,9 @@ public class MuteReconciliationTests : IntegrationTestBase
     {
         _muteRepository = new MuteRepository(MongoClient);
         _connectionMapping = new ConnectionMapping();
-        _harness = new MuteReconciliationTestHarness(_connectionMapping);
+        // Wire the reconciliation service's ApplyBanAsync to the REAL repo so controller/hub bans
+        // actually persist to (and are removable from) the live DB in these tests.
+        _harness = new MuteReconciliationTestHarness(_connectionMapping, _muteRepository);
         _controller = new MuteController(_muteRepository, _harness.Service);
 
         var chatAuthService = new Mock<IChatAuthenticationService>();
@@ -237,5 +239,132 @@ public class MuteReconciliationTests : IntegrationTestBase
         Assert.AreEqual("endDate", props[0].Name, "The only payload property must be endDate");
         Assert.AreEqual(endDate, (DateTime)props[0].GetValue(payload),
             "Payload endDate must equal the ban expiry");
+    }
+
+    // ── T5 ApplyBanAsync (consolidated ban orchestration) ─────────────────────
+
+    [Test]
+    public async Task ApplyBanAsync_FullBan_PersistsAndReconciles()
+    {
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var (success, parsed) = await _harness.Service.ApplyBanAsync(new LoungeMuteRequest
+        {
+            battleTag = "victim#123",
+            endDate = DateTime.UtcNow.AddDays(1).ToString("O"),
+            author = "admin#1",
+            reason = "bad behavior",
+            isShadowBan = false
+        });
+
+        Assert.IsTrue(success, "Full ban with a valid endDate must succeed");
+        Assert.Greater(parsed, DateTime.UtcNow, "Parsed endDate must be the future ban expiry");
+        // Persisted to the DB.
+        Assert.IsNotNull(await _muteRepository.GetMutedPlayer("victim#123"), "ApplyBanAsync must persist the mute");
+        // Live connection reconciled to Full + received the signal.
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached));
+        Assert.AreEqual(MuteStatus.Full, cached.Status, "Live cache must be reconciled to Full");
+        Assert.AreEqual(1, _harness.SignalCount("VictimConn", "PlayerBannedFromChat"),
+            "Full ban must push PlayerBannedFromChat");
+    }
+
+    [Test]
+    public async Task ApplyBanAsync_ShadowBan_PersistsAndReconciles_Silent()
+    {
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var (success, _) = await _harness.Service.ApplyBanAsync(new LoungeMuteRequest
+        {
+            battleTag = "victim#123",
+            endDate = DateTime.UtcNow.AddDays(1).ToString("O"),
+            author = "admin#1",
+            reason = "spam",
+            isShadowBan = true
+        });
+
+        Assert.IsTrue(success);
+        var persisted = await _muteRepository.GetMutedPlayer("victim#123");
+        Assert.IsNotNull(persisted);
+        Assert.IsTrue(persisted.isShadowBan, "Shadow ban must persist with isShadowBan=true");
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached));
+        Assert.AreEqual(MuteStatus.Shadow, cached.Status, "Live cache must be reconciled to Shadow");
+        Assert.AreEqual(0, _harness.SignalsFor("VictimConn").Count,
+            "Shadow ban must send NO signal to the target (illusion preserved)");
+    }
+
+    [Test]
+    public async Task ApplyBanAsync_MalformedEndDate_ReturnsFailure_PersistsThenSkipsReconcile()
+    {
+        // Use a mock repo whose AddLoungeMute succeeds (no-op) so the ban is "persisted" but the
+        // subsequent TryParse fails — isolating the parse-failure branch. (The real MuteRepository's
+        // AddLoungeMute would itself throw on a malformed date before we reach the TryParse guard.)
+        var mutes = new Mock<IMuteRepository>();
+        var persisted = false;
+        mutes.Setup(m => m.AddLoungeMute(It.IsAny<LoungeMuteRequest>()))
+            .Callback(() => persisted = true)
+            .Returns(Task.CompletedTask);
+        var harness = new MuteReconciliationTestHarness(_connectionMapping, mutes.Object);
+
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.None, DateTime.MinValue);
+
+        var (success, parsed) = await harness.Service.ApplyBanAsync(new LoungeMuteRequest
+        {
+            battleTag = "victim#123",
+            endDate = "not-a-real-date",
+            author = "admin#1",
+            reason = "x",
+            isShadowBan = false
+        });
+
+        Assert.IsFalse(success, "A malformed endDate must return success=false");
+        Assert.AreEqual(DateTime.MinValue, parsed);
+        Assert.IsTrue(persisted, "The ban is still persisted before the parse failure");
+        // The live cache must NOT have been reconciled (still None) and no signal sent.
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached));
+        Assert.AreEqual(MuteStatus.None, cached.Status, "Live cache must NOT be reconciled on a parse failure");
+        Assert.AreEqual(0, harness.SignalsFor("VictimConn").Count, "No signal on a parse failure");
+    }
+
+    [Test]
+    public async Task ApplyBanAsync_HubBanUser_And_ControllerAddLoungeMute_ProduceIdenticalCacheState()
+    {
+        // Two live connections of the same battleTag; ban one via the hub, the other via the controller.
+        // Both paths go through ApplyBanAsync → identical cache state.
+        _connectionMapping.Add("HubConn", "W3C Lounge", new ChatUser("victim#123", false, null, new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("HubConn", MuteStatus.None, DateTime.MinValue);
+
+        // Admin seat for the hub BanUser (GetUser must resolve for the caller).
+        _connectionMapping.Add("TestId", "W3C Lounge", new ChatUser("admin#1", true, null, new ProfilePicture(), null, null));
+        var hubContext = new Mock<HubCallerContext>();
+        hubContext.Setup(c => c.ConnectionId).Returns("TestId");
+        _chatHub.Context = hubContext.Object;
+
+        var endDate = DateTime.UtcNow.AddDays(1).ToString("O");
+        await _chatHub.BanUser("victim#123", "bad behavior", false, endDate);
+
+        Assert.IsTrue(_connectionMapping.TryGetMute("HubConn", out var afterHub));
+        var hubStatus = afterHub.Status;
+
+        // Reset that connection's cache and ban via the controller instead.
+        _connectionMapping.SetMute("HubConn", MuteStatus.None, DateTime.MinValue);
+        await _controller.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "victim#123",
+            endDate = endDate,
+            author = "admin#1",
+            reason = "bad behavior",
+            isShadowBan = false
+        });
+
+        Assert.IsTrue(_connectionMapping.TryGetMute("HubConn", out var afterController));
+        Assert.AreEqual(hubStatus, afterController.Status,
+            "Hub BanUser and controller AddLoungeMute must produce identical cache status");
+        Assert.AreEqual(MuteStatus.Full, afterController.Status);
     }
 }

--- a/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
 using NUnit.Framework;
@@ -157,6 +158,48 @@ public class MuteReconciliationTests : IntegrationTestBase
 
         Assert.AreEqual(1, _groupSendCount,
             "After a controller unban, the user can send again in a public room without reconnecting");
+    }
+
+    [Test]
+    public async Task ControllerDelete_MixedCaseBattleTag_ActuallyDeletesRow_AndReturnsOk()
+    {
+        // Casing fix: the row is stored lowercased (AddLoungeMute), so a mixed-case DELETE must still
+        // match and remove it — and report 200 OK, not a false 404.
+        await _muteRepository.AddLoungeMute(new LoungeMuteRequest
+        {
+            battleTag = "Victim#123",
+            endDate = DateTime.UtcNow.AddDays(1).ToString("O"),
+            author = "admin#1",
+            reason = "bad behavior",
+            isShadowBan = false
+        });
+
+        var result = await _controller.DeleteLoungeMute("VICTIM#123");
+
+        Assert.IsInstanceOf<OkObjectResult>(result,
+            "A mixed-case DELETE that matches a stored (lowercased) mute must return 200 OK");
+        Assert.IsNull(await _muteRepository.GetMutedPlayer("victim#123"),
+            "A mixed-case DELETE must actually remove the stored row (casing fix)");
+    }
+
+    [Test]
+    public async Task ControllerDelete_AbsentTag_ReturnsNotFound_ButStillClearsLiveCache()
+    {
+        // An explicit moderator unban of a target whose DB row is already gone/expired must STILL free
+        // any live connection (reconcile-then-respond), yet report an accurate 404 since nothing was
+        // deleted from the DB.
+        var liveUser = new ChatUser("victim#123", false, null, new ProfilePicture(), null, null);
+        _connectionMapping.Add("VictimConn", "W3C Lounge", liveUser);
+        _connectionMapping.SetMute("VictimConn", MuteStatus.Full, DateTime.UtcNow.AddDays(1));
+        // No DB row exists for this tag (SetUp drops the DB; we never AddLoungeMute here).
+
+        var result = await _controller.DeleteLoungeMute("victim#123");
+
+        Assert.IsInstanceOf<NotFoundObjectResult>(result,
+            "DELETE of an absent tag must return 404 (nothing was deleted)");
+        Assert.IsTrue(_connectionMapping.TryGetMute("VictimConn", out var cached));
+        Assert.AreEqual(MuteStatus.None, cached.Status,
+            "An explicit unban must clear the live cache even when the DB row was already gone");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/StartupDependencyInjectionTests.cs
+++ b/W3ChampionsChatService.Tests/StartupDependencyInjectionTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Mutes;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Composition-root smoke tests. These guard that the DI graph wired in
+/// <see cref="Startup.ConfigureServices"/> actually resolves the services that the out-of-band-ban
+/// fix depends on — in particular that the controller and hub share the SAME singleton
+/// <see cref="ConnectionMapping"/> (so a REST ban reconciles the hub's live connections), and that
+/// <see cref="MuteReconciliationService"/> resolves.
+/// </summary>
+public class StartupDependencyInjectionTests
+{
+    private static ServiceProvider BuildProvider()
+    {
+        var services = new ServiceCollection();
+        // The host normally registers logging outside ConfigureServices; add it here so the framework
+        // services (MVC/SignalR/routing) that need ILoggerFactory can be constructed during resolution.
+        services.AddLogging();
+        new Startup().ConfigureServices(services);
+        // ValidateScopes catches captive-dependency lifetime bugs (e.g. a singleton capturing a scoped
+        // service). We do NOT ValidateOnBuild because it eagerly validates every framework descriptor;
+        // the tests below resolve the specific services we care about, which is the real check.
+        return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+    }
+
+    [Test]
+    public void ConnectionMapping_IsSingleton_SharedAcrossResolutions()
+    {
+        using var provider = BuildProvider();
+
+        var first = provider.GetRequiredService<ConnectionMapping>();
+        var second = provider.GetRequiredService<ConnectionMapping>();
+
+        Assert.AreSame(first, second,
+            "ConnectionMapping MUST be a singleton so the REST controller and the SignalR hub share the SAME instance");
+    }
+
+    [Test]
+    public void MuteReconciliationService_Resolves_AndSharesTheSingletonConnectionMapping()
+    {
+        using var provider = BuildProvider();
+
+        var service = provider.GetRequiredService<MuteReconciliationService>();
+        Assert.IsNotNull(service, "MuteReconciliationService must resolve from the DI container");
+        // Resolving twice returns the same singleton instance.
+        Assert.AreSame(service, provider.GetRequiredService<MuteReconciliationService>(),
+            "MuteReconciliationService is registered as a singleton");
+    }
+
+    [Test]
+    public void IMuteRepository_ResolvesToMuteRepository()
+    {
+        using var provider = BuildProvider();
+
+        var repo = provider.GetRequiredService<IMuteRepository>();
+        Assert.IsInstanceOf<MuteRepository>(repo,
+            "IMuteRepository must resolve to the concrete MuteRepository");
+    }
+}

--- a/W3ChampionsChatService/Authentication/ChatHubPermissionFilter.cs
+++ b/W3ChampionsChatService/Authentication/ChatHubPermissionFilter.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Serilog;
@@ -6,14 +6,17 @@ using Serilog;
 namespace W3ChampionsChatService.Authentication;
 
 /// <summary>
-/// SignalR hub filter that enforces Moderation permission on the moderator-only hub methods.
+/// SignalR hub filter that enforces <see cref="UserHasPermissionAttribute"/> generically on hub
+/// methods. The required permission is DECLARED on the method as <c>[UserHasPermission(...)]</c> — the
+/// same attribute used on the MVC controllers — so the permission stays co-located with the method and
+/// is the single source of truth, enforced by the right pipeline per transport.
 /// <para>
-/// SECURITY: the MVC <c>[UserHasPermission]</c> attribute is INERT on SignalR hub methods (it is an
-/// <c>IAsyncActionFilter</c>, which the hub pipeline never runs), so without this filter ANY
-/// authenticated connection could invoke <c>BanUser</c>/<c>DeleteMessage</c>/<c>PurgeMessagesFromUser</c>.
-/// This closes that privilege-escalation hole using the SAME stateless JWT resolution as the MVC filter:
-/// decode the <c>access_token</c> via <see cref="IW3CAuthenticationService.GetUserByToken"/> and require
-/// <c>IsAdmin</c> + the Moderation permission.
+/// SECURITY: the MVC <c>[UserHasPermission]</c> attribute is an <c>IAsyncActionFilter</c>, which the
+/// SignalR hub pipeline never runs — so on a hub method it is inert without this filter. This filter
+/// reads the attribute off the invoked method via reflection and applies the SAME stateless JWT
+/// resolution as the MVC filter: decode the <c>access_token</c> via
+/// <see cref="IW3CAuthenticationService.GetUserByToken"/> and require <c>IsAdmin</c> + the declared
+/// permission. A method WITHOUT the attribute is unprotected and passes straight through (no JWT decode).
 /// </para>
 /// Rejections throw <see cref="HubException"/> (a graceful, client-visible error) — NEVER
 /// <c>Context.Abort()</c>; the connection stays alive.
@@ -22,23 +25,23 @@ public class ChatHubPermissionFilter(IW3CAuthenticationService authService) : IH
 {
     private readonly IW3CAuthenticationService _authService = authService;
 
-    // The moderator-only hub methods that require the Moderation permission.
-    private static readonly HashSet<string> ProtectedMethods = new()
-    {
-        nameof(Chats.ChatHub.BanUser),
-        nameof(Chats.ChatHub.DeleteMessage),
-        nameof(Chats.ChatHub.PurgeMessagesFromUser),
-    };
-
     public async ValueTask<object> InvokeMethodAsync(
         HubInvocationContext invocationContext,
         System.Func<HubInvocationContext, ValueTask<object>> next)
     {
-        if (!ProtectedMethods.Contains(invocationContext.HubMethodName))
+        // The required permission is whatever the method declares via [UserHasPermission(...)].
+        // No attribute → unprotected method (e.g. SendMessage) → pass straight through, no auth.
+        var permissionAttribute = invocationContext.HubMethod
+            .GetCustomAttributes(typeof(UserHasPermissionAttribute), inherit: true)
+            .Cast<UserHasPermissionAttribute>()
+            .FirstOrDefault();
+
+        if (permissionAttribute == null)
         {
-            // Unprotected method — pass straight through.
             return await next(invocationContext);
         }
+
+        var requiredPermission = permissionAttribute.Permission;
 
         // Read the access_token from the SignalR connection's HttpContext. IHttpContextAccessor is NOT
         // usable here: it is null for hub-METHOD invocations over WebSockets (only populated during the
@@ -48,12 +51,12 @@ public class ChatHubPermissionFilter(IW3CAuthenticationService authService) : IH
         var token = httpContext?.Request.Query["access_token"];
         var auth = _authService.GetUserByToken(token);
 
-        if (auth == null || !auth.IsAdmin || !auth.Permissions.Contains(EPermission.Moderation))
+        if (auth == null || !auth.IsAdmin || !auth.Permissions.Contains(requiredPermission))
         {
-            Log.Warning("Hub method {Method} rejected: caller {BattleTag} lacks Moderation permission",
-                invocationContext.HubMethodName, auth?.BattleTag ?? "<unauthenticated>");
+            Log.Warning("Hub method {Method} rejected: caller {BattleTag} lacks {Permission} permission",
+                invocationContext.HubMethodName, auth?.BattleTag ?? "<unauthenticated>", requiredPermission);
             // Graceful, client-visible rejection — never Context.Abort().
-            throw new HubException("Unauthorized: Moderation permission required");
+            throw new HubException($"Unauthorized: {requiredPermission} permission required");
         }
 
         return await next(invocationContext);

--- a/W3ChampionsChatService/Authentication/ChatHubPermissionFilter.cs
+++ b/W3ChampionsChatService/Authentication/ChatHubPermissionFilter.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
 using Serilog;
 
@@ -19,10 +18,9 @@ namespace W3ChampionsChatService.Authentication;
 /// Rejections throw <see cref="HubException"/> (a graceful, client-visible error) — NEVER
 /// <c>Context.Abort()</c>; the connection stays alive.
 /// </summary>
-public class ChatHubPermissionFilter(IW3CAuthenticationService authService, IHttpContextAccessor contextAccessor) : IHubFilter
+public class ChatHubPermissionFilter(IW3CAuthenticationService authService) : IHubFilter
 {
     private readonly IW3CAuthenticationService _authService = authService;
-    private readonly IHttpContextAccessor _contextAccessor = contextAccessor;
 
     // The moderator-only hub methods that require the Moderation permission.
     private static readonly HashSet<string> ProtectedMethods = new()
@@ -42,8 +40,12 @@ public class ChatHubPermissionFilter(IW3CAuthenticationService authService, IHtt
             return await next(invocationContext);
         }
 
-        // Same token source as OnConnectedAsync: the access_token query string.
-        var token = _contextAccessor.HttpContext?.Request.Query["access_token"];
+        // Read the access_token from the SignalR connection's HttpContext. IHttpContextAccessor is NOT
+        // usable here: it is null for hub-METHOD invocations over WebSockets (only populated during the
+        // handshake). HubCallerContext.GetHttpContext() reads the connection's IHttpContextFeature,
+        // which is reliably populated at handshake and persists for the connection lifetime.
+        var httpContext = invocationContext.Context.GetHttpContext();
+        var token = httpContext?.Request.Query["access_token"];
         var auth = _authService.GetUserByToken(token);
 
         if (auth == null || !auth.IsAdmin || !auth.Permissions.Contains(EPermission.Moderation))

--- a/W3ChampionsChatService/Authentication/ChatHubPermissionFilter.cs
+++ b/W3ChampionsChatService/Authentication/ChatHubPermissionFilter.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.SignalR;
+using Serilog;
+
+namespace W3ChampionsChatService.Authentication;
+
+/// <summary>
+/// SignalR hub filter that enforces Moderation permission on the moderator-only hub methods.
+/// <para>
+/// SECURITY: the MVC <c>[UserHasPermission]</c> attribute is INERT on SignalR hub methods (it is an
+/// <c>IAsyncActionFilter</c>, which the hub pipeline never runs), so without this filter ANY
+/// authenticated connection could invoke <c>BanUser</c>/<c>DeleteMessage</c>/<c>PurgeMessagesFromUser</c>.
+/// This closes that privilege-escalation hole using the SAME stateless JWT resolution as the MVC filter:
+/// decode the <c>access_token</c> via <see cref="IW3CAuthenticationService.GetUserByToken"/> and require
+/// <c>IsAdmin</c> + the Moderation permission.
+/// </para>
+/// Rejections throw <see cref="HubException"/> (a graceful, client-visible error) — NEVER
+/// <c>Context.Abort()</c>; the connection stays alive.
+/// </summary>
+public class ChatHubPermissionFilter(IW3CAuthenticationService authService, IHttpContextAccessor contextAccessor) : IHubFilter
+{
+    private readonly IW3CAuthenticationService _authService = authService;
+    private readonly IHttpContextAccessor _contextAccessor = contextAccessor;
+
+    // The moderator-only hub methods that require the Moderation permission.
+    private static readonly HashSet<string> ProtectedMethods = new()
+    {
+        nameof(Chats.ChatHub.BanUser),
+        nameof(Chats.ChatHub.DeleteMessage),
+        nameof(Chats.ChatHub.PurgeMessagesFromUser),
+    };
+
+    public async ValueTask<object> InvokeMethodAsync(
+        HubInvocationContext invocationContext,
+        System.Func<HubInvocationContext, ValueTask<object>> next)
+    {
+        if (!ProtectedMethods.Contains(invocationContext.HubMethodName))
+        {
+            // Unprotected method — pass straight through.
+            return await next(invocationContext);
+        }
+
+        // Same token source as OnConnectedAsync: the access_token query string.
+        var token = _contextAccessor.HttpContext?.Request.Query["access_token"];
+        var auth = _authService.GetUserByToken(token);
+
+        if (auth == null || !auth.IsAdmin || !auth.Permissions.Contains(EPermission.Moderation))
+        {
+            Log.Warning("Hub method {Method} rejected: caller {BattleTag} lacks Moderation permission",
+                invocationContext.HubMethodName, auth?.BattleTag ?? "<unauthenticated>");
+            // Graceful, client-visible rejection — never Context.Abort().
+            throw new HubException("Unauthorized: Moderation permission required");
+        }
+
+        return await next(invocationContext);
+    }
+}

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -349,26 +349,22 @@ public class ChatHub(
 
             if (!isShadowBan)
             {
-                // Full ban — G5: notify the target so old clients render their legacy ban notice.
-                // Only send when the user is in a banned room (spec §12 / G1/G5 signal).
-                // G1: do NOT call Context.Abort() — the connection must stay alive.
-                var currentRoom = _connections.GetRoom(connId);
-                if (currentRoom != null && DefaultChatRooms.IsBannedRoom(currentRoom))
+                // Full ban — R7/G5: notify the target REGARDLESS of their current room so they
+                // clearly and persistently know they're banned, independent of channel. A user
+                // full-banned while sitting in a clan/lobby room must still receive the notice
+                // (not just users in a lounge/ladder room).
+                // G1: SendAsync only — do NOT call Context.Abort(); the connection must stay alive.
+                // §12: no forced eviction — the user keeps their current room membership.
+                var mute = new LoungeMute
                 {
-                    var mute = new LoungeMute
-                    {
-                        battleTag = battleTag,
-                        endDate = parsedEndDate,
-                        insertDate = DateTime.UtcNow,
-                        author = adminUser.BattleTag,
-                        reason = reason,
-                        isShadowBan = false
-                    };
-                    // G1: SendAsync only — no Context.Abort().
-                    await Clients.Client(connId).SendAsync("PlayerBannedFromChat", mute);
-                }
-                // Full-ban user in an exempt room: cache is still updated (ban is active for future
-                // joins/sends), but no signal is sent — they can stay in the exempt room per spec §12.
+                    battleTag = battleTag,
+                    endDate = parsedEndDate,
+                    insertDate = DateTime.UtcNow,
+                    author = adminUser.BattleTag,
+                    reason = reason,
+                    isShadowBan = false
+                };
+                await Clients.Client(connId).SendAsync("PlayerBannedFromChat", mute);
             }
             // Shadow ban: no signal to the target whatsoever — preserve the illusion (spec §12).
         }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -44,9 +45,11 @@ public class ChatHub(
 
             if (mute != null && !mute.isShadowBan)
             {
-                // Regular mute: disconnect
-                await Clients.Caller.SendAsync("PlayerBannedFromChat", mute);
-                Context.Abort();
+                // G1: Full ban — silently drop the message (no Context.Abort(), no teardown).
+                // The PlayerBannedFromChat notice was already sent at connect time (LoginAsAuthenticated).
+                Log.Information("Full-banned user {BattleTag} attempted to send message in room {Room} — dropped silently",
+                    user?.BattleTag, chatRoom);
+                return;
             }
             else
             {
@@ -201,19 +204,59 @@ public class ChatHub(
     internal async Task LoginAsAuthenticated(ChatUser user)
     {
         var memberShip = await _settingsRepository.Load(user.BattleTag) ?? new ChatSettings(user.BattleTag);
-
         var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
 
-        if (mute != null && DateTime.Compare(mute.endDate, DateTime.UtcNow) > 0 && !mute.isShadowBan)
+        // Treat expired mutes as no mute
+        if (mute != null && DateTime.Compare(mute.endDate, DateTime.UtcNow) <= 0)
         {
-            Log.Information("Declining connection for {BattleTag} because they are banned until {EndDate}", user.BattleTag, mute.endDate);
+            mute = null;
+        }
+
+        var isFullBan = mute != null && !mute.isShadowBan;
+        var isShadowBan = mute != null && mute.isShadowBan;
+
+        if (isFullBan)
+        {
+            // G1: do NOT abort — connect the user. G5: still send legacy PlayerBannedFromChat.
+            Log.Information("Full-banned user {BattleTag} connecting — sending ban notice, filtering rooms", user.BattleTag);
+
+            // G5: legacy ban notice so old clients render their notice.
             await Clients.Caller.SendAsync("PlayerBannedFromChat", mute);
-            Context.Abort();
+
+            // Filtered channel list excludes all lounge/ladder banned rooms (spec §5.1).
+            var availableRooms = new List<string>();
+
+            // Seat in clan room if available, else no room (spec D2 — empty state).
+            var safeRoom = string.IsNullOrWhiteSpace(user.ClanTag) ? null : $"clan {user.ClanTag}";
+
+            if (safeRoom != null)
+            {
+                _connections.Add(Context.ConnectionId, safeRoom, user);
+                _connections.SetMuteStatus(Context.ConnectionId, MuteStatus.Full);
+                await Groups.AddToGroupAsync(Context.ConnectionId, safeRoom);
+                var usersOfRoom = _connections.GetUsersOfRoom(safeRoom);
+                await Clients.Group(safeRoom).SendAsync("UserEntered", user);
+                // G3: StartChat with the seated room's payload.
+                await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(safeRoom), safeRoom, availableRooms);
+            }
+            else
+            {
+                // No clan: not seated in any room (spec D2).
+                // Note: SetMuteStatus is not called here because the connection is not in the mapping yet.
+                // SwitchRoom enforcement (Task 4) lazily re-resolves the mute from MongoDB for this edge case.
+                // G3: STILL emit a StartChat — an empty-room payload — so legacy clients can initialize.
+                await Clients.Caller.SendAsync("StartChat", new List<ChatUser>(), new List<ChatMessage>(), (string)null, availableRooms);
+            }
         }
         else
         {
-            Log.Information("Accepting connection for {BattleTag} and adding to room {Room}", user.BattleTag, memberShip.DefaultChat);
+            // Shadow ban or no ban: connect as normal (G1 — never abort).
+            var muteStatus = isShadowBan ? MuteStatus.Shadow : MuteStatus.None;
+            Log.Information("Accepting connection for {BattleTag}, mute={MuteStatus}, room={Room}",
+                user.BattleTag, muteStatus, memberShip.DefaultChat);
+
             _connections.Add(Context.ConnectionId, memberShip.DefaultChat, user);
+            _connections.SetMuteStatus(Context.ConnectionId, muteStatus);
             await Groups.AddToGroupAsync(Context.ConnectionId, memberShip.DefaultChat);
             var usersOfRoom = _connections.GetUsersOfRoom(memberShip.DefaultChat);
             await Clients.Group(memberShip.DefaultChat).SendAsync("UserEntered", user);

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -47,55 +47,24 @@ public class ChatHub(
             return;
         }
 
-        var inBannedRoom = DefaultChatRooms.IsBannedRoom(chatRoom);
-        var muteStatus = MuteStatus.None;
+        // Mutes only apply in public lounge/ladder rooms; clan/lobby rooms are fully exempt.
+        // Read the per-user cached status once + classify the room — ZERO DB reads on the hot path.
+        // The cache is seeded authoritatively at login (every path) and reconciled live by BanUser,
+        // so consulting GetEffectiveMuteStatus alone is sufficient and expiry-aware. ACCEPTED TRADE-OFF:
+        // an out-of-band ban written directly to Mongo (bypassing the BanUser hub) only takes effect on
+        // the user's next (re)connect — we deliberately do NOT re-query the DB per send.
+        var inPublicRoom = DefaultChatRooms.IsPublicRoom(chatRoom);
+        var muteStatus = inPublicRoom
+            ? _connections.GetEffectiveMuteStatus(Context.ConnectionId, DateTime.UtcNow)
+            : MuteStatus.None;
 
-        if (inBannedRoom)
+        if (inPublicRoom && muteStatus == MuteStatus.Full)
         {
-            var hasCached = _connections.TryGetMute(Context.ConnectionId, out var cached);
-
-            if (hasCached && cached.Status != MuteStatus.None)
-            {
-                // Cache HIT with an active ban — honor cached status + expiry. ZERO DB reads.
-                // This is the primary §7 win: a cached-banned user does NOT hit the DB on every send.
-                // EffectiveStatus is the single expiry rule (expired ban → None).
-                muteStatus = cached.EffectiveStatus(DateTime.UtcNow);
-
-                if (muteStatus == MuteStatus.None)
-                {
-                    // Ban expired — update the cache so future sends skip the DB too.
-                    _connections.SetMute(Context.ConnectionId, MuteStatus.None, DateTime.MinValue);
-                }
-            }
-            else
-            {
-                // Cache MISS or cache HIT with None:
-                //   - MISS: no-clan full-ban login edge, or any first-send path.
-                //   - HIT-None: also re-resolve as a pre-Task 7 live-ban safety net
-                //     (a ban applied mid-session won't be reflected in the cached None until
-                //     Task 7 adds live cache-invalidation via BanUser; this keeps the net tight).
-                var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
-                if (mute != null && mute.IsActive(DateTime.UtcNow))
-                {
-                    muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
-                    _connections.SetMute(Context.ConnectionId, muteStatus, mute.endDate);
-                }
-                else if (!hasCached)
-                {
-                    // MISS path: cache the resolved None so future sends know the entry exists.
-                    _connections.SetMute(Context.ConnectionId, MuteStatus.None, DateTime.MinValue);
-                }
-                // HIT-None path: leave cache as-is (ban is truly not there).
-            }
-        }
-
-        if (inBannedRoom && muteStatus == MuteStatus.Full)
-        {
-            // Defense-in-depth: full-banned user should never be in a banned room,
+            // Defense-in-depth: full-banned user should never be in a public room,
             // but reject silently if they somehow are.
             // G1: the LEGACY SendMessage called Context.Abort() here for full bans — REMOVED.
             // G2: reject without abort, without throwing; connection + membership stay valid.
-            Log.Warning("Full-banned user {BattleTag} attempted to send in banned room {Room} — rejected",
+            Log.Warning("Full-banned user {BattleTag} attempted to send in public room {Room} — rejected",
                 user.BattleTag, chatRoom);
             return;
         }
@@ -104,18 +73,18 @@ public class ChatHub(
 
         if (!await ProcessChatCommand(chatMessage))
         {
-            if (inBannedRoom && muteStatus == MuteStatus.Shadow)
+            if (inPublicRoom && muteStatus == MuteStatus.Shadow)
             {
-                // Drop: echo only to caller (illusion of sending).
-                // Boyscout: do NOT log the raw message body — arbitrary user input should not appear in logs.
-                Log.Information("Shadow banned user {BattleTag} attempted to send in banned room {Room} — dropped",
-                    user.BattleTag, chatRoom);
+                // Drop: echo only to caller (illusion of sending). The message reaches no one else.
+                // Log the dropped attempt (incl. content) so moderators can audit shadow-banned activity.
+                Log.Information("Shadow banned user {BattleTag} attempted to send in public room {Room} — dropped: {Message}",
+                    user.BattleTag, chatRoom, trimmedMessage);
                 await Clients.Caller.SendAsync("ReceiveMessage", chatMessage);
             }
             else
             {
                 // Broadcast to room: covers no-ban in any room AND banned users in exempt rooms.
-                // Bans only restrict sending in the lounge/ladder banned rooms; clan/lobby rooms
+                // Bans only restrict sending in the public lounge/ladder rooms; clan/lobby rooms
                 // are fully exempt — even full- and shadow-banned users can post freely there.
                 _chatHistory.AddMessage(chatRoom, chatMessage);
                 await Clients.Group(chatRoom).SendAsync("ReceiveMessage", chatMessage);
@@ -177,12 +146,12 @@ public class ChatHub(
             _connections.Remove(Context.ConnectionId);
 
             // Guard against null room (full-ban no-clan user has no room — G3/G2: no crash).
-            // Suppress UserLeft for shadow-banned users in banned rooms: they were never announced
+            // Suppress UserLeft for shadow-banned users in public rooms: they were never announced
             // as present (ghost-join), so broadcasting UserLeft would break the illusion (spec §6).
             // Shadow users in exempt rooms (clan/lobby) were announced normally — broadcast as usual.
             var suppressUserLeft = muteStatus == MuteStatus.Shadow
                 && chatRoom != null
-                && DefaultChatRooms.IsBannedRoom(chatRoom);
+                && DefaultChatRooms.IsPublicRoom(chatRoom);
 
             if (!suppressUserLeft && chatRoom != null)
             {
@@ -198,79 +167,46 @@ public class ChatHub(
         var oldRoom = _connections.GetRoom(Context.ConnectionId);
         var user = _connections.GetUser(Context.ConnectionId);
 
-        var muteStatus = MuteStatus.None;
-        // Capture the full cached entry BEFORE Remove so we can re-populate it afterwards.
+        // R6/G1/G2: a connection with no user (not logged in, or a no-clan full-ban with no seat)
+        // cannot switch rooms. Reject gracefully — return, never Context.Abort(), never throw.
+        if (user == null)
+        {
+            Log.Warning("SwitchRoom rejected: connection {ConnectionId} has no user", Context.ConnectionId);
+            return;
+        }
+
+        // Resolve the per-user cached status once. The cache is seeded at login (every path) and
+        // reconciled live by BanUser, so it is authoritative — consult it ONLY, never the DB.
+        // EffectiveStatus is the single expiry rule (expired ban → None). Capture the cached endDate
+        // so we can re-populate the cache after Remove (which clears it) + Add.
         var hasCachedEntry = _connections.TryGetMute(Context.ConnectionId, out var preSwitchCached);
         var cachedEndDate = hasCachedEntry ? preSwitchCached.EndDate : DateTime.MinValue;
-        var targetIsBanned = DefaultChatRooms.IsBannedRoom(chatRoom);
-
-        if (user != null)
-        {
-            if (targetIsBanned)
-            {
-                // SECURITY: for a BANNED target, only trust the cache on a HIT with a real ban
-                // (Status != None). A cache MISS *or* a HIT-None must lazy-resolve from the DB —
-                // otherwise a no-clan full-banned user who first switched into an exempt room
-                // (which writes a cache-None) would bypass the ban on a later switch into a
-                // banned room. This mirrors SendMessage's HIT-None re-resolve path.
-                if (hasCachedEntry && preSwitchCached.Status != MuteStatus.None)
-                {
-                    // Fast path: cached active ban — honor cached status + expiry, no DB read.
-                    // EffectiveStatus is the single expiry rule (expired ban → None).
-                    muteStatus = preSwitchCached.EffectiveStatus(DateTime.UtcNow);
-                    cachedEndDate = preSwitchCached.EndDate;
-                }
-                else
-                {
-                    // Cache MISS or HIT-None — lazy-resolve the mute for the banned target.
-                    var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
-                    if (mute != null && mute.IsActive(DateTime.UtcNow))
-                    {
-                        muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
-                        cachedEndDate = mute.endDate;
-                    }
-                    else
-                    {
-                        muteStatus = MuteStatus.None;
-                        cachedEndDate = DateTime.MinValue;
-                    }
-                }
-            }
-            else if (hasCachedEntry)
-            {
-                // Exempt target — cache HIT drives the shadow presence gates below; no DB read.
-                // EffectiveStatus is the single expiry rule (expired ban → None).
-                muteStatus = preSwitchCached.EffectiveStatus(DateTime.UtcNow);
-            }
-            // Exempt target + cache MISS: muteStatus stays None; no DB read needed.
-        }
+        var targetIsPublic = DefaultChatRooms.IsPublicRoom(chatRoom);
+        var muteStatus = hasCachedEntry ? preSwitchCached.EffectiveStatus(DateTime.UtcNow) : MuteStatus.None;
 
         // G1/G2: Full-ban → graceful reject BEFORE any Remove/Add. User stays in their current room.
         // No Context.Abort(), no throw, no connection teardown.
-        if (targetIsBanned && muteStatus == MuteStatus.Full)
+        if (targetIsPublic && muteStatus == MuteStatus.Full)
         {
-            // S3: cache the resolved full ban before returning so subsequent SwitchRoom/SendMessage
-            // enforce from the cache instead of re-reading the DB.
-            _connections.SetMute(Context.ConnectionId, MuteStatus.Full, cachedEndDate);
-            Log.Information("Full-banned user {BattleTag} rejected from joining banned room {Room} — staying in {OldRoom}",
+            Log.Information("Full-banned user {BattleTag} rejected from joining public room {Room} — staying in {OldRoom}",
                 user.BattleTag, chatRoom, oldRoom);
             return;
         }
 
         // Two independent presence gates, each derived from the relevant room:
-        // - suppressLeave: the user was a GHOST in the OLD room (shadow + old room is banned),
+        // - suppressLeave: the user was a GHOST in the OLD room (shadow + old room is public),
         //   so no one ever saw them there — suppress the UserLeft on the room they're leaving.
-        // - suppressEnter: the user ghost-joins the TARGET room (shadow + target is banned),
+        // - suppressEnter: the user ghost-joins the TARGET room (shadow + target is public),
         //   so suppress the UserEntered on the room they're entering.
         // Using a single target-based flag for both would leak/strand presence on cross-category
-        // shadow transitions (exempt→banned must still broadcast UserLeft; banned→exempt must not).
-        var suppressLeave = oldRoom != null && DefaultChatRooms.IsBannedRoom(oldRoom) && muteStatus == MuteStatus.Shadow;
-        var suppressEnter = targetIsBanned && muteStatus == MuteStatus.Shadow;
+        // shadow transitions (exempt→public must still broadcast UserLeft; public→exempt must not).
+        var suppressLeave = oldRoom != null && DefaultChatRooms.IsPublicRoom(oldRoom) && muteStatus == MuteStatus.Shadow;
+        var suppressEnter = targetIsPublic && muteStatus == MuteStatus.Shadow;
 
         _connections.Remove(Context.ConnectionId);
         _connections.Add(Context.ConnectionId, chatRoom, user);
-        // Re-cache the mute status + endDate after Remove (which clears it) + Add.
-        // S3: this also caches a freshly lazy-resolved shadow ban on the ghost-join path.
+        // Re-cache the mute status + endDate after Remove (which clears it) + Add — the cache survives
+        // the switch with the same authoritative status it had before.
         _connections.SetMute(Context.ConnectionId, muteStatus, cachedEndDate);
 
         if (oldRoom != null)
@@ -290,7 +226,7 @@ public class ChatHub(
             await Clients.Group(chatRoom).SendAsync("UserEntered", user);
         }
         // Caller receives their viewer-filtered user list: they always see themselves;
-        // other shadow-banned users are hidden from them in banned rooms (spec §6).
+        // other shadow-banned users are hidden from them in public rooms (spec §6).
         await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(chatRoom), chatRoom);
 
         var memberShip = await _settingsRepository.Load(user.BattleTag) ?? new ChatSettings(user.BattleTag);
@@ -349,16 +285,19 @@ public class ChatHub(
 
         await _muteRepository.AddLoungeMute(loungeMuteRequest);
 
-        // Spec §12: Reconcile any live connections for this user so enforcement is instant.
+        // Spec §12: BanUser is the canonical IN-BAND ban path — it persists the ban AND reconciles
+        // every live connection's mute cache so enforcement is instant without a per-send DB read.
+        // (An out-of-band ban written straight to Mongo only takes effect on the user's next reconnect,
+        // when LoginAsAuthenticated re-seeds the cache from the DB — accepted trade-off, see SendMessage.)
         // Parse the endDate once — used for both the cache and the PlayerBannedFromChat payload.
         // Use the SAME DateTimeStyles the repository uses (AdjustToUniversal) so the CACHED expiry
         // can never disagree with the PERSISTED expiry for an offset-less endDate.
         // Guard a malformed/empty endDate: the ban is already persisted, so on a parse failure
-        // skip the live reconcile gracefully (the safety-net re-resolve enforces on next send/join)
+        // skip the live reconcile gracefully (next reconnect re-seeds the cache from the DB)
         // rather than throwing a hub exception after the write.
         if (!DateTime.TryParse(endDate, null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsedEndDate))
         {
-            Log.Warning("BanUser: could not parse endDate '{EndDate}' for {BattleTag} — ban persisted, skipping live cache reconcile (safety-net re-resolve will enforce)",
+            Log.Warning("BanUser: could not parse endDate '{EndDate}' for {BattleTag} — ban persisted, skipping live cache reconcile (next reconnect will re-seed the cache)",
                 endDate, battleTag);
             return;
         }
@@ -379,19 +318,14 @@ public class ChatHub(
                 // Full ban — R7/G5: notify the target REGARDLESS of their current room so they
                 // clearly and persistently know they're banned, independent of channel. A user
                 // full-banned while sitting in a clan/lobby room must still receive the notice
-                // (not just users in a lounge/ladder room).
+                // (not just users in a public lounge/ladder room).
                 // G1: SendAsync only — do NOT call Context.Abort(); the connection must stay alive.
                 // §12: no forced eviction — the user keeps their current room membership.
-                var mute = new LoungeMute
-                {
-                    battleTag = battleTag,
-                    endDate = parsedEndDate,
-                    insertDate = DateTime.UtcNow,
-                    author = adminUser.BattleTag,
-                    reason = reason,
-                    isShadowBan = false
-                };
-                await Clients.Client(connId).SendAsync("PlayerBannedFromChat", mute);
+                // SECURITY: send only the expiry — never leak the moderation reason or the shadow flag
+                // to the client. The event name + the camelCase `endDate` field stay unchanged so old
+                // clients keep reading `.endDate`; the missing reason/isShadowBan deserialize to
+                // null/false on legacy clients (harmless).
+                await Clients.Client(connId).SendAsync("PlayerBannedFromChat", new { endDate = parsedEndDate });
             }
             // Shadow ban: no signal to the target whatsoever — preserve the illusion (spec §12).
         }
@@ -417,10 +351,16 @@ public class ChatHub(
             Log.Information("Full-banned user {BattleTag} connecting — sending ban notice, filtering rooms", user.BattleTag);
 
             // G5: legacy ban notice so old clients render their notice.
-            await Clients.Caller.SendAsync("PlayerBannedFromChat", mute);
+            // SECURITY: send only the expiry — never leak the moderation reason or the shadow flag.
+            // The event name + camelCase `endDate` field stay unchanged for backward-compat.
+            await Clients.Caller.SendAsync("PlayerBannedFromChat", new { endDate = mute.endDate });
 
-            // Filtered channel list excludes all lounge/ladder banned rooms (spec §5.1).
+            // Filtered channel list excludes all public lounge/ladder rooms (spec §5.1).
             var availableRooms = new List<string>();
+
+            // Seed the per-connection mute cache authoritatively for BOTH branches so the send/switch
+            // hot paths enforce from the cache alone (zero DB reads), even on the no-clan/no-room edge.
+            _connections.SetMute(Context.ConnectionId, MuteStatus.Full, mute.endDate);
 
             // Seat in clan room if available, else no room (spec D2 — empty state).
             var safeRoom = string.IsNullOrWhiteSpace(user.ClanTag) ? null : $"clan {user.ClanTag}";
@@ -428,8 +368,6 @@ public class ChatHub(
             if (safeRoom != null)
             {
                 _connections.Add(Context.ConnectionId, safeRoom, user);
-                // Cache full-ban status + endDate so SwitchRoom/SendMessage never need a DB read.
-                _connections.SetMute(Context.ConnectionId, MuteStatus.Full, mute.endDate);
                 await Groups.AddToGroupAsync(Context.ConnectionId, safeRoom);
                 var usersOfRoom = _connections.GetUsersOfRoomForViewer(safeRoom, Context.ConnectionId);
                 await Clients.Group(safeRoom).SendAsync("UserEntered", user);
@@ -438,11 +376,9 @@ public class ChatHub(
             }
             else
             {
-                // No clan: not seated in any room (spec D2).
-                // SetMute is NOT called here — the connection is not in the mapping yet.
-                // SwitchRoom/SendMessage enforcement lazily re-resolves from MongoDB for this edge case
-                // (cache MISS path). This is acceptable: full-banned users with no clan have no room,
-                // so any SwitchRoom into a banned room still triggers the lazy resolve and is rejected.
+                // No clan: not seated in any room (spec D2). The cache is STILL seeded above
+                // (SetMute keys by connectionId only, independent of room membership), so a later
+                // SwitchRoom into a public room enforces the full ban from the cache — no DB read.
                 // G3: STILL emit a StartChat — an empty-room payload — so legacy clients can initialize.
                 await Clients.Caller.SendAsync("StartChat", new List<ChatUser>(), new List<ChatMessage>(), (string)null, availableRooms);
             }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -31,52 +31,80 @@ public class ChatHub(
     public async Task SendMessage(string message)
     {
         var trimmedMessage = message.Trim();
-        if (!string.IsNullOrEmpty(trimmedMessage))
+        if (string.IsNullOrEmpty(trimmedMessage))
         {
-            var chatRoom = _connections.GetRoom(Context.ConnectionId);
-            var user = _connections.GetUser(Context.ConnectionId);
+            return;
+        }
 
-            // R6 (membership-before-send, start): a connected user may be seated in NO room
-            // (e.g. full-banned with no clan). Without a room/user there is nothing to send.
-            // Guard before dereferencing user/chatRoom to avoid an NRE. Task 5 completes room-scoping.
-            if (user == null || chatRoom == null)
-            {
-                return;
-            }
+        var chatRoom = _connections.GetRoom(Context.ConnectionId);
+        var user = _connections.GetUser(Context.ConnectionId);
 
-            // Check if player is on Lounge Mute list. If yes, handle accordingly.
+        // R6: Membership prerequisite — user must be a member of a valid room.
+        // G1/G2: graceful reject — return, never Context.Abort(), never throw.
+        if (chatRoom == null || user == null)
+        {
+            Log.Warning("SendMessage rejected: connection {ConnectionId} has no room membership", Context.ConnectionId);
+            return;
+        }
+
+        var muteStatus = _connections.GetMuteStatus(Context.ConnectionId);
+        var inBannedRoom = DefaultChatRooms.IsBannedRoom(chatRoom);
+
+        // Lazy DB resolve: mirroring SwitchRoom — if cache is None but we're in a banned room,
+        // re-resolve from DB in case a ban was applied mid-session (before Task 7 cache-reconciliation
+        // is in place via BanUser). Without Task 7 live-reconciliation, this keeps the safety net.
+        if (muteStatus == MuteStatus.None && inBannedRoom)
+        {
             var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
-            if (mute != null && !mute.IsActive(DateTime.UtcNow))
+            if (mute != null && mute.IsActive(DateTime.UtcNow))
             {
-                mute = null;
+                muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
+                _connections.SetMuteStatus(Context.ConnectionId, muteStatus);
             }
+        }
 
-            // TODO (Task 5): room-scope via DefaultChatRooms.IsBannedRoom + cached GetMuteStatus; currently room-blind.
-            if (mute != null && !mute.isShadowBan)
+        // Re-verify expiry from DB if cached as banned (handles edge case where ban expired mid-session).
+        // Per spec §7: the per-message DB read is scoped to cached-banned connections only (not every send).
+        if (muteStatus != MuteStatus.None)
+        {
+            var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
+            if (mute == null || !mute.IsActive(DateTime.UtcNow))
             {
-                // G1: Full ban — silently drop the message (no Context.Abort(), no teardown).
-                // The PlayerBannedFromChat notice was already sent at connect time (LoginAsAuthenticated).
-                Log.Information("Full-banned user {BattleTag} attempted to send message in room {Room} — dropped silently",
-                    user.BattleTag, chatRoom);
-                return;
+                // Ban has expired — treat as no ban for this send
+                muteStatus = MuteStatus.None;
+                _connections.SetMuteStatus(Context.ConnectionId, MuteStatus.None);
+            }
+        }
+
+        if (inBannedRoom && muteStatus == MuteStatus.Full)
+        {
+            // Defense-in-depth: full-banned user should never be in a banned room,
+            // but reject silently if they somehow are.
+            // G1: the LEGACY SendMessage called Context.Abort() here for full bans — REMOVED.
+            // G2: reject without abort, without throwing; connection + membership stay valid.
+            Log.Warning("Full-banned user {BattleTag} attempted to send in banned room {Room} — rejected",
+                user.BattleTag, chatRoom);
+            return;
+        }
+
+        var chatMessage = new ChatMessage(user, trimmedMessage);
+
+        if (!await ProcessChatCommand(chatMessage))
+        {
+            if (inBannedRoom && muteStatus == MuteStatus.Shadow)
+            {
+                // Drop: echo only to caller (illusion of sending)
+                Log.Information("Shadow banned user {BattleTag} sent message {Message} in banned room {Room} — dropped",
+                    user.BattleTag, trimmedMessage, chatRoom);
+                await Clients.Caller.SendAsync("ReceiveMessage", chatMessage);
             }
             else
             {
-                var chatMessage = new ChatMessage(user, trimmedMessage);
-                if (!await ProcessChatCommand(chatMessage))
-                {
-                    if (mute != null && mute.isShadowBan)
-                    {
-                        // Only send to caller to make them think it was sent
-                        Log.Information("Shadow banned user {BattleTag} sent message {Message}", user.BattleTag, trimmedMessage);
-                        await Clients.Caller.SendAsync("ReceiveMessage", chatMessage);
-                    }
-                    else
-                    {
-                        _chatHistory.AddMessage(chatRoom, chatMessage);
-                        await Clients.Group(chatRoom).SendAsync("ReceiveMessage", chatMessage);
-                    }
-                }
+                // Broadcast to room: covers no-ban in any room AND banned users in exempt rooms.
+                // Bans only restrict sending in the lounge/ladder banned rooms; clan/lobby rooms
+                // are fully exempt — even full- and shadow-banned users can post freely there.
+                _chatHistory.AddMessage(chatRoom, chatMessage);
+                await Clients.Group(chatRoom).SendAsync("ReceiveMessage", chatMessage);
             }
         }
     }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -47,32 +47,44 @@ public class ChatHub(
             return;
         }
 
-        var muteStatus = _connections.GetMuteStatus(Context.ConnectionId);
         var inBannedRoom = DefaultChatRooms.IsBannedRoom(chatRoom);
+        var muteStatus = MuteStatus.None;
 
-        // Lazy DB resolve: mirroring SwitchRoom — if cache is None but we're in a banned room,
-        // re-resolve from DB in case a ban was applied mid-session (before Task 7 cache-reconciliation
-        // is in place via BanUser). Without Task 7 live-reconciliation, this keeps the safety net.
-        if (muteStatus == MuteStatus.None && inBannedRoom)
+        if (inBannedRoom)
         {
-            var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
-            if (mute != null && mute.IsActive(DateTime.UtcNow))
+            var hasCached = _connections.TryGetMute(Context.ConnectionId, out var cached);
+
+            if (hasCached && cached.Status != MuteStatus.None)
             {
-                muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
-                _connections.SetMuteStatus(Context.ConnectionId, muteStatus);
+                // Cache HIT with an active ban — honor cached status + expiry. ZERO DB reads.
+                // This is the primary §7 win: a cached-banned user does NOT hit the DB on every send.
+                muteStatus = cached.EndDate > DateTime.UtcNow ? cached.Status : MuteStatus.None;
+
+                if (muteStatus == MuteStatus.None)
+                {
+                    // Ban expired — update the cache so future sends skip the DB too.
+                    _connections.SetMute(Context.ConnectionId, MuteStatus.None, DateTime.MinValue);
+                }
             }
-        }
-
-        // Re-verify expiry from DB if cached as banned (handles edge case where ban expired mid-session).
-        // Per spec §7: the per-message DB read is scoped to cached-banned connections only (not every send).
-        if (muteStatus != MuteStatus.None)
-        {
-            var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
-            if (mute == null || !mute.IsActive(DateTime.UtcNow))
+            else
             {
-                // Ban has expired — treat as no ban for this send
-                muteStatus = MuteStatus.None;
-                _connections.SetMuteStatus(Context.ConnectionId, MuteStatus.None);
+                // Cache MISS or cache HIT with None:
+                //   - MISS: no-clan full-ban login edge, or any first-send path.
+                //   - HIT-None: also re-resolve as a pre-Task 7 live-ban safety net
+                //     (a ban applied mid-session won't be reflected in the cached None until
+                //     Task 7 adds live cache-invalidation via BanUser; this keeps the net tight).
+                var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
+                if (mute != null && mute.IsActive(DateTime.UtcNow))
+                {
+                    muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
+                    _connections.SetMute(Context.ConnectionId, muteStatus, mute.endDate);
+                }
+                else if (!hasCached)
+                {
+                    // MISS path: cache the resolved None so future sends know the entry exists.
+                    _connections.SetMute(Context.ConnectionId, MuteStatus.None, DateTime.MinValue);
+                }
+                // HIT-None path: leave cache as-is (ban is truly not there).
             }
         }
 
@@ -93,9 +105,10 @@ public class ChatHub(
         {
             if (inBannedRoom && muteStatus == MuteStatus.Shadow)
             {
-                // Drop: echo only to caller (illusion of sending)
-                Log.Information("Shadow banned user {BattleTag} sent message {Message} in banned room {Room} — dropped",
-                    user.BattleTag, trimmedMessage, chatRoom);
+                // Drop: echo only to caller (illusion of sending).
+                // Boyscout: do NOT log the raw message body — arbitrary user input should not appear in logs.
+                Log.Information("Shadow banned user {BattleTag} attempted to send in banned room {Room} — dropped",
+                    user.BattleTag, chatRoom);
                 await Clients.Caller.SendAsync("ReceiveMessage", chatMessage);
             }
             else
@@ -110,7 +123,7 @@ public class ChatHub(
     }
 
     /// <summary>
-    /// Processes chat commands and returns a boolean indicating whether a command was processed 
+    /// Processes chat commands and returns a boolean indicating whether a command was processed
     /// or the message should be sent as a normal message.
     /// </summary>
     /// <param name="message">The chat message to process.</param>
@@ -170,19 +183,37 @@ public class ChatHub(
         var oldRoom = _connections.GetRoom(Context.ConnectionId);
         var user = _connections.GetUser(Context.ConnectionId);
 
-        // Resolve the cached mute status for this connection.
-        var muteStatus = _connections.GetMuteStatus(Context.ConnectionId);
+        var muteStatus = MuteStatus.None;
+        // Capture the full cached entry BEFORE Remove so we can re-populate it afterwards.
+        var hasCachedEntry = _connections.TryGetMute(Context.ConnectionId, out var preSwitchCached);
+        var cachedEndDate = hasCachedEntry ? preSwitchCached.EndDate : DateTime.MinValue;
 
-        // Lazy re-resolve: if cache shows None but target is a banned room, check DB in case
-        // this connection was never cached (e.g. full-banned user with no clan at login).
-        if (muteStatus == MuteStatus.None && user != null && DefaultChatRooms.IsBannedRoom(chatRoom))
+        if (user != null)
         {
-            var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
-            if (mute != null && mute.IsActive(DateTime.UtcNow))
+            if (hasCachedEntry)
             {
-                muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
-                _connections.SetMuteStatus(Context.ConnectionId, muteStatus);
+                // Cache HIT — use the cached status with expiry; no DB read needed for any room.
+                muteStatus = (preSwitchCached.Status == MuteStatus.None || preSwitchCached.EndDate > DateTime.UtcNow)
+                    ? preSwitchCached.Status
+                    : MuteStatus.None;
             }
+            else if (DefaultChatRooms.IsBannedRoom(chatRoom))
+            {
+                // Cache MISS + target is banned — lazy resolve (no-clan full-ban edge case at login).
+                var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
+                if (mute != null && mute.IsActive(DateTime.UtcNow))
+                {
+                    muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
+                    cachedEndDate = mute.endDate;
+                }
+                else
+                {
+                    cachedEndDate = DateTime.MinValue;
+                }
+                // We will cache the resolved result after Remove+Add below.
+                hasCachedEntry = false; // treat as "needs to be written after Remove+Add"
+            }
+            // Cache MISS + exempt room: muteStatus stays None; no DB read needed.
         }
 
         // G1/G2: Full-ban → graceful reject BEFORE any Remove/Add. User stays in their current room.
@@ -206,8 +237,8 @@ public class ChatHub(
 
         _connections.Remove(Context.ConnectionId);
         _connections.Add(Context.ConnectionId, chatRoom, user);
-        // Re-cache the mute status after Remove (which clears it) + Add.
-        _connections.SetMuteStatus(Context.ConnectionId, muteStatus);
+        // Re-cache the mute status + endDate after Remove (which clears it) + Add.
+        _connections.SetMute(Context.ConnectionId, muteStatus, cachedEndDate);
 
         if (oldRoom != null)
         {
@@ -316,7 +347,8 @@ public class ChatHub(
             if (safeRoom != null)
             {
                 _connections.Add(Context.ConnectionId, safeRoom, user);
-                _connections.SetMuteStatus(Context.ConnectionId, MuteStatus.Full);
+                // Cache full-ban status + endDate so SwitchRoom/SendMessage never need a DB read.
+                _connections.SetMute(Context.ConnectionId, MuteStatus.Full, mute.endDate);
                 await Groups.AddToGroupAsync(Context.ConnectionId, safeRoom);
                 var usersOfRoom = _connections.GetUsersOfRoom(safeRoom);
                 await Clients.Group(safeRoom).SendAsync("UserEntered", user);
@@ -326,8 +358,10 @@ public class ChatHub(
             else
             {
                 // No clan: not seated in any room (spec D2).
-                // Note: SetMuteStatus is not called here because the connection is not in the mapping yet.
-                // SwitchRoom enforcement (Task 4) lazily re-resolves the mute from MongoDB for this edge case.
+                // SetMute is NOT called here — the connection is not in the mapping yet.
+                // SwitchRoom/SendMessage enforcement lazily re-resolves from MongoDB for this edge case
+                // (cache MISS path). This is acceptable: full-banned users with no clan have no room,
+                // so any SwitchRoom into a banned room still triggers the lazy resolve and is rejected.
                 // G3: STILL emit a StartChat — an empty-room payload — so legacy clients can initialize.
                 await Clients.Caller.SendAsync("StartChat", new List<ChatUser>(), new List<ChatMessage>(), (string)null, availableRooms);
             }
@@ -336,11 +370,13 @@ public class ChatHub(
         {
             // Shadow ban or no ban: connect as normal (G1 — never abort).
             var muteStatus = isShadowBan ? MuteStatus.Shadow : MuteStatus.None;
+            var muteEndDate = mute?.endDate ?? DateTime.MinValue;
             Log.Information("Accepting connection for {BattleTag}, mute={MuteStatus}, room={Room}",
                 user.BattleTag, muteStatus, memberShip.DefaultChat);
 
             _connections.Add(Context.ConnectionId, memberShip.DefaultChat, user);
-            _connections.SetMuteStatus(Context.ConnectionId, muteStatus);
+            // Cache status + endDate at login so every subsequent send/join works from the cache.
+            _connections.SetMute(Context.ConnectionId, muteStatus, muteEndDate);
             await Groups.AddToGroupAsync(Context.ConnectionId, memberShip.DefaultChat);
             var usersOfRoom = _connections.GetUsersOfRoom(memberShip.DefaultChat);
             await Clients.Group(memberShip.DefaultChat).SendAsync("UserEntered", user);

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -335,6 +335,43 @@ public class ChatHub(
         };
 
         await _muteRepository.AddLoungeMute(loungeMuteRequest);
+
+        // Spec §12: Reconcile any live connections for this user so enforcement is instant.
+        // Parse the endDate once — used for both the cache and the PlayerBannedFromChat payload.
+        var parsedEndDate = DateTime.Parse(endDate, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime();
+        var newStatus = isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
+
+        var liveConnectionIds = _connections.GetConnectionIdsForUser(battleTag);
+        foreach (var connId in liveConnectionIds)
+        {
+            // Update the cache so the next SendMessage/SwitchRoom enforces from the cache (no DB read).
+            _connections.SetMute(connId, newStatus, parsedEndDate);
+
+            if (!isShadowBan)
+            {
+                // Full ban — G5: notify the target so old clients render their legacy ban notice.
+                // Only send when the user is in a banned room (spec §12 / G1/G5 signal).
+                // G1: do NOT call Context.Abort() — the connection must stay alive.
+                var currentRoom = _connections.GetRoom(connId);
+                if (currentRoom != null && DefaultChatRooms.IsBannedRoom(currentRoom))
+                {
+                    var mute = new LoungeMute
+                    {
+                        battleTag = battleTag,
+                        endDate = parsedEndDate,
+                        insertDate = DateTime.UtcNow,
+                        author = adminUser.BattleTag,
+                        reason = reason,
+                        isShadowBan = false
+                    };
+                    // G1: SendAsync only — no Context.Abort().
+                    await Clients.Client(connId).SendAsync("PlayerBannedFromChat", mute);
+                }
+                // Full-ban user in an exempt room: cache is still updated (ban is active for future
+                // joins/sends), but no signal is sent — they can stay in the exempt room per spec §12.
+            }
+            // Shadow ban: no signal to the target whatsoever — preserve the illusion (spec §12).
+        }
     }
 
     internal async Task LoginAsAuthenticated(ChatUser user)

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -142,15 +142,56 @@ public class ChatHub(
         var oldRoom = _connections.GetRoom(Context.ConnectionId);
         var user = _connections.GetUser(Context.ConnectionId);
 
+        // Resolve the cached mute status for this connection.
+        var muteStatus = _connections.GetMuteStatus(Context.ConnectionId);
+
+        // Lazy re-resolve: if cache shows None but target is a banned room, check DB in case
+        // this connection was never cached (e.g. full-banned user with no clan at login).
+        if (muteStatus == MuteStatus.None && user != null && DefaultChatRooms.IsBannedRoom(chatRoom))
+        {
+            var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
+            if (mute != null && mute.IsActive(DateTime.UtcNow))
+            {
+                muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
+                _connections.SetMuteStatus(Context.ConnectionId, muteStatus);
+            }
+        }
+
+        // G1/G2: Full-ban → graceful reject BEFORE any Remove/Add. User stays in their current room.
+        // No Context.Abort(), no throw, no connection teardown.
+        if (DefaultChatRooms.IsBannedRoom(chatRoom) && muteStatus == MuteStatus.Full)
+        {
+            Log.Information("Full-banned user {BattleTag} rejected from joining banned room {Room} — staying in {OldRoom}",
+                user?.BattleTag, chatRoom, oldRoom);
+            return;
+        }
+
+        // Ghost-join flag: shadow-banned user entering a banned room receives messages
+        // but their presence is hidden from others (no UserEntered / UserLeft broadcasts).
+        var ghostJoin = DefaultChatRooms.IsBannedRoom(chatRoom) && muteStatus == MuteStatus.Shadow;
+
         _connections.Remove(Context.ConnectionId);
         _connections.Add(Context.ConnectionId, chatRoom, user);
+        // Re-cache the mute status after Remove (which clears it) + Add.
+        _connections.SetMuteStatus(Context.ConnectionId, muteStatus);
 
-        await Groups.RemoveFromGroupAsync(Context.ConnectionId, oldRoom);
+        if (oldRoom != null)
+        {
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, oldRoom);
+            if (!ghostJoin)
+            {
+                await Clients.Group(oldRoom).SendAsync("UserLeft", user);
+            }
+        }
+
         await Groups.AddToGroupAsync(Context.ConnectionId, chatRoom);
 
         var usersOfRoom = _connections.GetUsersOfRoom(chatRoom);
-        await Clients.Group(oldRoom).SendAsync("UserLeft", user);
-        await Clients.Group(chatRoom).SendAsync("UserEntered", user);
+        if (!ghostJoin)
+        {
+            await Clients.Group(chatRoom).SendAsync("UserEntered", user);
+        }
+        // Caller always receives StartChat (their own view — unfiltered for now; Task 6 adds viewer-aware filtering).
         await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(chatRoom), chatRoom);
 
         var memberShip = await _settingsRepository.Load(user.BattleTag) ?? new ChatSettings(user.BattleTag);

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -271,12 +271,13 @@ public class ChatHub(
 
         await Groups.AddToGroupAsync(Context.ConnectionId, chatRoom);
 
-        var usersOfRoom = _connections.GetUsersOfRoom(chatRoom);
+        var usersOfRoom = _connections.GetUsersOfRoomForViewer(chatRoom, Context.ConnectionId);
         if (!suppressEnter)
         {
             await Clients.Group(chatRoom).SendAsync("UserEntered", user);
         }
-        // Caller always receives StartChat (their own view — unfiltered for now; Task 6 adds viewer-aware filtering).
+        // Caller receives their viewer-filtered user list: they always see themselves;
+        // other shadow-banned users are hidden from them in banned rooms (spec §6).
         await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(chatRoom), chatRoom);
 
         var memberShip = await _settingsRepository.Load(user.BattleTag) ?? new ChatSettings(user.BattleTag);
@@ -370,7 +371,7 @@ public class ChatHub(
                 // Cache full-ban status + endDate so SwitchRoom/SendMessage never need a DB read.
                 _connections.SetMute(Context.ConnectionId, MuteStatus.Full, mute.endDate);
                 await Groups.AddToGroupAsync(Context.ConnectionId, safeRoom);
-                var usersOfRoom = _connections.GetUsersOfRoom(safeRoom);
+                var usersOfRoom = _connections.GetUsersOfRoomForViewer(safeRoom, Context.ConnectionId);
                 await Clients.Group(safeRoom).SendAsync("UserEntered", user);
                 // G3: StartChat with the seated room's payload.
                 await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(safeRoom), safeRoom, availableRooms);
@@ -398,7 +399,7 @@ public class ChatHub(
             // Cache status + endDate at login so every subsequent send/join works from the cache.
             _connections.SetMute(Context.ConnectionId, muteStatus, muteEndDate);
             await Groups.AddToGroupAsync(Context.ConnectionId, memberShip.DefaultChat);
-            var usersOfRoom = _connections.GetUsersOfRoom(memberShip.DefaultChat);
+            var usersOfRoom = _connections.GetUsersOfRoomForViewer(memberShip.DefaultChat, Context.ConnectionId);
             await Clients.Group(memberShip.DefaultChat).SendAsync("UserEntered", user);
             await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(memberShip.DefaultChat), memberShip.DefaultChat, DefaultChatRooms.Rooms);
         }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -153,20 +153,13 @@ public class ChatHub(
         var user = _connections.GetUser(Context.ConnectionId);
         if (user != null)
         {
-            // Capture room and mute status BEFORE Remove (which clears the cache entry).
+            // Capture the room BEFORE Remove. Shadow users are full room members (no presence-hiding),
+            // so UserLeft is unconditional on room membership — only guard against a null room
+            // (a full-ban no-clan user has no room — G3/G2: no crash).
             var chatRoom = _connections.GetRoom(Context.ConnectionId);
-            var muteStatus = _connections.GetEffectiveMuteStatus(Context.ConnectionId, DateTime.UtcNow);
             _connections.Remove(Context.ConnectionId);
 
-            // Guard against null room (full-ban no-clan user has no room — G3/G2: no crash).
-            // Suppress UserLeft for shadow-banned users in public rooms: they were never announced
-            // as present (ghost-join), so broadcasting UserLeft would break the illusion (spec §6).
-            // Shadow users in exempt rooms (clan/lobby) were announced normally — broadcast as usual.
-            var suppressUserLeft = muteStatus == MuteStatus.Shadow
-                && chatRoom != null
-                && DefaultChatRooms.IsPublicRoom(chatRoom);
-
-            if (!suppressUserLeft && chatRoom != null)
+            if (chatRoom != null)
             {
                 await Clients.Group(chatRoom).SendAsync("UserLeft", user);
             }
@@ -207,41 +200,25 @@ public class ChatHub(
             return;
         }
 
-        // Two independent presence gates, each derived from the relevant room:
-        // - suppressLeave: the user was a GHOST in the OLD room (shadow + old room is public),
-        //   so no one ever saw them there — suppress the UserLeft on the room they're leaving.
-        // - suppressEnter: the user ghost-joins the TARGET room (shadow + target is public),
-        //   so suppress the UserEntered on the room they're entering.
-        // Using a single target-based flag for both would leak/strand presence on cross-category
-        // shadow transitions (exempt→public must still broadcast UserLeft; public→exempt must not).
-        var suppressLeave = oldRoom != null && DefaultChatRooms.IsPublicRoom(oldRoom) && muteStatus == MuteStatus.Shadow;
-        var suppressEnter = targetIsPublic && muteStatus == MuteStatus.Shadow;
-
         _connections.Remove(Context.ConnectionId);
         _connections.Add(Context.ConnectionId, chatRoom, user);
         // Re-cache the mute status + endDate after Remove (which clears it) + Add — the cache survives
         // the switch with the same authoritative status it had before.
         _connections.SetMute(Context.ConnectionId, muteStatus, cachedEndDate);
 
+        // Shadow users are full room members — no presence-hiding. UserLeft/UserEntered are
+        // unconditional on room membership; the only remaining shadow effect is the SendMessage drop.
         if (oldRoom != null)
         {
             await Groups.RemoveFromGroupAsync(Context.ConnectionId, oldRoom);
-            if (!suppressLeave)
-            {
-                await Clients.Group(oldRoom).SendAsync("UserLeft", user);
-            }
+            await Clients.Group(oldRoom).SendAsync("UserLeft", user);
         }
 
         await Groups.AddToGroupAsync(Context.ConnectionId, chatRoom);
 
-        var usersOfRoom = _connections.GetUsersOfRoomForViewer(chatRoom, Context.ConnectionId);
-        if (!suppressEnter)
-        {
-            await Clients.Group(chatRoom).SendAsync("UserEntered", user);
-        }
-        // Caller receives their viewer-filtered user list: they always see themselves;
-        // other shadow-banned users are hidden from them in public rooms (spec §6).
-        await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(chatRoom), chatRoom);
+        await Clients.Group(chatRoom).SendAsync("UserEntered", user);
+        // Caller receives the full member list of the room — every member is visible.
+        await Clients.Caller.SendAsync("StartChat", _connections.GetUsersOfRoom(chatRoom), _chatHistory.GetMessages(chatRoom), chatRoom);
 
         var memberShip = await _settingsRepository.Load(user.BattleTag) ?? new ChatSettings(user.BattleTag);
         memberShip.Update(chatRoom);
@@ -360,10 +337,9 @@ public class ChatHub(
             {
                 _connections.Add(Context.ConnectionId, safeRoom, user);
                 await Groups.AddToGroupAsync(Context.ConnectionId, safeRoom);
-                var usersOfRoom = _connections.GetUsersOfRoomForViewer(safeRoom, Context.ConnectionId);
                 await Clients.Group(safeRoom).SendAsync("UserEntered", user);
-                // G3: StartChat with the seated room's payload.
-                await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(safeRoom), safeRoom, availableRooms);
+                // G3: StartChat with the seated room's full member list.
+                await Clients.Caller.SendAsync("StartChat", _connections.GetUsersOfRoom(safeRoom), _chatHistory.GetMessages(safeRoom), safeRoom, availableRooms);
             }
             else
             {
@@ -388,9 +364,8 @@ public class ChatHub(
             // Cache status + endDate at login so every subsequent send/join works from the cache.
             _connections.SetMute(Context.ConnectionId, muteStatus, muteEndDate);
             await Groups.AddToGroupAsync(Context.ConnectionId, memberShip.DefaultChat);
-            var usersOfRoom = _connections.GetUsersOfRoomForViewer(memberShip.DefaultChat, Context.ConnectionId);
             await Clients.Group(memberShip.DefaultChat).SendAsync("UserEntered", user);
-            await Clients.Caller.SendAsync("StartChat", usersOfRoom, _chatHistory.GetMessages(memberShip.DefaultChat), memberShip.DefaultChat, DefaultChatRooms.Rooms);
+            await Clients.Caller.SendAsync("StartChat", _connections.GetUsersOfRoom(memberShip.DefaultChat), _chatHistory.GetMessages(memberShip.DefaultChat), memberShip.DefaultChat, DefaultChatRooms.Rooms);
         }
     }
 

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -166,9 +166,15 @@ public class ChatHub(
             return;
         }
 
-        // Ghost-join flag: shadow-banned user entering a banned room receives messages
-        // but their presence is hidden from others (no UserEntered / UserLeft broadcasts).
-        var ghostJoin = DefaultChatRooms.IsBannedRoom(chatRoom) && muteStatus == MuteStatus.Shadow;
+        // Two independent presence gates, each derived from the relevant room:
+        // - suppressLeave: the user was a GHOST in the OLD room (shadow + old room is banned),
+        //   so no one ever saw them there — suppress the UserLeft on the room they're leaving.
+        // - suppressEnter: the user ghost-joins the TARGET room (shadow + target is banned),
+        //   so suppress the UserEntered on the room they're entering.
+        // Using a single target-based flag for both would leak/strand presence on cross-category
+        // shadow transitions (exempt→banned must still broadcast UserLeft; banned→exempt must not).
+        var suppressLeave = oldRoom != null && DefaultChatRooms.IsBannedRoom(oldRoom) && muteStatus == MuteStatus.Shadow;
+        var suppressEnter = DefaultChatRooms.IsBannedRoom(chatRoom) && muteStatus == MuteStatus.Shadow;
 
         _connections.Remove(Context.ConnectionId);
         _connections.Add(Context.ConnectionId, chatRoom, user);
@@ -178,7 +184,7 @@ public class ChatHub(
         if (oldRoom != null)
         {
             await Groups.RemoveFromGroupAsync(Context.ConnectionId, oldRoom);
-            if (!ghostJoin)
+            if (!suppressLeave)
             {
                 await Clients.Group(oldRoom).SendAsync("UserLeft", user);
             }
@@ -187,7 +193,7 @@ public class ChatHub(
         await Groups.AddToGroupAsync(Context.ConnectionId, chatRoom);
 
         var usersOfRoom = _connections.GetUsersOfRoom(chatRoom);
-        if (!ghostJoin)
+        if (!suppressEnter)
         {
             await Clients.Group(chatRoom).SendAsync("UserEntered", user);
         }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -36,19 +36,28 @@ public class ChatHub(
             var chatRoom = _connections.GetRoom(Context.ConnectionId);
             var user = _connections.GetUser(Context.ConnectionId);
 
+            // R6 (membership-before-send, start): a connected user may be seated in NO room
+            // (e.g. full-banned with no clan). Without a room/user there is nothing to send.
+            // Guard before dereferencing user/chatRoom to avoid an NRE. Task 5 completes room-scoping.
+            if (user == null || chatRoom == null)
+            {
+                return;
+            }
+
             // Check if player is on Lounge Mute list. If yes, handle accordingly.
             var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
-            if (mute != null && DateTime.Compare(mute.endDate, DateTime.UtcNow) <= 0)
+            if (mute != null && !mute.IsActive(DateTime.UtcNow))
             {
                 mute = null;
             }
 
+            // TODO (Task 5): room-scope via DefaultChatRooms.IsBannedRoom + cached GetMuteStatus; currently room-blind.
             if (mute != null && !mute.isShadowBan)
             {
                 // G1: Full ban — silently drop the message (no Context.Abort(), no teardown).
                 // The PlayerBannedFromChat notice was already sent at connect time (LoginAsAuthenticated).
                 Log.Information("Full-banned user {BattleTag} attempted to send message in room {Room} — dropped silently",
-                    user?.BattleTag, chatRoom);
+                    user.BattleTag, chatRoom);
                 return;
             }
             else
@@ -207,7 +216,7 @@ public class ChatHub(
         var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
 
         // Treat expired mutes as no mute
-        if (mute != null && DateTime.Compare(mute.endDate, DateTime.UtcNow) <= 0)
+        if (mute != null && !mute.IsActive(DateTime.UtcNow))
         {
             mute = null;
         }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -15,18 +15,29 @@ namespace W3ChampionsChatService.Chats;
 
 public class ChatHub(
     IChatAuthenticationService authenticationService,
-    MuteRepository muteRepository,
+    IMuteRepository muteRepository,
     SettingsRepository settingsRepository,
     ConnectionMapping connections,
     ChatHistory chatHistory,
+    MuteReconciliationService muteReconciliation,
     IHttpContextAccessor contextAccessor) : Hub
 {
     private readonly IChatAuthenticationService _authenticationService = authenticationService;
-    private readonly MuteRepository _muteRepository = muteRepository;
+    private readonly IMuteRepository _muteRepository = muteRepository;
     private readonly SettingsRepository _settingsRepository = settingsRepository;
     private readonly ConnectionMapping _connections = connections;
     private readonly ChatHistory _chatHistory = chatHistory;
+    private readonly MuteReconciliationService _muteReconciliation = muteReconciliation;
     private readonly IHttpContextAccessor _contextAccessor = contextAccessor;
+
+    // Cap how much of an arbitrary user message is written to logs (the shadow-drop audit line) so a
+    // single huge message can't bloat the logs.
+    private const int MaxLoggedMessageLength = 500;
+
+    private static string TruncateForLog(string message) =>
+        message.Length <= MaxLoggedMessageLength
+            ? message
+            : message[..MaxLoggedMessageLength] + "…[truncated]";
 
     public async Task SendMessage(string message)
     {
@@ -49,10 +60,12 @@ public class ChatHub(
 
         // Mutes only apply in public lounge/ladder rooms; clan/lobby rooms are fully exempt.
         // Read the per-user cached status once + classify the room — ZERO DB reads on the hot path.
-        // The cache is seeded authoritatively at login (every path) and reconciled live by BanUser,
-        // so consulting GetEffectiveMuteStatus alone is sufficient and expiry-aware. ACCEPTED TRADE-OFF:
-        // an out-of-band ban written directly to Mongo (bypassing the BanUser hub) only takes effect on
-        // the user's next (re)connect — we deliberately do NOT re-query the DB per send.
+        // The cache is seeded authoritatively at login (every path) and reconciled live by every ban
+        // WRITE path (the hub's BanUser AND the REST MuteController, via MuteReconciliationService),
+        // so consulting GetEffectiveMuteStatus alone is sufficient and expiry-aware. RESIDUAL TRADE-OFF:
+        // a ban written DIRECTLY to the Mongo collection — bypassing BOTH the hub and the REST controller
+        // (e.g. a manual DB edit or migration) — only takes effect on the user's next (re)connect; we
+        // deliberately do NOT re-query the DB per send.
         var inPublicRoom = DefaultChatRooms.IsPublicRoom(chatRoom);
         var muteStatus = inPublicRoom
             ? _connections.GetEffectiveMuteStatus(Context.ConnectionId, DateTime.UtcNow)
@@ -76,9 +89,9 @@ public class ChatHub(
             if (inPublicRoom && muteStatus == MuteStatus.Shadow)
             {
                 // Drop: echo only to caller (illusion of sending). The message reaches no one else.
-                // Log the dropped attempt (incl. content) so moderators can audit shadow-banned activity.
+                // Log the dropped attempt (incl. content, bounded) so moderators can audit shadow activity.
                 Log.Information("Shadow banned user {BattleTag} attempted to send in public room {Room} — dropped: {Message}",
-                    user.BattleTag, chatRoom, trimmedMessage);
+                    user.BattleTag, chatRoom, TruncateForLog(trimmedMessage));
                 await Clients.Caller.SendAsync("ReceiveMessage", chatMessage);
             }
             else
@@ -176,9 +189,10 @@ public class ChatHub(
         }
 
         // Resolve the per-user cached status once. The cache is seeded at login (every path) and
-        // reconciled live by BanUser, so it is authoritative — consult it ONLY, never the DB.
-        // EffectiveStatus is the single expiry rule (expired ban → None). Capture the cached endDate
-        // so we can re-populate the cache after Remove (which clears it) + Add.
+        // reconciled live by every ban write path (hub + REST controller, via MuteReconciliationService),
+        // so it is authoritative — consult it ONLY, never the DB. EffectiveStatus is the single expiry
+        // rule (expired ban → None). Capture the cached endDate so we can re-populate the cache after
+        // Remove (which clears it) + Add.
         var hasCachedEntry = _connections.TryGetMute(Context.ConnectionId, out var preSwitchCached);
         var cachedEndDate = hasCachedEntry ? preSwitchCached.EndDate : DateTime.MinValue;
         var targetIsPublic = DefaultChatRooms.IsPublicRoom(chatRoom);
@@ -285,16 +299,15 @@ public class ChatHub(
 
         await _muteRepository.AddLoungeMute(loungeMuteRequest);
 
-        // Spec §12: BanUser is the canonical IN-BAND ban path — it persists the ban AND reconciles
-        // every live connection's mute cache so enforcement is instant without a per-send DB read.
-        // (An out-of-band ban written straight to Mongo only takes effect on the user's next reconnect,
-        // when LoginAsAuthenticated re-seeds the cache from the DB — accepted trade-off, see SendMessage.)
-        // Parse the endDate once — used for both the cache and the PlayerBannedFromChat payload.
-        // Use the SAME DateTimeStyles the repository uses (AdjustToUniversal) so the CACHED expiry
-        // can never disagree with the PERSISTED expiry for an offset-less endDate.
-        // Guard a malformed/empty endDate: the ban is already persisted, so on a parse failure
-        // skip the live reconcile gracefully (next reconnect re-seeds the cache from the DB)
-        // rather than throwing a hub exception after the write.
+        // Spec §12: BanUser is one of the two canonical IN-BAND ban paths (the other is the REST
+        // MuteController). Both persist the ban AND reconcile every live connection's mute cache via
+        // MuteReconciliationService, so enforcement is instant without a per-send DB read. Only a ban
+        // written DIRECTLY to the Mongo collection (bypassing both the hub and the REST controller —
+        // e.g. a manual DB edit) takes effect on the target's next reconnect.
+        // Parse the endDate once. Use the SAME DateTimeStyles the repository uses (AdjustToUniversal)
+        // so the CACHED expiry can never disagree with the PERSISTED expiry for an offset-less endDate.
+        // Guard a malformed/empty endDate: the ban is already persisted, so on a parse failure skip the
+        // live reconcile gracefully (next reconnect re-seeds the cache) rather than throwing after the write.
         if (!DateTime.TryParse(endDate, null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsedEndDate))
         {
             Log.Warning("BanUser: could not parse endDate '{EndDate}' for {BattleTag} — ban persisted, skipping live cache reconcile (next reconnect will re-seed the cache)",
@@ -303,32 +316,7 @@ public class ChatHub(
         }
 
         var newStatus = isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
-
-        // Match the DB convention (GetMutedPlayer/AddLoungeMute lowercase the battleTag) by lowercasing
-        // the lookup arg too. GetConnectionIdsForUser also compares case-insensitively, so the instant
-        // reconcile works on a casing mismatch (not just via the safety-net self-heal).
-        var liveConnectionIds = _connections.GetConnectionIdsForUser(battleTag.ToLower());
-        foreach (var connId in liveConnectionIds)
-        {
-            // Update the cache so the next SendMessage/SwitchRoom enforces from the cache (no DB read).
-            _connections.SetMute(connId, newStatus, parsedEndDate);
-
-            if (!isShadowBan)
-            {
-                // Full ban — R7/G5: notify the target REGARDLESS of their current room so they
-                // clearly and persistently know they're banned, independent of channel. A user
-                // full-banned while sitting in a clan/lobby room must still receive the notice
-                // (not just users in a public lounge/ladder room).
-                // G1: SendAsync only — do NOT call Context.Abort(); the connection must stay alive.
-                // §12: no forced eviction — the user keeps their current room membership.
-                // SECURITY: send only the expiry — never leak the moderation reason or the shadow flag
-                // to the client. The event name + the camelCase `endDate` field stay unchanged so old
-                // clients keep reading `.endDate`; the missing reason/isShadowBan deserialize to
-                // null/false on legacy clients (harmless).
-                await Clients.Client(connId).SendAsync("PlayerBannedFromChat", new { endDate = parsedEndDate });
-            }
-            // Shadow ban: no signal to the target whatsoever — preserve the illusion (spec §12).
-        }
+        await _muteReconciliation.ApplyMuteToLiveConnections(battleTag, newStatus, parsedEndDate);
     }
 
     internal async Task LoginAsAuthenticated(ChatUser user)
@@ -376,9 +364,12 @@ public class ChatHub(
             }
             else
             {
-                // No clan: not seated in any room (spec D2). The cache is STILL seeded above
-                // (SetMute keys by connectionId only, independent of room membership), so a later
-                // SwitchRoom into a public room enforces the full ban from the cache — no DB read.
+                // No clan: not seated in any room (spec D2). A SwitchRoom attempt by this connection
+                // is rejected by SwitchRoom's `user == null` early-return (GetUser finds no mapping
+                // entry), NOT by the cache gate. The cache is STILL seeded above as defense-in-depth:
+                // if this connection ever became seated in a public room, SendMessage would enforce
+                // the full ban from the cache (zero DB read). SetMute keys by connectionId only, so
+                // seeding works even with no room membership.
                 // G3: STILL emit a StartChat — an empty-room payload — so legacy clients can initialize.
                 await Clients.Caller.SendAsync("StartChat", new List<ChatUser>(), new List<ChatMessage>(), (string)null, availableRooms);
             }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
+using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Mutes;
 using W3ChampionsChatService.Settings;
 using Serilog;
@@ -242,7 +243,7 @@ public class ChatHub(
         await _settingsRepository.Save(memberShip);
     }
 
-    // Moderation enforced by ChatHubPermissionFilter (the [UserHasPermission] MVC attribute is inert on SignalR).
+    [UserHasPermission(EPermission.Moderation)]
     public async Task DeleteMessage(string messageId)
     {
         var deletedMessage = _chatHistory.DeleteMessage(messageId);
@@ -256,7 +257,7 @@ public class ChatHub(
         }
     }
 
-    // Moderation enforced by ChatHubPermissionFilter (the [UserHasPermission] MVC attribute is inert on SignalR).
+    [UserHasPermission(EPermission.Moderation)]
     public async Task PurgeMessagesFromUser(string battleTag)
     {
         var deletedMessages = _chatHistory.DeleteMessagesFromUser(battleTag);
@@ -275,7 +276,7 @@ public class ChatHub(
         }
     }
 
-    // Moderation enforced by ChatHubPermissionFilter (the [UserHasPermission] MVC attribute is inert on SignalR).
+    [UserHasPermission(EPermission.Moderation)]
     public async Task BanUser(string battleTag, string reason, bool isShadowBan, string endDate)
     {
         var adminUser = _connections.GetUser(Context.ConnectionId);

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -30,6 +30,9 @@ public class ChatHub(
     private readonly MuteReconciliationService _muteReconciliation = muteReconciliation;
     private readonly IHttpContextAccessor _contextAccessor = contextAccessor;
 
+    // Maximum accepted chat message length (after trim). Longer messages are rejected gracefully.
+    private const int MaxMessageLength = 1024;
+
     // Cap how much of an arbitrary user message is written to logs (the shadow-drop audit line) so a
     // single huge message can't bloat the logs.
     private const int MaxLoggedMessageLength = 500;
@@ -50,11 +53,26 @@ public class ChatHub(
         var chatRoom = _connections.GetRoom(Context.ConnectionId);
         var user = _connections.GetUser(Context.ConnectionId);
 
-        // R6: Membership prerequisite — user must be a member of a valid room.
-        // G1/G2: graceful reject — return, never Context.Abort(), never throw.
-        if (chatRoom == null || user == null)
+        // R6: Membership prerequisite. G1/G2: graceful reject — return, never Context.Abort(), never throw.
+        // Split so the log carries the battletag whenever we have a user (an unauthenticated connection
+        // has none — log the ConnectionId only).
+        if (user == null)
         {
-            Log.Warning("SendMessage rejected: connection {ConnectionId} has no room membership", Context.ConnectionId);
+            Log.Warning("SendMessage rejected: unauthenticated connection {ConnectionId}", Context.ConnectionId);
+            return;
+        }
+        if (chatRoom == null)
+        {
+            Log.Warning("SendMessage rejected: authenticated user {BattleTag} has no room membership (connection {ConnectionId})",
+                user.BattleTag, Context.ConnectionId);
+            return;
+        }
+
+        // Reject over-length messages gracefully (user is non-null here so the log carries the battletag).
+        if (trimmedMessage.Length > MaxMessageLength)
+        {
+            Log.Warning("SendMessage rejected: message from {BattleTag} exceeds {MaxLength} characters ({ActualLength})",
+                user.BattleTag, MaxMessageLength, trimmedMessage.Length);
             return;
         }
 

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.SignalR;
 using W3ChampionsChatService.Mutes;
 using W3ChampionsChatService.Settings;
 using Serilog;
-using W3ChampionsChatService.Authentication;
 
 [assembly: InternalsVisibleTo("W3ChampionsChatService.Tests")]
 namespace W3ChampionsChatService.Chats;
@@ -243,7 +242,7 @@ public class ChatHub(
         await _settingsRepository.Save(memberShip);
     }
 
-    [UserHasPermission(EPermission.Moderation)]
+    // Moderation enforced by ChatHubPermissionFilter (the [UserHasPermission] MVC attribute is inert on SignalR).
     public async Task DeleteMessage(string messageId)
     {
         var deletedMessage = _chatHistory.DeleteMessage(messageId);
@@ -257,7 +256,7 @@ public class ChatHub(
         }
     }
 
-    [UserHasPermission(EPermission.Moderation)]
+    // Moderation enforced by ChatHubPermissionFilter (the [UserHasPermission] MVC attribute is inert on SignalR).
     public async Task PurgeMessagesFromUser(string battleTag)
     {
         var deletedMessages = _chatHistory.DeleteMessagesFromUser(battleTag);
@@ -276,7 +275,7 @@ public class ChatHub(
         }
     }
 
-    [UserHasPermission(EPermission.Moderation)]
+    // Moderation enforced by ChatHubPermissionFilter (the [UserHasPermission] MVC attribute is inert on SignalR).
     public async Task BanUser(string battleTag, string reason, bool isShadowBan, string endDate)
     {
         var adminUser = _connections.GetUser(Context.ConnectionId);

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -292,26 +292,12 @@ public class ChatHub(
             reason = reason
         };
 
-        await _muteRepository.AddLoungeMute(loungeMuteRequest);
-
         // Spec §12: BanUser is one of the two canonical IN-BAND ban paths (the other is the REST
-        // MuteController). Both persist the ban AND reconcile every live connection's mute cache via
-        // MuteReconciliationService, so enforcement is instant without a per-send DB read. Only a ban
-        // written DIRECTLY to the Mongo collection (bypassing both the hub and the REST controller —
+        // MuteController). Both delegate to MuteReconciliationService.ApplyBanAsync, which persists the
+        // ban AND reconciles every live connection's mute cache, so enforcement is instant without a
+        // per-send DB read. Only a ban written DIRECTLY to the Mongo collection (bypassing both paths —
         // e.g. a manual DB edit) takes effect on the target's next reconnect.
-        // Parse the endDate once. Use the SAME DateTimeStyles the repository uses (AdjustToUniversal)
-        // so the CACHED expiry can never disagree with the PERSISTED expiry for an offset-less endDate.
-        // Guard a malformed/empty endDate: the ban is already persisted, so on a parse failure skip the
-        // live reconcile gracefully (next reconnect re-seeds the cache) rather than throwing after the write.
-        if (!DateTime.TryParse(endDate, null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsedEndDate))
-        {
-            Log.Warning("BanUser: could not parse endDate '{EndDate}' for {BattleTag} — ban persisted, skipping live cache reconcile (next reconnect will re-seed the cache)",
-                endDate, battleTag);
-            return;
-        }
-
-        var newStatus = isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
-        await _muteReconciliation.ApplyMuteToLiveConnections(battleTag, newStatus, parsedEndDate);
+        await _muteReconciliation.ApplyBanAsync(loungeMuteRequest);
     }
 
     internal async Task LoginAsAuthenticated(ChatUser user)

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -170,9 +170,23 @@ public class ChatHub(
         var user = _connections.GetUser(Context.ConnectionId);
         if (user != null)
         {
+            // Capture room and mute status BEFORE Remove (which clears the cache entry).
             var chatRoom = _connections.GetRoom(Context.ConnectionId);
+            var muteStatus = _connections.GetEffectiveMuteStatus(Context.ConnectionId, DateTime.UtcNow);
             _connections.Remove(Context.ConnectionId);
-            await Clients.Group(chatRoom).SendAsync("UserLeft", user);
+
+            // Guard against null room (full-ban no-clan user has no room — G3/G2: no crash).
+            // Suppress UserLeft for shadow-banned users in banned rooms: they were never announced
+            // as present (ghost-join), so broadcasting UserLeft would break the illusion (spec §6).
+            // Shadow users in exempt rooms (clan/lobby) were announced normally — broadcast as usual.
+            var suppressUserLeft = muteStatus == MuteStatus.Shadow
+                && chatRoom != null
+                && DefaultChatRooms.IsBannedRoom(chatRoom);
+
+            if (!suppressUserLeft && chatRoom != null)
+            {
+                await Clients.Group(chatRoom).SendAsync("UserLeft", user);
+            }
         }
 
         await base.OnDisconnectedAsync(exception);

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -58,7 +58,8 @@ public class ChatHub(
             {
                 // Cache HIT with an active ban — honor cached status + expiry. ZERO DB reads.
                 // This is the primary §7 win: a cached-banned user does NOT hit the DB on every send.
-                muteStatus = cached.EndDate > DateTime.UtcNow ? cached.Status : MuteStatus.None;
+                // EffectiveStatus is the single expiry rule (expired ban → None).
+                muteStatus = cached.EffectiveStatus(DateTime.UtcNow);
 
                 if (muteStatus == MuteStatus.None)
                 {
@@ -215,9 +216,8 @@ public class ChatHub(
                 if (hasCachedEntry && preSwitchCached.Status != MuteStatus.None)
                 {
                     // Fast path: cached active ban — honor cached status + expiry, no DB read.
-                    muteStatus = preSwitchCached.EndDate > DateTime.UtcNow
-                        ? preSwitchCached.Status
-                        : MuteStatus.None;
+                    // EffectiveStatus is the single expiry rule (expired ban → None).
+                    muteStatus = preSwitchCached.EffectiveStatus(DateTime.UtcNow);
                     cachedEndDate = preSwitchCached.EndDate;
                 }
                 else
@@ -239,9 +239,8 @@ public class ChatHub(
             else if (hasCachedEntry)
             {
                 // Exempt target — cache HIT drives the shadow presence gates below; no DB read.
-                muteStatus = (preSwitchCached.Status == MuteStatus.None || preSwitchCached.EndDate > DateTime.UtcNow)
-                    ? preSwitchCached.Status
-                    : MuteStatus.None;
+                // EffectiveStatus is the single expiry rule (expired ban → None).
+                muteStatus = preSwitchCached.EffectiveStatus(DateTime.UtcNow);
             }
             // Exempt target + cache MISS: muteStatus stays None; no DB read needed.
         }
@@ -352,10 +351,24 @@ public class ChatHub(
 
         // Spec §12: Reconcile any live connections for this user so enforcement is instant.
         // Parse the endDate once — used for both the cache and the PlayerBannedFromChat payload.
-        var parsedEndDate = DateTime.Parse(endDate, null, System.Globalization.DateTimeStyles.RoundtripKind).ToUniversalTime();
+        // Use the SAME DateTimeStyles the repository uses (AdjustToUniversal) so the CACHED expiry
+        // can never disagree with the PERSISTED expiry for an offset-less endDate.
+        // Guard a malformed/empty endDate: the ban is already persisted, so on a parse failure
+        // skip the live reconcile gracefully (the safety-net re-resolve enforces on next send/join)
+        // rather than throwing a hub exception after the write.
+        if (!DateTime.TryParse(endDate, null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsedEndDate))
+        {
+            Log.Warning("BanUser: could not parse endDate '{EndDate}' for {BattleTag} — ban persisted, skipping live cache reconcile (safety-net re-resolve will enforce)",
+                endDate, battleTag);
+            return;
+        }
+
         var newStatus = isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
 
-        var liveConnectionIds = _connections.GetConnectionIdsForUser(battleTag);
+        // Match the DB convention (GetMutedPlayer/AddLoungeMute lowercase the battleTag) by lowercasing
+        // the lookup arg too. GetConnectionIdsForUser also compares case-insensitively, so the instant
+        // reconcile works on a casing mismatch (not just via the safety-net self-heal).
+        var liveConnectionIds = _connections.GetConnectionIdsForUser(battleTag.ToLower());
         foreach (var connId in liveConnectionIds)
         {
             // Update the cache so the next SendMessage/SwitchRoom enforces from the cache (no DB read).

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -349,6 +349,9 @@ public class ChatHub(
             // Seed the per-connection mute cache authoritatively for BOTH branches so the send/switch
             // hot paths enforce from the cache alone (zero DB reads), even on the no-clan/no-room edge.
             _connections.SetMute(Context.ConnectionId, MuteStatus.Full, mute.endDate);
+            // Register the connection→user mapping so GetUser is authoritative even when the user is
+            // seated in no room (no-clan branch below). The clan branch's Add also registers.
+            _connections.RegisterUser(Context.ConnectionId, user);
 
             // Seat in clan room if available, else no room (spec D2 — empty state).
             var safeRoom = string.IsNullOrWhiteSpace(user.ClanTag) ? null : $"clan {user.ClanTag}";
@@ -364,12 +367,11 @@ public class ChatHub(
             }
             else
             {
-                // No clan: not seated in any room (spec D2). A SwitchRoom attempt by this connection
-                // is rejected by SwitchRoom's `user == null` early-return (GetUser finds no mapping
-                // entry), NOT by the cache gate. The cache is STILL seeded above as defense-in-depth:
-                // if this connection ever became seated in a public room, SendMessage would enforce
-                // the full ban from the cache (zero DB read). SetMute keys by connectionId only, so
-                // seeding works even with no room membership.
+                // No clan: not seated in any room (spec D2), but the connection→user mapping IS
+                // registered above, so GetUser is non-null. A later SwitchRoom into a public room is
+                // rejected by the Full→public cache gate (not by a user==null guard); a switch into an
+                // exempt clan/lobby room is allowed. The mute cache (seeded above) enforces the full ban
+                // from the cache on any subsequent send (zero DB read).
                 // G3: STILL emit a StartChat — an empty-room payload — so legacy clients can initialize.
                 await Clients.Caller.SendAsync("StartChat", new List<ChatUser>(), new List<ChatMessage>(), (string)null, availableRooms);
             }
@@ -395,6 +397,9 @@ public class ChatHub(
     public async Task UpdateUserProfilePicture(string chatRoom, ProfilePicture profilePicture)
     {
         var user = _connections.GetUser(Context.ConnectionId);
+        // Graceful guard: an unauthenticated/unregistered connection has no user — return without
+        // dereferencing (prevents a latent NRE). No Context.Abort.
+        if (user == null) return;
         user.ProfilePicture = profilePicture;
         await Clients.Group(chatRoom).SendAsync("UserUpdated", user);
     }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -187,41 +187,60 @@ public class ChatHub(
         // Capture the full cached entry BEFORE Remove so we can re-populate it afterwards.
         var hasCachedEntry = _connections.TryGetMute(Context.ConnectionId, out var preSwitchCached);
         var cachedEndDate = hasCachedEntry ? preSwitchCached.EndDate : DateTime.MinValue;
+        var targetIsBanned = DefaultChatRooms.IsBannedRoom(chatRoom);
 
         if (user != null)
         {
-            if (hasCachedEntry)
+            if (targetIsBanned)
             {
-                // Cache HIT — use the cached status with expiry; no DB read needed for any room.
+                // SECURITY: for a BANNED target, only trust the cache on a HIT with a real ban
+                // (Status != None). A cache MISS *or* a HIT-None must lazy-resolve from the DB —
+                // otherwise a no-clan full-banned user who first switched into an exempt room
+                // (which writes a cache-None) would bypass the ban on a later switch into a
+                // banned room. This mirrors SendMessage's HIT-None re-resolve path.
+                if (hasCachedEntry && preSwitchCached.Status != MuteStatus.None)
+                {
+                    // Fast path: cached active ban — honor cached status + expiry, no DB read.
+                    muteStatus = preSwitchCached.EndDate > DateTime.UtcNow
+                        ? preSwitchCached.Status
+                        : MuteStatus.None;
+                    cachedEndDate = preSwitchCached.EndDate;
+                }
+                else
+                {
+                    // Cache MISS or HIT-None — lazy-resolve the mute for the banned target.
+                    var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
+                    if (mute != null && mute.IsActive(DateTime.UtcNow))
+                    {
+                        muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
+                        cachedEndDate = mute.endDate;
+                    }
+                    else
+                    {
+                        muteStatus = MuteStatus.None;
+                        cachedEndDate = DateTime.MinValue;
+                    }
+                }
+            }
+            else if (hasCachedEntry)
+            {
+                // Exempt target — cache HIT drives the shadow presence gates below; no DB read.
                 muteStatus = (preSwitchCached.Status == MuteStatus.None || preSwitchCached.EndDate > DateTime.UtcNow)
                     ? preSwitchCached.Status
                     : MuteStatus.None;
             }
-            else if (DefaultChatRooms.IsBannedRoom(chatRoom))
-            {
-                // Cache MISS + target is banned — lazy resolve (no-clan full-ban edge case at login).
-                var mute = await _muteRepository.GetMutedPlayer(user.BattleTag);
-                if (mute != null && mute.IsActive(DateTime.UtcNow))
-                {
-                    muteStatus = mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
-                    cachedEndDate = mute.endDate;
-                }
-                else
-                {
-                    cachedEndDate = DateTime.MinValue;
-                }
-                // We will cache the resolved result after Remove+Add below.
-                hasCachedEntry = false; // treat as "needs to be written after Remove+Add"
-            }
-            // Cache MISS + exempt room: muteStatus stays None; no DB read needed.
+            // Exempt target + cache MISS: muteStatus stays None; no DB read needed.
         }
 
         // G1/G2: Full-ban → graceful reject BEFORE any Remove/Add. User stays in their current room.
         // No Context.Abort(), no throw, no connection teardown.
-        if (DefaultChatRooms.IsBannedRoom(chatRoom) && muteStatus == MuteStatus.Full)
+        if (targetIsBanned && muteStatus == MuteStatus.Full)
         {
+            // S3: cache the resolved full ban before returning so subsequent SwitchRoom/SendMessage
+            // enforce from the cache instead of re-reading the DB.
+            _connections.SetMute(Context.ConnectionId, MuteStatus.Full, cachedEndDate);
             Log.Information("Full-banned user {BattleTag} rejected from joining banned room {Room} — staying in {OldRoom}",
-                user?.BattleTag, chatRoom, oldRoom);
+                user.BattleTag, chatRoom, oldRoom);
             return;
         }
 
@@ -233,11 +252,12 @@ public class ChatHub(
         // Using a single target-based flag for both would leak/strand presence on cross-category
         // shadow transitions (exempt→banned must still broadcast UserLeft; banned→exempt must not).
         var suppressLeave = oldRoom != null && DefaultChatRooms.IsBannedRoom(oldRoom) && muteStatus == MuteStatus.Shadow;
-        var suppressEnter = DefaultChatRooms.IsBannedRoom(chatRoom) && muteStatus == MuteStatus.Shadow;
+        var suppressEnter = targetIsBanned && muteStatus == MuteStatus.Shadow;
 
         _connections.Remove(Context.ConnectionId);
         _connections.Add(Context.ConnectionId, chatRoom, user);
         // Re-cache the mute status + endDate after Remove (which clears it) + Add.
+        // S3: this also caches a freshly lazy-resolved shadow ban on the ghost-join path.
         _connections.SetMute(Context.ConnectionId, muteStatus, cachedEndDate);
 
         if (oldRoom != null)

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -15,7 +15,18 @@ public enum MuteStatus
 /// Per-connection mute state cached at login. Carries both the resolved status and
 /// the expiry so the hub can enforce expiry from the cache alone — no per-message DB read.
 /// </summary>
-public readonly record struct CachedMute(MuteStatus Status, DateTime EndDate);
+public readonly record struct CachedMute(MuteStatus Status, DateTime EndDate)
+{
+    /// <summary>
+    /// The single source of truth for the cache-expiry rule (this is a SECURITY rule —
+    /// it gates ban enforcement, so it must never be re-derived in divergent copies).
+    /// <c>None</c> never expires (an unbanned connection stays unbanned); any other status
+    /// is effective only while <see cref="EndDate"/> is still in the future. Once the ban
+    /// has expired it returns <c>None</c>.
+    /// </summary>
+    public MuteStatus EffectiveStatus(DateTime now) =>
+        (Status == MuteStatus.None || EndDate > now) ? Status : MuteStatus.None;
+}
 
 public class ConnectionMapping
 {
@@ -98,7 +109,10 @@ public class ConnectionMapping
             {
                 foreach (var connection in chatRoomConnections)
                 {
-                    if (connection.Value.BattleTag == battleTag)
+                    // Case-insensitive match: the DB lowercases battleTags (see MuteRepository),
+                    // while connection-stored tags keep their original casing — so an exact (==)
+                    // compare would silently miss a casing mismatch (e.g. live-ban reconcile).
+                    if (string.Equals(connection.Value.BattleTag, battleTag, StringComparison.OrdinalIgnoreCase))
                     {
                         connectionIds.Add(connection.Key);
                     }
@@ -142,9 +156,10 @@ public class ConnectionMapping
     /// first to decide whether a lazy resolve is needed.
     /// </summary>
     /// <remarks>
-    /// The expiry rule lives in a single place: <see cref="GetEffectiveMuteStatusNoLock"/>.
-    /// This method just acquires the lock and delegates. <see cref="GetUsersOfRoomForViewer"/>
-    /// calls the no-lock helper directly because it already holds <c>lock(_connections)</c>.
+    /// The expiry rule itself lives on <see cref="CachedMute.EffectiveStatus"/> (single source).
+    /// This method just acquires the lock and delegates to <see cref="GetEffectiveMuteStatusNoLock"/>.
+    /// <see cref="GetUsersOfRoomForViewer"/> calls the no-lock helper directly because it already
+    /// holds <c>lock(_connections)</c>.
     /// </remarks>
     public MuteStatus GetEffectiveMuteStatus(string connectionId, DateTime now)
     {
@@ -155,21 +170,16 @@ public class ConnectionMapping
     }
 
     /// <summary>
-    /// Single source of truth for the cache expiry rule. The caller MUST already hold
-    /// <c>lock(_connections)</c>. A cache MISS returns <c>None</c>; a HIT returns its status
-    /// while still effective (<c>None</c> never expires; other statuses expire once
-    /// <c>EndDate</c> has passed).
+    /// Resolves the effective mute status from the cache. The caller MUST already hold
+    /// <c>lock(_connections)</c>. A cache MISS returns <c>None</c>; a HIT delegates to
+    /// <see cref="CachedMute.EffectiveStatus"/> (the single expiry rule).
     /// </summary>
     private MuteStatus GetEffectiveMuteStatusNoLock(string connectionId, DateTime now)
     {
-        if (!_mutes.TryGetValue(connectionId, out var cached))
-            return MuteStatus.None;
-
-        // None is always effective (unbanned); other statuses expire when EndDate passes.
-        if (cached.Status == MuteStatus.None || cached.EndDate > now)
-            return cached.Status;
-
-        return MuteStatus.None;
+        // Cache MISS → None; otherwise the single expiry rule lives on CachedMute.EffectiveStatus.
+        return _mutes.TryGetValue(connectionId, out var cached)
+            ? cached.EffectiveStatus(now)
+            : MuteStatus.None;
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -141,6 +141,13 @@ public class ConnectionMapping
     /// <c>MuteStatus.None</c>. Does NOT trigger a DB read — call <see cref="TryGetMute"/>
     /// first to decide whether a lazy resolve is needed.
     /// </summary>
+    /// <remarks>
+    /// <see cref="GetUsersOfRoomForViewer"/> intentionally inlines this same expiry logic
+    /// rather than calling this method. C#'s <c>lock</c> is reentrant so calling here while
+    /// already holding <c>lock(_connections)</c> would not deadlock, but inlining keeps the
+    /// single-lock discipline explicit while iterating the room. Keep the inlined copy in
+    /// <see cref="GetUsersOfRoomForViewer"/> in sync with the expiry rule below.
+    /// </remarks>
     public MuteStatus GetEffectiveMuteStatus(string connectionId, DateTime now)
     {
         lock (_connections)

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -39,6 +39,13 @@ public class ConnectionMapping
     private readonly Dictionary<string, CachedMute> _mutes =
         new Dictionary<string, CachedMute>();
 
+    // Per-connection user, keyed by connectionId. This is the AUTHORITATIVE record of which
+    // ChatUser owns a connection — independent of room membership — so GetUser is non-null even
+    // for a connection seated in no room (e.g. a no-clan full-banned user). Guarded by the same
+    // lock (_connections) as the other maps.
+    private readonly Dictionary<string, ChatUser> _users =
+        new Dictionary<string, ChatUser>();
+
     public List<ChatUser> GetUsersOfRoom(string chatRoom)
     {
         lock (_connections)
@@ -64,6 +71,22 @@ public class ConnectionMapping
                     chatUsers.Add(connectionId, user);
                 }
             }
+            // Add is the room-seated path; it also registers the connection→user mapping so a single
+            // call covers both. (No-room seats use RegisterUser instead.)
+            _users[connectionId] = user;
+        }
+    }
+
+    /// <summary>
+    /// Registers a connection→user mapping WITHOUT seating the connection in any room. For no-room
+    /// seats only (e.g. a no-clan full-banned user); room-seated callers use <see cref="Add"/>, which
+    /// also registers. This keeps <see cref="GetUser"/> authoritative for every authenticated connection.
+    /// </summary>
+    public void RegisterUser(string connectionId, ChatUser user)
+    {
+        lock (_connections)
+        {
+            _users[connectionId] = user;
         }
     }
 
@@ -71,8 +94,8 @@ public class ConnectionMapping
     {
         lock (_connections)
         {
-            var connection = _connections.Values.SingleOrDefault(r => r.ContainsKey(connectionId));
-            return connection?[connectionId];
+            // Authoritative O(1) lookup; non-null for both room-seated and no-room connections.
+            return _users.TryGetValue(connectionId, out var user) ? user : null;
         }
     }
 
@@ -83,6 +106,7 @@ public class ConnectionMapping
             var connection = _connections.Values.SingleOrDefault(r => r.ContainsKey(connectionId));
             connection?.Remove(connectionId);
             _mutes.Remove(connectionId);
+            _users.Remove(connectionId);
         }
     }
 
@@ -104,21 +128,15 @@ public class ConnectionMapping
     {
         lock (_connections)
         {
-            var connectionIds = new List<string>();
-            foreach (var chatRoomConnections in _connections.Values)
-            {
-                foreach (var connection in chatRoomConnections)
-                {
-                    // Case-insensitive match: the DB lowercases battleTags (see MuteRepository),
-                    // while connection-stored tags keep their original casing — so an exact (==)
-                    // compare would silently miss a casing mismatch (e.g. live-ban reconcile).
-                    if (string.Equals(connection.Value.BattleTag, battleTag, StringComparison.OrdinalIgnoreCase))
-                    {
-                        connectionIds.Add(connection.Key);
-                    }
-                }
-            }
-            return connectionIds;
+            // Scan _users (the single source of truth for connection→user), so a no-room seat
+            // (e.g. a no-clan full-banned user) is reconcilable — room buckets would miss it.
+            // Case-insensitive match: the DB lowercases battleTags (see MuteRepository), while
+            // connection-stored tags keep their original casing — so an exact (==) compare would
+            // silently miss a casing mismatch (e.g. live-ban reconcile).
+            return _users
+                .Where(kvp => string.Equals(kvp.Value.BattleTag, battleTag, StringComparison.OrdinalIgnoreCase))
+                .Select(kvp => kvp.Key)
+                .ToList();
         }
     }
 

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -123,9 +123,10 @@ public class ConnectionMapping
     }
 
     /// <summary>
-    /// Cache the mute status and expiry for a connection.
+    /// Cache the mute status and expiry for a connection. Seeded authoritatively at login for
+    /// every login path, so after login the cache always reflects the user's true status.
     /// Pass <c>status = MuteStatus.None</c> and <c>endDate = DateTime.MinValue</c> for an
-    /// explicitly-resolved unbanned connection (distinguishes a cache HIT-None from a MISS).
+    /// unbanned connection.
     /// </summary>
     public void SetMute(string connectionId, MuteStatus status, DateTime endDate)
     {
@@ -138,8 +139,9 @@ public class ConnectionMapping
     /// <summary>
     /// Returns true if a cache entry exists for the connection (regardless of status),
     /// and writes it to <paramref name="cached"/>. Returns false on a cache MISS.
-    /// Use this to distinguish "cached None" from "never resolved" — only a MISS triggers
-    /// a lazy DB re-resolve.
+    /// Since the cache is seeded at login for every path, a MISS only happens for a
+    /// connection that is not (yet) logged in; the send/switch hot paths consult
+    /// <see cref="GetEffectiveMuteStatus"/> instead and never re-query the DB.
     /// </summary>
     public bool TryGetMute(string connectionId, out CachedMute cached)
     {
@@ -184,7 +186,7 @@ public class ConnectionMapping
 
     /// <summary>
     /// Returns the users of <paramref name="chatRoom"/> as seen by <paramref name="viewerConnectionId"/>.
-    /// In banned rooms (see <see cref="DefaultChatRooms.IsBannedRoom"/>), shadow-banned users whose ban
+    /// In public rooms (see <see cref="DefaultChatRooms.IsPublicRoom"/>), shadow-banned users whose ban
     /// has not yet expired are hidden from all viewers except themselves (a shadow user always sees themselves).
     /// In exempt rooms (clan, lobby) the filter is a no-op — all users are visible.
     /// Uses per-connection cached expiry so the check is EXPIRY-AWARE without a DB read.
@@ -197,7 +199,7 @@ public class ConnectionMapping
             if (!_connections.TryGetValue(chatRoom, out var roomConnections))
                 return [];
 
-            var isBannedRoom = DefaultChatRooms.IsBannedRoom(chatRoom);
+            var isPublicRoom = DefaultChatRooms.IsPublicRoom(chatRoom);
             var now = DateTime.UtcNow;
 
             return roomConnections
@@ -206,10 +208,10 @@ public class ConnectionMapping
                     // Always include the viewer themselves — shadow users see themselves.
                     if (kvp.Key == viewerConnectionId) return true;
 
-                    // In banned rooms, exclude users whose effective mute status is Shadow.
+                    // In public rooms, exclude users whose effective mute status is Shadow.
                     // GetEffectiveMuteStatusNoLock is expiry-aware: an expired shadow ban returns None.
                     // We already hold lock(_connections), so call the no-lock helper directly.
-                    if (isBannedRoom && GetEffectiveMuteStatusNoLock(kvp.Key, now) == MuteStatus.Shadow)
+                    if (isPublicRoom && GetEffectiveMuteStatusNoLock(kvp.Key, now) == MuteStatus.Shadow)
                         return false;
 
                     return true;

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -155,4 +155,46 @@ public class ConnectionMapping
             return MuteStatus.None;
         }
     }
+
+    /// <summary>
+    /// Returns the users of <paramref name="chatRoom"/> as seen by <paramref name="viewerConnectionId"/>.
+    /// In banned rooms (see <see cref="DefaultChatRooms.IsBannedRoom"/>), shadow-banned users whose ban
+    /// has not yet expired are hidden from all viewers except themselves (a shadow user always sees themselves).
+    /// In exempt rooms (clan, lobby) the filter is a no-op — all users are visible.
+    /// Uses per-connection cached expiry so the check is EXPIRY-AWARE without a DB read.
+    /// All access is under the single <c>_connections</c> lock for consistency.
+    /// </summary>
+    public List<ChatUser> GetUsersOfRoomForViewer(string chatRoom, string viewerConnectionId)
+    {
+        lock (_connections)
+        {
+            if (!_connections.TryGetValue(chatRoom, out var roomConnections))
+                return [];
+
+            var isBannedRoom = DefaultChatRooms.IsBannedRoom(chatRoom);
+            var now = DateTime.UtcNow;
+
+            return roomConnections
+                .Where(kvp =>
+                {
+                    // Always include the viewer themselves — shadow users see themselves.
+                    if (kvp.Key == viewerConnectionId) return true;
+
+                    // In banned rooms, exclude users whose effective mute status is Shadow.
+                    // GetEffectiveMuteStatus is expiry-aware: an expired shadow ban returns None.
+                    if (isBannedRoom && _mutes.TryGetValue(kvp.Key, out var cached))
+                    {
+                        var effectiveStatus = (cached.Status == MuteStatus.None || cached.EndDate > now)
+                            ? cached.Status
+                            : MuteStatus.None;
+                        if (effectiveStatus == MuteStatus.Shadow) return false;
+                    }
+
+                    return true;
+                })
+                .Select(kvp => kvp.Value)
+                .OrderBy(u => u.BattleTag)
+                .ToList();
+        }
+    }
 }

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -142,25 +142,34 @@ public class ConnectionMapping
     /// first to decide whether a lazy resolve is needed.
     /// </summary>
     /// <remarks>
-    /// <see cref="GetUsersOfRoomForViewer"/> intentionally inlines this same expiry logic
-    /// rather than calling this method. C#'s <c>lock</c> is reentrant so calling here while
-    /// already holding <c>lock(_connections)</c> would not deadlock, but inlining keeps the
-    /// single-lock discipline explicit while iterating the room. Keep the inlined copy in
-    /// <see cref="GetUsersOfRoomForViewer"/> in sync with the expiry rule below.
+    /// The expiry rule lives in a single place: <see cref="GetEffectiveMuteStatusNoLock"/>.
+    /// This method just acquires the lock and delegates. <see cref="GetUsersOfRoomForViewer"/>
+    /// calls the no-lock helper directly because it already holds <c>lock(_connections)</c>.
     /// </remarks>
     public MuteStatus GetEffectiveMuteStatus(string connectionId, DateTime now)
     {
         lock (_connections)
         {
-            if (!_mutes.TryGetValue(connectionId, out var cached))
-                return MuteStatus.None;
-
-            // None is always effective (unbanned); other statuses expire when EndDate passes.
-            if (cached.Status == MuteStatus.None || cached.EndDate > now)
-                return cached.Status;
-
-            return MuteStatus.None;
+            return GetEffectiveMuteStatusNoLock(connectionId, now);
         }
+    }
+
+    /// <summary>
+    /// Single source of truth for the cache expiry rule. The caller MUST already hold
+    /// <c>lock(_connections)</c>. A cache MISS returns <c>None</c>; a HIT returns its status
+    /// while still effective (<c>None</c> never expires; other statuses expire once
+    /// <c>EndDate</c> has passed).
+    /// </summary>
+    private MuteStatus GetEffectiveMuteStatusNoLock(string connectionId, DateTime now)
+    {
+        if (!_mutes.TryGetValue(connectionId, out var cached))
+            return MuteStatus.None;
+
+        // None is always effective (unbanned); other statuses expire when EndDate passes.
+        if (cached.Status == MuteStatus.None || cached.EndDate > now)
+            return cached.Status;
+
+        return MuteStatus.None;
     }
 
     /// <summary>
@@ -188,14 +197,10 @@ public class ConnectionMapping
                     if (kvp.Key == viewerConnectionId) return true;
 
                     // In banned rooms, exclude users whose effective mute status is Shadow.
-                    // GetEffectiveMuteStatus is expiry-aware: an expired shadow ban returns None.
-                    if (isBannedRoom && _mutes.TryGetValue(kvp.Key, out var cached))
-                    {
-                        var effectiveStatus = (cached.Status == MuteStatus.None || cached.EndDate > now)
-                            ? cached.Status
-                            : MuteStatus.None;
-                        if (effectiveStatus == MuteStatus.Shadow) return false;
-                    }
+                    // GetEffectiveMuteStatusNoLock is expiry-aware: an expired shadow ban returns None.
+                    // We already hold lock(_connections), so call the no-lock helper directly.
+                    if (isBannedRoom && GetEffectiveMuteStatusNoLock(kvp.Key, now) == MuteStatus.Shadow)
+                        return false;
 
                     return true;
                 })

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,16 +11,22 @@ public enum MuteStatus
     Full
 }
 
+/// <summary>
+/// Per-connection mute state cached at login. Carries both the resolved status and
+/// the expiry so the hub can enforce expiry from the cache alone — no per-message DB read.
+/// </summary>
+public readonly record struct CachedMute(MuteStatus Status, DateTime EndDate);
+
 public class ConnectionMapping
 {
     private readonly Dictionary<string, Dictionary<string, ChatUser>> _connections =
         new Dictionary<string, Dictionary<string, ChatUser>>();
 
-    // Per-connection mute status cache. Keyed by connectionId.
+    // Per-connection mute cache. Keyed by connectionId.
     // Guarded by the same lock (_connections) as the connection map so reads/writes
     // of both dictionaries stay atomic and consistent (no TOCTOU on Remove).
-    private readonly Dictionary<string, MuteStatus> _muteStatuses =
-        new Dictionary<string, MuteStatus>();
+    private readonly Dictionary<string, CachedMute> _mutes =
+        new Dictionary<string, CachedMute>();
 
     public List<ChatUser> GetUsersOfRoom(string chatRoom)
     {
@@ -64,7 +71,7 @@ public class ConnectionMapping
         {
             var connection = _connections.Values.SingleOrDefault(r => r.ContainsKey(connectionId));
             connection?.Remove(connectionId);
-            _muteStatuses.Remove(connectionId);
+            _mutes.Remove(connectionId);
         }
     }
 
@@ -101,19 +108,51 @@ public class ConnectionMapping
         }
     }
 
-    public void SetMuteStatus(string connectionId, MuteStatus status)
+    /// <summary>
+    /// Cache the mute status and expiry for a connection.
+    /// Pass <c>status = MuteStatus.None</c> and <c>endDate = DateTime.MinValue</c> for an
+    /// explicitly-resolved unbanned connection (distinguishes a cache HIT-None from a MISS).
+    /// </summary>
+    public void SetMute(string connectionId, MuteStatus status, DateTime endDate)
     {
         lock (_connections)
         {
-            _muteStatuses[connectionId] = status;
+            _mutes[connectionId] = new CachedMute(status, endDate);
         }
     }
 
-    public MuteStatus GetMuteStatus(string connectionId)
+    /// <summary>
+    /// Returns true if a cache entry exists for the connection (regardless of status),
+    /// and writes it to <paramref name="cached"/>. Returns false on a cache MISS.
+    /// Use this to distinguish "cached None" from "never resolved" — only a MISS triggers
+    /// a lazy DB re-resolve.
+    /// </summary>
+    public bool TryGetMute(string connectionId, out CachedMute cached)
     {
         lock (_connections)
         {
-            return _muteStatuses.TryGetValue(connectionId, out var status) ? status : MuteStatus.None;
+            return _mutes.TryGetValue(connectionId, out cached);
+        }
+    }
+
+    /// <summary>
+    /// Returns the effective mute status for <paramref name="now"/>. If there is no cache
+    /// entry, or the entry is non-None but its <c>EndDate</c> has passed, returns
+    /// <c>MuteStatus.None</c>. Does NOT trigger a DB read — call <see cref="TryGetMute"/>
+    /// first to decide whether a lazy resolve is needed.
+    /// </summary>
+    public MuteStatus GetEffectiveMuteStatus(string connectionId, DateTime now)
+    {
+        lock (_connections)
+        {
+            if (!_mutes.TryGetValue(connectionId, out var cached))
+                return MuteStatus.None;
+
+            // None is always effective (unbanned); other statuses expire when EndDate passes.
+            if (cached.Status == MuteStatus.None || cached.EndDate > now)
+                return cached.Status;
+
+            return MuteStatus.None;
         }
     }
 }

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -16,6 +16,8 @@ public class ConnectionMapping
         new Dictionary<string, Dictionary<string, ChatUser>>();
 
     // Per-connection mute status cache. Keyed by connectionId.
+    // Guarded by the same lock (_connections) as the connection map so reads/writes
+    // of both dictionaries stay atomic and consistent (no TOCTOU on Remove).
     private readonly Dictionary<string, MuteStatus> _muteStatuses =
         new Dictionary<string, MuteStatus>();
 
@@ -62,9 +64,6 @@ public class ConnectionMapping
         {
             var connection = _connections.Values.SingleOrDefault(r => r.ContainsKey(connectionId));
             connection?.Remove(connectionId);
-        }
-        lock (_muteStatuses)
-        {
             _muteStatuses.Remove(connectionId);
         }
     }
@@ -104,7 +103,7 @@ public class ConnectionMapping
 
     public void SetMuteStatus(string connectionId, MuteStatus status)
     {
-        lock (_muteStatuses)
+        lock (_connections)
         {
             _muteStatuses[connectionId] = status;
         }
@@ -112,7 +111,7 @@ public class ConnectionMapping
 
     public MuteStatus GetMuteStatus(string connectionId)
     {
-        lock (_muteStatuses)
+        lock (_connections)
         {
             return _muteStatuses.TryGetValue(connectionId, out var status) ? status : MuteStatus.None;
         }

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -178,8 +178,6 @@ public class ConnectionMapping
     /// <remarks>
     /// The expiry rule itself lives on <see cref="CachedMute.EffectiveStatus"/> (single source).
     /// This method just acquires the lock and delegates to <see cref="GetEffectiveMuteStatusNoLock"/>.
-    /// <see cref="GetUsersOfRoomForViewer"/> calls the no-lock helper directly because it already
-    /// holds <c>lock(_connections)</c>.
     /// </remarks>
     public MuteStatus GetEffectiveMuteStatus(string connectionId, DateTime now)
     {
@@ -200,43 +198,5 @@ public class ConnectionMapping
         return _mutes.TryGetValue(connectionId, out var cached)
             ? cached.EffectiveStatus(now)
             : MuteStatus.None;
-    }
-
-    /// <summary>
-    /// Returns the users of <paramref name="chatRoom"/> as seen by <paramref name="viewerConnectionId"/>.
-    /// In public rooms (see <see cref="DefaultChatRooms.IsPublicRoom"/>), shadow-banned users whose ban
-    /// has not yet expired are hidden from all viewers except themselves (a shadow user always sees themselves).
-    /// In exempt rooms (clan, lobby) the filter is a no-op — all users are visible.
-    /// Uses per-connection cached expiry so the check is EXPIRY-AWARE without a DB read.
-    /// All access is under the single <c>_connections</c> lock for consistency.
-    /// </summary>
-    public List<ChatUser> GetUsersOfRoomForViewer(string chatRoom, string viewerConnectionId)
-    {
-        lock (_connections)
-        {
-            if (!_connections.TryGetValue(chatRoom, out var roomConnections))
-                return [];
-
-            var isPublicRoom = DefaultChatRooms.IsPublicRoom(chatRoom);
-            var now = DateTime.UtcNow;
-
-            return roomConnections
-                .Where(kvp =>
-                {
-                    // Always include the viewer themselves — shadow users see themselves.
-                    if (kvp.Key == viewerConnectionId) return true;
-
-                    // In public rooms, exclude users whose effective mute status is Shadow.
-                    // GetEffectiveMuteStatusNoLock is expiry-aware: an expired shadow ban returns None.
-                    // We already hold lock(_connections), so call the no-lock helper directly.
-                    if (isPublicRoom && GetEffectiveMuteStatusNoLock(kvp.Key, now) == MuteStatus.Shadow)
-                        return false;
-
-                    return true;
-                })
-                .Select(kvp => kvp.Value)
-                .OrderBy(u => u.BattleTag)
-                .ToList();
-        }
     }
 }

--- a/W3ChampionsChatService/Chats/ConnectionMapping.cs
+++ b/W3ChampionsChatService/Chats/ConnectionMapping.cs
@@ -3,10 +3,21 @@ using System.Linq;
 
 namespace W3ChampionsChatService.Chats;
 
+public enum MuteStatus
+{
+    None,
+    Shadow,
+    Full
+}
+
 public class ConnectionMapping
 {
     private readonly Dictionary<string, Dictionary<string, ChatUser>> _connections =
         new Dictionary<string, Dictionary<string, ChatUser>>();
+
+    // Per-connection mute status cache. Keyed by connectionId.
+    private readonly Dictionary<string, MuteStatus> _muteStatuses =
+        new Dictionary<string, MuteStatus>();
 
     public List<ChatUser> GetUsersOfRoom(string chatRoom)
     {
@@ -52,6 +63,10 @@ public class ConnectionMapping
             var connection = _connections.Values.SingleOrDefault(r => r.ContainsKey(connectionId));
             connection?.Remove(connectionId);
         }
+        lock (_muteStatuses)
+        {
+            _muteStatuses.Remove(connectionId);
+        }
     }
 
     public string GetRoom(string connectionId)
@@ -84,6 +99,22 @@ public class ConnectionMapping
                 }
             }
             return connectionIds;
+        }
+    }
+
+    public void SetMuteStatus(string connectionId, MuteStatus status)
+    {
+        lock (_muteStatuses)
+        {
+            _muteStatuses[connectionId] = status;
+        }
+    }
+
+    public MuteStatus GetMuteStatus(string connectionId)
+    {
+        lock (_muteStatuses)
+        {
+            return _muteStatuses.TryGetValue(connectionId, out var status) ? status : MuteStatus.None;
         }
     }
 }

--- a/W3ChampionsChatService/Chats/DefaultChatRooms.cs
+++ b/W3ChampionsChatService/Chats/DefaultChatRooms.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace W3ChampionsChatService.Chats;
 
@@ -20,8 +22,8 @@ public class DefaultChatRooms()
     ];
 
     /// <summary>
-    /// Returns true if <paramref name="room"/> is a lounge/ladder channel
-    /// where chat mutes apply. Clan and custom-game-lobby rooms return false.
+    /// True only for the official lounge/ladder rooms in <see cref="Rooms"/> (case-insensitive).
+    /// Any other room — clan rooms, game-lobby rooms, or any dynamic room — returns false.
     /// </summary>
-    public static bool IsBannedRoom(string room) => Rooms.Contains(room);
+    public static bool IsBannedRoom(string room) => Rooms.Contains(room, StringComparer.OrdinalIgnoreCase);
 }

--- a/W3ChampionsChatService/Chats/DefaultChatRooms.cs
+++ b/W3ChampionsChatService/Chats/DefaultChatRooms.cs
@@ -22,8 +22,9 @@ public class DefaultChatRooms()
     ];
 
     /// <summary>
-    /// True only for the official lounge/ladder rooms in <see cref="Rooms"/> (case-insensitive).
-    /// Any other room — clan rooms, game-lobby rooms, or any dynamic room — returns false.
+    /// True only for the official public lounge/ladder rooms in <see cref="Rooms"/> (case-insensitive).
+    /// These are the only rooms where lounge mutes (full/shadow bans) apply. Any other room —
+    /// clan rooms, game-lobby rooms, or any dynamic room — is a private/exempt room and returns false.
     /// </summary>
-    public static bool IsBannedRoom(string room) => Rooms.Contains(room, StringComparer.OrdinalIgnoreCase);
+    public static bool IsPublicRoom(string room) => Rooms.Contains(room, StringComparer.OrdinalIgnoreCase);
 }

--- a/W3ChampionsChatService/Chats/DefaultChatRooms.cs
+++ b/W3ChampionsChatService/Chats/DefaultChatRooms.cs
@@ -18,4 +18,10 @@ public class DefaultChatRooms()
         "Risk Europe",
         "Mini Dota",
     ];
+
+    /// <summary>
+    /// Returns true if <paramref name="room"/> is a lounge/ladder channel
+    /// where chat mutes apply. Clan and custom-game-lobby rooms return false.
+    /// </summary>
+    public static bool IsBannedRoom(string room) => Rooms.Contains(room);
 }

--- a/W3ChampionsChatService/Mutes/IMuteRepository.cs
+++ b/W3ChampionsChatService/Mutes/IMuteRepository.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+
+namespace W3ChampionsChatService.Mutes;
+
+/// <summary>
+/// Persistence abstraction for lounge mutes. Injected (instead of the concrete
+/// <see cref="MuteRepository"/>) so the hub and controller depend on an interface — and so tests
+/// can substitute a counting/fake implementation to assert the cache-only hot paths perform
+/// ZERO mute-repository reads.
+/// </summary>
+public interface IMuteRepository
+{
+    Task AddLoungeMute(LoungeMuteRequest loungeMuteRequest);
+    Task<LoungeMute> GetMutedPlayer(string battleTag);
+    Task<List<LoungeMute>> GetLoungeMutes();
+    Task<DeleteResult> DeleteLoungeMute(string battleTag);
+}

--- a/W3ChampionsChatService/Mutes/LoungeMute.cs
+++ b/W3ChampionsChatService/Mutes/LoungeMute.cs
@@ -20,4 +20,10 @@ public class LoungeMute : IIdentifiable
     public string author { get; set; }
     public string reason { get; set; }
     public bool isShadowBan { get; set; } = false;
+
+    /// <summary>
+    /// Returns true if this mute is still active at <paramref name="now"/>
+    /// (i.e. its end date is in the future). An expired mute is treated as no mute.
+    /// </summary>
+    public bool IsActive(DateTime now) => DateTime.Compare(endDate, now) > 0;
 }

--- a/W3ChampionsChatService/Mutes/MuteController.cs
+++ b/W3ChampionsChatService/Mutes/MuteController.cs
@@ -64,16 +64,17 @@ public class MuteController(IMuteRepository muteRepository, MuteReconciliationSe
     {
         Log.Information("Deleting lounge mute for {BattleTag}", bTag);
         DeleteResult result = await _muteRepository.DeleteLoungeMute(bTag);
-        if (result.DeletedCount == 0)
-        {
-            NotFound($"Unable to delete. Lounge mute for {bTag} not found.");
-        }
 
-        // Clear the cached mute on the target's live connections so an unbanned user can send again
-        // server-side without reconnecting. Intentionally does not restore hidden rooms or clear the
-        // client banner — that refreshes on reconnect (no "ban lifted" event; product decision).
+        // Clear the cached mute on the target's live connections FIRST, regardless of whether a DB row
+        // was removed. An explicit moderator unban should always free live connections — even if the DB
+        // row was already gone or expired — and ClearMuteOnLiveConnections is a safe no-op when there is
+        // nothing cached. (Does not restore hidden rooms or clear the client banner — that refreshes on
+        // reconnect; no "ban lifted" event, per the product decision.)
         await _muteReconciliation.ClearMuteOnLiveConnections(bTag);
 
-        return Ok($"Lounge mute for {bTag} deleted.");
+        // Report an accurate status: 404 when nothing was deleted, 200 otherwise.
+        return result.DeletedCount == 0
+            ? NotFound($"Unable to delete. Lounge mute for {bTag} not found.")
+            : Ok($"Lounge mute for {bTag} deleted.");
     }
 }

--- a/W3ChampionsChatService/Mutes/MuteController.cs
+++ b/W3ChampionsChatService/Mutes/MuteController.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Chats;
 using Serilog;
 using MongoDB.Driver;
 
@@ -8,9 +10,10 @@ namespace W3ChampionsChatService.Mutes;
 
 [ApiController]
 [Route("api/loungeMute")]
-public class MuteController(MuteRepository muteRepository) : ControllerBase
+public class MuteController(IMuteRepository muteRepository, MuteReconciliationService muteReconciliation) : ControllerBase
 {
-    private readonly MuteRepository _muteRepository = muteRepository;
+    private readonly IMuteRepository _muteRepository = muteRepository;
+    private readonly MuteReconciliationService _muteReconciliation = muteReconciliation;
 
     [HttpGet("")]
     [UserHasPermission(EPermission.Moderation)]
@@ -35,6 +38,23 @@ public class MuteController(MuteRepository muteRepository) : ControllerBase
 
         Log.Information("Adding lounge mute shadowBan={IsShadowBan} for {BattleTag} until {EndDate} by {Author}. Reason: {Reason}", loungeMuteRequest.isShadowBan, loungeMuteRequest.battleTag, loungeMuteRequest.endDate, loungeMuteRequest.author, loungeMuteRequest.reason);
         await _muteRepository.AddLoungeMute(loungeMuteRequest);
+
+        // The REST POST is an IN-BAND ban path: reconcile the target's live connections so the mute
+        // takes effect immediately (zero per-send DB read), not only on their next reconnect.
+        // Parse the endDate with the SAME DateTimeStyles the repository uses (AdjustToUniversal) so the
+        // cached expiry matches the persisted expiry. On a parse failure the ban is already persisted —
+        // skip the live reconcile gracefully (the target's next reconnect re-seeds the cache).
+        if (DateTime.TryParse(loungeMuteRequest.endDate, null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsedEndDate))
+        {
+            var status = loungeMuteRequest.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
+            await _muteReconciliation.ApplyMuteToLiveConnections(loungeMuteRequest.battleTag, status, parsedEndDate);
+        }
+        else
+        {
+            Log.Warning("AddLoungeMute: could not parse endDate '{EndDate}' for {BattleTag} — ban persisted, skipping live cache reconcile (next reconnect will re-seed the cache)",
+                loungeMuteRequest.endDate, loungeMuteRequest.battleTag);
+        }
+
         return Ok($"Lounge mute for {loungeMuteRequest.battleTag} inserted successfully.");
     }
 
@@ -48,6 +68,12 @@ public class MuteController(MuteRepository muteRepository) : ControllerBase
         {
             NotFound($"Unable to delete. Lounge mute for {bTag} not found.");
         }
+
+        // Clear the cached mute on the target's live connections so an unbanned user can send again
+        // server-side without reconnecting. Intentionally does not restore hidden rooms or clear the
+        // client banner — that refreshes on reconnect (no "ban lifted" event; product decision).
+        await _muteReconciliation.ClearMuteOnLiveConnections(bTag);
+
         return Ok($"Lounge mute for {bTag} deleted.");
     }
 }

--- a/W3ChampionsChatService/Mutes/MuteController.cs
+++ b/W3ChampionsChatService/Mutes/MuteController.cs
@@ -1,8 +1,6 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using W3ChampionsChatService.Authentication;
-using W3ChampionsChatService.Chats;
 using Serilog;
 using MongoDB.Driver;
 
@@ -37,23 +35,12 @@ public class MuteController(IMuteRepository muteRepository, MuteReconciliationSe
         }
 
         Log.Information("Adding lounge mute shadowBan={IsShadowBan} for {BattleTag} until {EndDate} by {Author}. Reason: {Reason}", loungeMuteRequest.isShadowBan, loungeMuteRequest.battleTag, loungeMuteRequest.endDate, loungeMuteRequest.author, loungeMuteRequest.reason);
-        await _muteRepository.AddLoungeMute(loungeMuteRequest);
 
-        // The REST POST is an IN-BAND ban path: reconcile the target's live connections so the mute
-        // takes effect immediately (zero per-send DB read), not only on their next reconnect.
-        // Parse the endDate with the SAME DateTimeStyles the repository uses (AdjustToUniversal) so the
-        // cached expiry matches the persisted expiry. On a parse failure the ban is already persisted —
-        // skip the live reconcile gracefully (the target's next reconnect re-seeds the cache).
-        if (DateTime.TryParse(loungeMuteRequest.endDate, null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsedEndDate))
-        {
-            var status = loungeMuteRequest.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
-            await _muteReconciliation.ApplyMuteToLiveConnections(loungeMuteRequest.battleTag, status, parsedEndDate);
-        }
-        else
-        {
-            Log.Warning("AddLoungeMute: could not parse endDate '{EndDate}' for {BattleTag} — ban persisted, skipping live cache reconcile (next reconnect will re-seed the cache)",
-                loungeMuteRequest.endDate, loungeMuteRequest.battleTag);
-        }
+        // The REST POST is an IN-BAND ban path: ApplyBanAsync persists the mute AND reconciles the
+        // target's live connections so the mute takes effect immediately (zero per-send DB read), not
+        // only on their next reconnect. A malformed endDate still persists; the live reconcile is
+        // skipped and the target's next reconnect re-seeds the cache.
+        await _muteReconciliation.ApplyBanAsync(loungeMuteRequest);
 
         return Ok($"Lounge mute for {loungeMuteRequest.battleTag} inserted successfully.");
     }

--- a/W3ChampionsChatService/Mutes/MuteReconciliationService.cs
+++ b/W3ChampionsChatService/Mutes/MuteReconciliationService.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using W3ChampionsChatService.Chats;
+
+namespace W3ChampionsChatService.Mutes;
+
+/// <summary>
+/// Reconciles the in-memory per-connection mute cache for EVERY ban write path — the SignalR hub
+/// (<see cref="ChatHub.BanUser"/>) AND the REST controller (<see cref="MuteController"/>) — so a
+/// mute takes effect on a target's live connections immediately, without a per-send DB read and
+/// without waiting for a reconnect.
+/// <para>
+/// The ONLY residual case that still requires a reconnect is a ban written DIRECTLY to the Mongo
+/// collection, bypassing both the hub and the REST controller (e.g. a manual DB edit or a data
+/// migration). Those writes never invoke this service, so the cache only catches up at the
+/// target's next login.
+/// </para>
+/// Shares the singleton <see cref="ConnectionMapping"/> with the hub and uses
+/// <see cref="IHubContext{ChatHub}"/> to push client signals from outside the hub call context.
+/// </summary>
+public class MuteReconciliationService(ConnectionMapping connections, IHubContext<ChatHub> hubContext)
+{
+    private readonly ConnectionMapping _connections = connections;
+    private readonly IHubContext<ChatHub> _hubContext = hubContext;
+
+    /// <summary>
+    /// Applies a mute to every live connection of <paramref name="battleTag"/>: updates the cached
+    /// status/expiry so the next SendMessage/SwitchRoom enforces from the cache (zero DB read), and
+    /// for a FULL ban pushes <c>PlayerBannedFromChat</c> (expiry only) to each connection. A SHADOW
+    /// ban stays completely silent to the target (preserve the illusion). Never aborts a connection.
+    /// </summary>
+    public async Task ApplyMuteToLiveConnections(string battleTag, MuteStatus status, DateTime endDate)
+    {
+        // Match the DB convention (GetMutedPlayer/AddLoungeMute lowercase the battleTag) by lowercasing
+        // the lookup arg too. GetConnectionIdsForUser also compares case-insensitively, so the reconcile
+        // works even on a casing mismatch.
+        var liveConnectionIds = _connections.GetConnectionIdsForUser(battleTag.ToLower());
+        foreach (var connId in liveConnectionIds)
+        {
+            // Update the cache so the next SendMessage/SwitchRoom enforces from the cache (no DB read).
+            _connections.SetMute(connId, status, endDate);
+
+            if (status == MuteStatus.Full)
+            {
+                // Full ban — R7/G5: notify the target REGARDLESS of their current room so they
+                // clearly and persistently know they're banned, independent of channel. A user
+                // full-banned while sitting in a clan/lobby room must still receive the notice
+                // (not just users in a public lounge/ladder room).
+                // G1: SendAsync only — never abort; the connection must stay alive.
+                // §12: no forced eviction — the user keeps their current room membership.
+                // SECURITY: send only the expiry — never leak the moderation reason or the shadow flag
+                // to the client. The event name + the camelCase `endDate` field stay unchanged so old
+                // clients keep reading `.endDate`; the missing reason/isShadowBan deserialize to
+                // null/false on legacy clients (harmless).
+                await _hubContext.Clients.Client(connId).SendAsync("PlayerBannedFromChat", new { endDate });
+            }
+            // Shadow ban: no signal to the target whatsoever — preserve the illusion (spec §12).
+        }
+    }
+
+    /// <summary>
+    /// Clears the mute on every live connection of <paramref name="battleTag"/> (sets cached status to
+    /// <see cref="MuteStatus.None"/>) so an unbanned user can send again server-side WITHOUT reconnecting.
+    /// <para>
+    /// Intentionally does NOT restore the client's hidden public rooms or clear its ban banner — those
+    /// only refresh on reconnect, matching the product decision (no auto-reconnect on ban lift). No
+    /// "ban lifted" client event is emitted.
+    /// </para>
+    /// </summary>
+    public Task ClearMuteOnLiveConnections(string battleTag)
+    {
+        var liveConnectionIds = _connections.GetConnectionIdsForUser(battleTag.ToLower());
+        foreach (var connId in liveConnectionIds)
+        {
+            _connections.SetMute(connId, MuteStatus.None, DateTime.MinValue);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/W3ChampionsChatService/Mutes/MuteReconciliationService.cs
+++ b/W3ChampionsChatService/Mutes/MuteReconciliationService.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
+using Serilog;
 using W3ChampionsChatService.Chats;
 
 namespace W3ChampionsChatService.Mutes;
@@ -18,11 +20,45 @@ namespace W3ChampionsChatService.Mutes;
 /// </para>
 /// Shares the singleton <see cref="ConnectionMapping"/> with the hub and uses
 /// <see cref="IHubContext{ChatHub}"/> to push client signals from outside the hub call context.
+/// <para>
+/// Lifetime: registered as a singleton. <see cref="IMuteRepository"/> resolves to
+/// <see cref="MuteRepository"/>, which wraps a thread-safe singleton <c>MongoClient</c>, so injecting
+/// it directly into a singleton is safe (no captured scoped/transient state).
+/// </para>
 /// </summary>
-public class MuteReconciliationService(ConnectionMapping connections, IHubContext<ChatHub> hubContext)
+public class MuteReconciliationService(
+    ConnectionMapping connections,
+    IHubContext<ChatHub> hubContext,
+    IMuteRepository muteRepository)
 {
     private readonly ConnectionMapping _connections = connections;
     private readonly IHubContext<ChatHub> _hubContext = hubContext;
+    private readonly IMuteRepository _muteRepository = muteRepository;
+
+    /// <summary>
+    /// Single home for the IN-BAND ban orchestration shared by the hub (<see cref="ChatHub.BanUser"/>)
+    /// and the REST controller (<see cref="MuteController"/>): persist the mute, then reconcile every
+    /// live connection of the target. Returns <c>(success, parsedEndDate)</c> — <c>success == false</c>
+    /// when the endDate could not be parsed (the mute is still persisted; the live reconcile is skipped
+    /// and the target's next reconnect re-seeds the cache).
+    /// </summary>
+    public async Task<(bool success, DateTime parsedEndDate)> ApplyBanAsync(LoungeMuteRequest request)
+    {
+        await _muteRepository.AddLoungeMute(request);
+
+        // Parse the endDate with the SAME DateTimeStyles the repository uses (AdjustToUniversal) so the
+        // CACHED expiry can never disagree with the PERSISTED expiry for an offset-less endDate.
+        if (!DateTime.TryParse(request.endDate, null, DateTimeStyles.AdjustToUniversal, out var parsedEndDate))
+        {
+            Log.Warning("ApplyBanAsync: could not parse endDate '{EndDate}' for {BattleTag} — ban persisted, skipping live cache reconcile (next reconnect will re-seed the cache)",
+                request.endDate, request.battleTag);
+            return (false, DateTime.MinValue);
+        }
+
+        var status = request.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
+        await ApplyMuteToLiveConnections(request.battleTag, status, parsedEndDate);
+        return (true, parsedEndDate);
+    }
 
     /// <summary>
     /// Applies a mute to every live connection of <paramref name="battleTag"/>: updates the cached

--- a/W3ChampionsChatService/Mutes/MuteRepository.cs
+++ b/W3ChampionsChatService/Mutes/MuteRepository.cs
@@ -19,7 +19,9 @@ public class MuteRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mon
         return Upsert(loungeMute);
     }
 
-    public Task<LoungeMute> GetMutedPlayer(string battleTag)
+    // virtual so tests can spy on it and assert the SendMessage/SwitchRoom hot paths perform
+    // ZERO mute-repository reads (the §7 cache-only contract).
+    public virtual Task<LoungeMute> GetMutedPlayer(string battleTag)
     {
         return LoadFirst<LoungeMute>(battleTag.ToLower());
     }

--- a/W3ChampionsChatService/Mutes/MuteRepository.cs
+++ b/W3ChampionsChatService/Mutes/MuteRepository.cs
@@ -31,6 +31,8 @@ public class MuteRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mon
 
     public Task<DeleteResult> DeleteLoungeMute(string battleTag)
     {
-        return Delete<LoungeMute>(c => c.battleTag == battleTag);
+        // Lowercase the tag to mirror AddLoungeMute/GetMutedPlayer — the stored battleTag is always
+        // lowercased, so a mixed-case delete would otherwise silently match 0 rows.
+        return Delete<LoungeMute>(c => c.battleTag == battleTag.ToLower());
     }
 }

--- a/W3ChampionsChatService/Mutes/MuteRepository.cs
+++ b/W3ChampionsChatService/Mutes/MuteRepository.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 namespace W3ChampionsChatService.Mutes;
 
-public class MuteRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient)
+public class MuteRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient), IMuteRepository
 {
     public Task AddLoungeMute(LoungeMuteRequest loungeMuteRequest)
     {
@@ -19,9 +19,7 @@ public class MuteRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mon
         return Upsert(loungeMute);
     }
 
-    // virtual so tests can spy on it and assert the SendMessage/SwitchRoom hot paths perform
-    // ZERO mute-repository reads (the §7 cache-only contract).
-    public virtual Task<LoungeMute> GetMutedPlayer(string battleTag)
+    public Task<LoungeMute> GetMutedPlayer(string battleTag)
     {
         return LoadFirst<LoungeMute>(battleTag.ToLower());
     }

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -29,12 +29,15 @@ public class Startup
         services.AddTransient<IChatAuthenticationService, ChatAuthenticationService>();
         services.AddTransient<IW3CAuthenticationService, W3CAuthenticationService>();
         services.AddTransient<IWebsiteBackendRepository, WebsiteBackendRepository>();
-        services.AddTransient<MuteRepository>();
+        services.AddTransient<IMuteRepository, MuteRepository>();
         services.AddTransient<UserHasPermissionFilter>();
         services.AddHttpContextAccessor();
 
         services.AddSingleton<ConnectionMapping>();
         services.AddSingleton<ChatHistory>();
+        // Reconciles the live mute cache from every ban WRITE path (hub + REST controller).
+        // Singleton: it only holds the singleton ConnectionMapping + IHubContext<ChatHub>.
+        services.AddSingleton<MuteReconciliationService>();
         Log.Information("Services added");
     }
 

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -3,6 +3,7 @@ using Serilog;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
 using W3ChampionsChatService.Authentication;
@@ -23,7 +24,9 @@ public class Startup
         var mongoClient = new MongoClient(mongoConnectionString.Replace("'", ""));
         services.AddSingleton(mongoClient);
 
-        services.AddSignalR();
+        // SECURITY: the hub permission filter enforces Moderation on the moderator-only hub methods.
+        // The MVC [UserHasPermission] attribute is inert on SignalR, so this filter is the real gate.
+        services.AddSignalR(options => { options.AddFilter<ChatHubPermissionFilter>(); });
 
         services.AddTransient<SettingsRepository>();
         services.AddTransient<IChatAuthenticationService, ChatAuthenticationService>();
@@ -31,6 +34,7 @@ public class Startup
         services.AddTransient<IWebsiteBackendRepository, WebsiteBackendRepository>();
         services.AddTransient<IMuteRepository, MuteRepository>();
         services.AddTransient<UserHasPermissionFilter>();
+        services.AddTransient<ChatHubPermissionFilter>();
         services.AddHttpContextAccessor();
 
         services.AddSingleton<ConnectionMapping>();


### PR DESCRIPTION
## Summary
Chat mutes (full and shadow `LoungeMute`) now apply **only in lounge/ladder channels**. **Clan channels and per-game custom-game lobbies are exempt** for both ban types, so banned players can still coordinate in their clan and in game lobbies. All enforcement is **server-side** (defense in depth) and **safe for old clients** (server deploys before clients update).

## Behavior
- **Banned rooms** = the official lounge/ladder channels (`DefaultChatRooms.Rooms`, matched case-insensitively). Everything else — clan rooms (`"clan …"`) and per-game lobby rooms (gameId) — is exempt.
- **Full ban:** stays connected but lounge/ladder are hidden (filtered channel list + safe-room seating); can chat in clan/lobby; receives `PlayerBannedFromChat` regardless of current room (so the client can show a persistent ban notice); rejected from joining or sending in banned rooms.
- **Shadow ban:** illusion preserved — types everywhere; in lounge/ladder their messages are dropped and they are hidden from other members' user lists (ghost), while in clan/lobby they participate for real.

## Enforcement (three server-authoritative layers)
- **Connect** (`LoginAsAuthenticated`): no abort; filtered channel list; safe-room seating; caches mute status + endDate.
- **Join** (`SwitchRoom`): full-ban hard reject (graceful, stays in prior room); shadow ghost-join (receives messages, hidden from others).
- **Send** (`SendMessage`): membership-before-send (R6); room-scoped — full reject / shadow drop in banned rooms, broadcast for everyone in exempt rooms.
- **Presence** (`GetUsersOfRoomForViewer`, `OnDisconnectedAsync`): shadow users hidden from others in banned rooms (viewer always sees self); `UserEntered`/`UserLeft` suppressed correctly across all cross-category transitions.
- **`BanUser`:** live cache reconcile + signal for already-connected users, no forced eviction.

## Backward compatibility (server deploys before clients)
Safe for old/unupdated clients: **zero `Context.Abort()`** on any ban path, all rejections return gracefully, connect always emits a `StartChat`, and payloads are additive only (no renamed/removed events or fields). Old clients can't be made to hide channels, but the server still prevents banned actions.

## Trade-off
A per-connection mute cache (status + endDate) eliminates most per-message DB reads; a deliberate cache-`None` safety-net re-resolve is kept so a ban issued by an external source still takes effect without requiring a reconnect.

## Tests
139 tests (NUnit, against the live test MongoDB), `-warnaserror` clean. Covers the full design §15 matrix + §16 G1–G5 backward-compat assertions, expiry at every layer, the case-variation / two-step-cache / membership bypasses, presence-hiding asserted by battleTag, and multi-connection ban reconciliation.

## Pairs with
A launcher-e client PR (full-ban channel hiding + persistent ban banner + treating a rejected `SwitchRoom` as a no-op) — forthcoming. This server PR is designed to deploy first.