### PR TITLE
fix(auth): tolerate unknown permission claims in chat JWT validation

### DIFF
--- a/W3ChampionsChatService.Tests/AuthenticationTests.cs
+++ b/W3ChampionsChatService.Tests/AuthenticationTests.cs
@@ -1,4 +1,10 @@
+using System;
 using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text.Json;
 using Microsoft.Extensions.Primitives;
 using Microsoft.IdentityModel.Tokens;
 using NUnit.Framework;
@@ -77,5 +83,76 @@ public class AuthenticationTests
 
         Assert.Throws<SecurityTokenValidationException>(() =>
             UserHasPermissionFilter.GetToken(authorization));
+    }
+
+    // ── Permission-vocabulary drift between identification-service and chat-service ────────
+    //
+    // identification-service can grant permissions that chat-service's EPermission enum does not yet
+    // contain (e.g. "Warnings", added id-service-side in #76 after chat-service's enum was last
+    // touched). Its JWT carries `permissions` as a serialized JSON array — the JWT handler expands it
+    // into one claim per element on read. chat-service must tolerate an unrecognized element: the user
+    // still authenticates and the permissions it DOES understand are retained. A hard Enum.Parse on an
+    // unknown value throws, is swallowed by FromJWT's catch, and the whole login silently fails with
+    // only "Receiver {ConnectionId} failed to authenticate" in the logs.
+
+    /// <summary>
+    /// Builds a JWT signed with a freshly-generated RSA keypair, carrying the same claim shape the
+    /// identification-service emits — crucially the <c>permissions</c> claim as a serialized JSON array
+    /// (<see cref="JsonClaimValueTypes.JsonArray"/>), which the handler expands into one claim per
+    /// element on read. Returns the token plus the matching public-key PEM that
+    /// <see cref="W3CUserAuthentication.FromJWT"/> validates against.
+    /// </summary>
+    private static (string jwt, string publicKeyPem) CreateSignedJwt(string battleTag, bool isAdmin, IEnumerable<string> permissions)
+    {
+        using var rsa = RSA.Create(2048);
+        var publicKeyPem = rsa.ExportSubjectPublicKeyInfoPem();
+
+        var signingCredentials = new SigningCredentials(new RsaSecurityKey(rsa), SecurityAlgorithms.RsaSha256)
+        {
+            CryptoProviderFactory = new CryptoProviderFactory { CacheSignatureProviders = false },
+        };
+
+        var token = new JwtSecurityToken(
+            claims: new[]
+            {
+                new Claim("battleTag", battleTag),
+                new Claim("isAdmin", isAdmin.ToString()),
+                new Claim("name", battleTag.Split('#')[0]),
+                new Claim("permissions", JsonSerializer.Serialize(permissions.ToList()), JsonClaimValueTypes.JsonArray),
+            },
+            signingCredentials: signingCredentials,
+            expires: DateTime.UtcNow.AddDays(7));
+
+        return (new JwtSecurityTokenHandler().WriteToken(token), publicKeyPem);
+    }
+
+    [Test]
+    public void FromJWT_TokenWithPermissionUnknownToChatService_StillAuthenticates()
+    {
+        // Reproduces the production incident: a moderator was granted "Warnings" (unknown to chat-service).
+        var (jwt, publicKeyPem) = CreateSignedJwt("moderator#123", isAdmin: true,
+            new[] { "Moderation", "Warnings" });
+
+        var result = W3CUserAuthentication.FromJWT(jwt, publicKeyPem);
+
+        Assert.IsNotNull(result, "A user holding a permission unknown to chat-service must still authenticate");
+        Assert.AreEqual("moderator#123", result.BattleTag);
+        Assert.IsTrue(result.IsAdmin);
+        Assert.IsTrue(result.Permissions.Contains(EPermission.Moderation), "Known permissions must be retained");
+        Assert.AreEqual(1, result.Permissions.Count, "The unknown 'Warnings' permission must be dropped, not crash the parse");
+    }
+
+    [Test]
+    public void FromJWT_TokenWithOnlyKnownPermissions_ParsesAll()
+    {
+        // Control: proves the JSON-array claim is expanded into per-element claims and all known
+        // permissions parse. Passes both before and after the tolerant-parse fix.
+        var (jwt, publicKeyPem) = CreateSignedJwt("admin#1", isAdmin: true,
+            new[] { "Moderation", "Queue" });
+
+        var result = W3CUserAuthentication.FromJWT(jwt, publicKeyPem);
+
+        Assert.IsNotNull(result);
+        CollectionAssert.AreEquivalent(new[] { EPermission.Moderation, EPermission.Queue }, result.Permissions);
     }
 }

--- a/W3ChampionsChatService/Authentication/W3CAuthenticationService.cs
+++ b/W3ChampionsChatService/Authentication/W3CAuthenticationService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using Microsoft.IdentityModel.Tokens;
+using Serilog;
 
 namespace W3ChampionsChatService.Authentication;
 
@@ -48,9 +49,17 @@ public class W3CUserAuthentication
             var btag = claims.Claims.First(c => c.Type == "battleTag").Value;
             var isAdmin = Boolean.Parse(claims.Claims.First(c => c.Type == "isAdmin").Value);
             var name = claims.Claims.First(c => c.Type == "name").Value;
+            // Keep only the permissions chat-service recognizes. identification-service grows its own
+            // EPermission vocabulary independently (e.g. it added "Warnings" in #76, which this enum does
+            // not contain); an unrecognized value must NOT fail the whole authentication. A hard
+            // Enum.Parse on an unknown value throws, gets swallowed below, and the user is silently
+            // rejected at connect with only a generic "failed to authenticate" warning. Skip unknown
+            // values via TryParse instead — chat-service only acts on the subset it understands.
             var permissions = claims.Claims
                     .Where(claim => claim.Type == "permissions")
-                    .Select(x => Enum.Parse<EPermission>(x.Value))
+                    .Select(x => Enum.TryParse<EPermission>(x.Value, out var permission) ? (EPermission?)permission : null)
+                    .Where(permission => permission.HasValue)
+                    .Select(permission => permission.Value)
                     .ToHashSet();
             return new W3CUserAuthentication
             {
@@ -60,8 +69,12 @@ public class W3CUserAuthentication
                 Permissions = permissions
             };
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            // Never swallow silently: a swallowed exception here surfaces only as a generic
+            // "Receiver {ConnectionId} failed to authenticate" warning in ChatHub, making auth failures
+            // undiagnosable. Log the real reason (bad signature, malformed token, missing claim, …).
+            Log.Warning(ex, "Failed to validate chat authentication token");
             return null;
         }
     }


### PR DESCRIPTION
## Problem

A user could not connect to chat-service — the only log line was a generic, detail-free warning:

```
Warning: Receiver {ConnectionId} failed to authenticate
```

The user had authenticated fresh to identification-service (a new JWT was issued), yet chat rejected them. It affected **one specific user** while everyone else connected fine.

## Root cause

`EPermission` enum drift between identification-service and chat-service, masked by a silent catch:

1. identification-service grants permissions and emits them in the JWT `permissions` claim (a JSON array, expanded into one claim per element on read). It recently added a permission (`Warnings`) that chat-service's `EPermission` enum does not contain.
2. `W3CUserAuthentication.FromJWT` parsed each element with `Enum.Parse<EPermission>(x.Value)`, which **throws `ArgumentException`** on a value the enum doesn't know.
3. The throw was swallowed by `catch (Exception) { return null; }` → `ChatAuthenticationService.GetUser` returned `null` → `OnConnectedAsync` logged the generic warning and aborted the connection.

It's user-specific because only users holding the unknown permission hit the throw; everyone else parses cleanly.

## Fix

- **Tolerant parse:** use `Enum.TryParse` and **skip** permission values chat-service doesn't recognize. chat-service only acts on the subset it understands (`Moderation`), so identification-service growing its permission vocabulary must never block chat login again.
- **No more silent swallow:** the `catch` now logs the real exception (`Log.Warning(ex, …)`) so future token-validation failures (bad signature, malformed token, missing claim) are diagnosable instead of vanishing.

Deliberately did **not** just add `Warnings` to chat-service's enum — that treats the symptom and re-arms the same landmine on the next permission addition. Decoupling via tolerant parse is the durable fix.

## Tests

Added to `AuthenticationTests.cs` (self-contained — builds a JWT with a test RSA keypair, mirroring identification-service's exact `JsonClaimValueTypes.JsonArray` claim shape; no prod key needed):

- `FromJWT_TokenWithPermissionUnknownToChatService_StillAuthenticates` — reproduces the incident; **RED before this change** (returned null), green after.
- `FromJWT_TokenWithOnlyKnownPermissions_ParsesAll` — control; proves the JSON-array claim expands into per-element claims (so only holders of the unknown permission were affected, not all permissioned users).

Full suite: **188/188 green**. `dotnet format` clean.

## Note for reviewers

website-backend has the same latent `Enum.Parse<EPermission>` pattern (not currently broken — its enum already has the permission, but it would 401 on the next drift). Hardened in a companion PR.