### PR TITLE
Add Jobs admin permission

### DIFF
--- a/W3ChampionsChatService/Authentication/EPermission.cs
+++ b/W3ChampionsChatService/Authentication/EPermission.cs
@@ -13,4 +13,6 @@ public enum EPermission
     SmurfCheckerQuery,
     SmurfCheckerQueryExplanation,
     SmurfCheckerAdministration,
+    Warnings,
+    Jobs,
 }


### PR DESCRIPTION
Adds `Jobs` to the chat-service mirror of the permission enum, backing the admin job runner (w3champions/website-backend#541). `Warnings` rides along: it was never mirrored here when identification-service#76 added it, and the tolerant JWT parse drops permission names this enum lacks before they reach `ownProfile.permissions`. Appended in org order, so both land on the standard ordinals (11, 12).

Siblings: w3champions/identification-service#77, w3champions/website-backend#546, w3champions/website#1113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)