### PR TITLE
fix: temporary JWT fallback on chat hub — make the next deploy safe for released launchers

### DIFF
--- a/W3ChampionsChatService.Tests/ChatHubBanUserTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubBanUserTests.cs
@@ -66,6 +66,7 @@ public class ChatHubBanUserTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             new TicketStore(),
+            new W3CAuthenticationService(),
             _sessionRegistry,
             new UserDirectoryRepository(MongoClient),
             new SessionStateAssembler(

--- a/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
@@ -30,10 +30,12 @@ using W3ChampionsChatService.Users;
 namespace W3ChampionsChatService.Tests;
 
 /// <summary>
-/// C2 connect-path tests: the SignalR hub now authenticates via a one-time TICKET carried in the
-/// standard <c>access_token</c> query param (hard cutover — a raw JWT is no longer accepted). Covers
-/// valid connect + single-use consumption, all rejection shapes (raw JWT / reused ticket / missing
-/// ticket → <c>AuthorizationFailed</c> + <c>Context.Abort()</c>), battleTag displacement
+/// C2 connect-path tests: the SignalR hub authenticates via a one-time TICKET carried in the
+/// standard <c>access_token</c> query param, with a TEMPORARY raw-JWT fallback bridging launchers
+/// released before the ticket flow (see ChatHub.OnConnectedAsync — remove with the bridge). Covers
+/// valid connect + single-use consumption, the fallback accept/reject split, all rejection shapes
+/// (invalid JWT / reused ticket / missing ticket → <c>AuthorizationFailed</c> +
+/// <c>Context.Abort()</c>), battleTag displacement
 /// (<c>ConnectionDisplaced</c> BEFORE close — acceptance 4), the displaced-old-socket disconnect race,
 /// and the directory stub upsert. Drives the REAL <c>Context.GetHttpContext()</c> resolution path via
 /// an <see cref="IHttpContextFeature"/> on the connection's feature collection (never
@@ -112,12 +114,17 @@ public class ChatHubConnectionTests : IntegrationTestBase
     private static W3CUserAuthentication Identity(string battleTag = BattleTag, string name = "peter", bool isAdmin = false) =>
         new() { BattleTag = battleTag, Name = name, IsAdmin = isAdmin };
 
-    private (ChatHub Hub, Mock<HubCallerContext> Context) BuildConnection(string connectionId, string accessToken)
+    private (ChatHub Hub, Mock<HubCallerContext> Context) BuildConnection(string connectionId, string accessToken, string jwtFallbackPublicKeyPem = null)
     {
+        // jwtFallbackPublicKeyPem: test seam for the raw-JWT fallback bridge. Default (null) uses the
+        // real service with the production public key, under which CreateSignedJwt tokens are invalid.
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            jwtFallbackPublicKeyPem == null
+                ? new W3CAuthenticationService()
+                : new W3CAuthenticationService(jwtFallbackPublicKeyPem),
             _sessionRegistry,
             _userDirectory,
             _assembler,
@@ -235,17 +242,36 @@ public class ChatHubConnectionTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task RawJwt_AsAccessToken_IsRejected()
+    public async Task RawJwt_ValidSignature_ConnectsViaFallback()
     {
-        // Acceptance 3: a client that mistakenly presents a raw (even cryptographically valid) JWT as
-        // access_token is rejected — the hub consumes ONLY one-time tickets after the hard cutover.
+        // TEMPORARY bridge (see ChatHub.OnConnectedAsync): a launcher released before the ticket
+        // flow presents its raw JWT as access_token. A signature-valid JWT must connect exactly as
+        // it did before the C2 cutover, so deploying this service cannot strand released launchers.
+        var (jwt, publicKeyPem) = CreateSignedJwt(BattleTag, isAdmin: false, new[] { "Moderation" });
+        var (hub, _) = BuildConnection("conn-jwt", jwt, jwtFallbackPublicKeyPem: publicKeyPem);
+
+        await hub.OnConnectedAsync();
+
+        Assert.IsFalse(_sends.Contains(("conn-jwt", "AuthorizationFailed")),
+            "A signature-valid raw JWT must be accepted by the fallback bridge");
+        Assert.IsTrue(_sessionRegistry.TryGetByConnectionId("conn-jwt", out var session),
+            "The fallback connect must register a session");
+        Assert.AreEqual(BattleTag, session.Identity.BattleTag);
+    }
+
+    [Test]
+    public async Task RawJwt_InvalidSignature_IsRejected()
+    {
+        // The bridge only widens auth to VALID JWTs: a token that is neither a ticket nor signed by
+        // the trusted key is still rejected. (BuildConnection's default auth service validates
+        // against the production key, under which this test-signed JWT is invalid.)
         var (jwt, _) = CreateSignedJwt(BattleTag, isAdmin: false, new[] { "Moderation" });
         var (hub, _) = BuildConnection("conn-jwt", jwt);
 
         await hub.OnConnectedAsync();
 
         Assert.IsTrue(_sends.Contains(("conn-jwt", "AuthorizationFailed")),
-            "A raw JWT is not a valid ticket — the caller must receive AuthorizationFailed");
+            "A JWT not signed by the trusted key must receive AuthorizationFailed");
         Assert.IsTrue(_sends.Contains(("conn-jwt", "ABORT")),
             "Connect-time auth failure is the one rejection-style abort");
         Assert.IsFalse(_sessionRegistry.TryGetByConnectionId("conn-jwt", out _),

--- a/W3ChampionsChatService.Tests/ChatHubConsentTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConsentTests.cs
@@ -145,6 +145,7 @@ public class ChatHubConsentTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
@@ -92,6 +92,7 @@ public class ChatHubDeletionTests : IntegrationTestBase
             _connectionMapping,
             new MuteReconciliationTestHarness(_connectionMapping, _muteRepository).Service,
             new TicketStore(),
+            new W3CAuthenticationService(),
             _sessionRegistry,
             new UserDirectoryRepository(MongoClient),
             assembler,

--- a/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
@@ -107,6 +107,7 @@ public class ChatHubDmFocusTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -133,6 +133,7 @@ public class ChatHubDmSendTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
@@ -89,6 +89,7 @@ public class ChatHubFocusTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -152,6 +152,7 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -103,6 +103,7 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubGroupCreateTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupCreateTests.cs
@@ -122,6 +122,7 @@ public class ChatHubGroupCreateTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
@@ -132,6 +132,7 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubMarkReadTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMarkReadTests.cs
@@ -102,6 +102,7 @@ public class ChatHubMarkReadTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
@@ -88,6 +88,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubMentionInboxTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionInboxTests.cs
@@ -98,6 +98,7 @@ public class ChatHubMentionInboxTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubMentionSearchTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionSearchTests.cs
@@ -98,6 +98,7 @@ public class ChatHubMentionSearchTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
@@ -126,6 +126,7 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             userDirectory ?? _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubOpenDmTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubOpenDmTests.cs
@@ -112,6 +112,7 @@ public class ChatHubOpenDmTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubPresenceReadTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceReadTests.cs
@@ -126,6 +126,7 @@ public class ChatHubPresenceReadTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
@@ -134,6 +134,7 @@ public class ChatHubPresenceTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -121,6 +121,7 @@ public class ChatHubSendMessageTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ChatHubSettingsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSettingsTests.cs
@@ -88,6 +88,7 @@ public class ChatHubSettingsTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
@@ -180,6 +180,7 @@ public class DmGroupIntegrationTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
@@ -150,6 +150,7 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -194,6 +194,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
@@ -172,6 +172,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService.Tests/MutePortTests.cs
+++ b/W3ChampionsChatService.Tests/MutePortTests.cs
@@ -126,6 +126,7 @@ public class MutePortTests : IntegrationTestBase
             _connectionMapping,
             _reconcileHarness.Service,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             assembler,

--- a/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
@@ -66,6 +66,7 @@ public class MuteReconciliationTests : IntegrationTestBase
             _connectionMapping,
             _harness.Service,
             new TicketStore(),
+            new W3CAuthenticationService(),
             _sessionRegistry,
             new UserDirectoryRepository(MongoClient),
             new SessionStateAssembler(

--- a/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
+++ b/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
@@ -299,6 +299,7 @@ public class ViewersAccumulatorTests : IntegrationTestBase
             _connectionMapping,
             _reconcileService,
             _ticketStore,
+            new W3CAuthenticationService(),
             _sessionRegistry,
             _userDirectory,
             _assembler,

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -24,6 +24,10 @@ public partial class ChatHub(
     ConnectionMapping connections,
     MuteReconciliationService muteReconciliation,
     ITicketStore ticketStore,
+    // TEMPORARY bridge (see OnConnectedAsync): validates raw JWTs from launchers released before
+    // the ticket flow existed. Remove together with the fallback once the forced launcher update
+    // has rolled out.
+    IW3CAuthenticationService w3cAuthenticationService,
     ISessionRegistry sessionRegistry,
     UserDirectoryRepository userDirectory,
     SessionStateAssembler assembler,
@@ -97,6 +101,7 @@ public partial class ChatHub(
     private readonly ConnectionMapping _connections = connections;
     private readonly MuteReconciliationService _muteReconciliation = muteReconciliation;
     private readonly ITicketStore _ticketStore = ticketStore;
+    private readonly IW3CAuthenticationService _w3cAuthenticationService = w3cAuthenticationService;
     private readonly ISessionRegistry _sessionRegistry = sessionRegistry;
     private readonly UserDirectoryRepository _userDirectory = userDirectory;
     // C3 (Task 8): the SessionState snapshot assembler + the in-memory fan-out registries this hub
@@ -137,15 +142,37 @@ public partial class ChatHub(
 
     public override async Task OnConnectedAsync()
     {
-        // HARD CUTOVER (C2): access_token carries a one-time TICKET minted by POST /auth/session.
-        // A raw JWT lands here too — it is simply not a valid ticket and is rejected.
+        // Ticket-first auth (C2) with a TEMPORARY raw-JWT fallback.
+        //
+        // C2 was written as a hard cutover, lock-step with a forced launcher update. That update has
+        // not shipped (latest release v1.6.5, 2026-06-16, predates the ticket flow), and deploying a
+        // ticket-only hub against it caused a fleet-wide friends/presence outage on website-backend —
+        // this fallback exists so chat-service CANNOT repeat that: whenever this deploys, released
+        // launchers keep authenticating with the raw JWT they have always sent (the pre-C2 behavior),
+        // while updated launchers take the ticket path first.
+        //
+        // REMOVE the fallback (and the IW3CAuthenticationService ctor param) once a launcher release
+        // containing the ticket mint (launcher-e #833) has shipped AND its forced-update rollout has
+        // completed.
         var ticket = Context.GetHttpContext()?.Request.Query["access_token"].ToString();
         // Deliberate wall-clock seam, NOT routed through _timeProvider: the ticket is minted with
         // DateTime.UtcNow by the REST AuthSessionController (a separate process boundary that has no
         // access to this hub's injected clock), so the consume-side check MUST compare against the
         // same wall clock the mint side used. This is intentionally decoupled from the injectable
         // fan-out clock below — TicketStore TTL correctness does not depend on TimeProvider.
-        if (string.IsNullOrEmpty(ticket) || !_ticketStore.TryConsume(ticket, DateTime.UtcNow, out var identity))
+        W3CUserAuthentication identity = null;
+        if (!string.IsNullOrEmpty(ticket))
+        {
+            if (_ticketStore.TryConsume(ticket, DateTime.UtcNow, out var ticketIdentity))
+            {
+                identity = ticketIdentity;
+            }
+            else
+            {
+                identity = _w3cAuthenticationService.GetUserByToken(ticket);
+            }
+        }
+        if (identity == null)
         {
             Log.Warning("Receiver {ConnectionId} failed to authenticate", Context.ConnectionId);
             await Clients.Caller.SendAsync("AuthorizationFailed");


### PR DESCRIPTION
Chat-side twin of w3champions/website-backend#545 — read that PR for the full incident story.

## Why now, before any chat deploy

The C2 cutover (#33) made this hub ticket-only, assuming a lock-step forced launcher update that **has not shipped** (latest launcher release v1.6.5, June 16, predates the ticket flow). website-backend deployed its identical cutover and instantly broke friends/presence for every released launcher. Chat only escaped because this service **hasn't been deployed since** — the next deploy, whenever it happens, would take chat down the same way. This PR removes that landmine so deploy order stops mattering.

## Change

`OnConnectedAsync`: try the one-time ticket first (updated launchers), else validate `access_token` as a raw JWT — the exact pre-cutover behavior (chat's `FromJWT` swallows invalid tokens to null, so no catch needed; pinned by a real-service test). Marked loudly as temporary: remove once a launcher release with the ticket mint (launcher-e #833) has rolled out.

## Tests

- The old `RawJwt_AsAccessToken_IsRejected` pinned the outage-causing behavior; replaced by the two new contracts: **signature-valid JWT connects via fallback** (real `W3CAuthenticationService` against the test signing key, via a new optional builder param) and **wrong-key JWT still rejected** (real service, prod key).
- Other 27 test files: one mechanical line each (the new ctor arg). Compiler enforces arity; connection-area suite (100 tests) green locally. Full suite runs in CI on this PR.

## Reviewer notes

- Same temporary cost as wb: released launchers keep the pre-cutover JWT-in-query-string posture until the bridge is removed.
- Same `TicketStore` single-replica caveat as wb applies here too.