### PR TITLE
Chat follow-up fixes: escalating throttle, mention reach, bounded snapshot + conversation paging

### DIFF
--- a/W3ChampionsChatService.Tests/AuthenticationTests.cs
+++ b/W3ChampionsChatService.Tests/AuthenticationTests.cs
@@ -88,12 +88,17 @@ public class AuthenticationTests
     // ── Permission-vocabulary drift between identification-service and chat-service ────────
     //
     // identification-service can grant permissions that chat-service's EPermission enum does not yet
-    // contain (e.g. "Warnings", added id-service-side in #76 after chat-service's enum was last
-    // touched). Its JWT carries `permissions` as a serialized JSON array — the JWT handler expands it
-    // into one claim per element on read. chat-service must tolerate an unrecognized element: the user
-    // still authenticates and the permissions it DOES understand are retained. A hard Enum.Parse on an
-    // unknown value throws, is swallowed by FromJWT's catch, and the whole login silently fails with
+    // contain (historically "Warnings", added id-service-side in #76 after chat-service's enum was
+    // last touched). Its JWT carries `permissions` as a serialized JSON array — the JWT handler expands
+    // it into one claim per element on read. chat-service must tolerate an unrecognized element: the
+    // user still authenticates and the permissions it DOES understand are retained. A hard Enum.Parse on
+    // an unknown value throws, is swallowed by FromJWT's catch, and the whole login silently fails with
     // only "Receiver {ConnectionId} failed to authenticate" in the logs.
+    //
+    // The tests below use "UnknownToChatService" rather than the historical "Warnings" example: #35
+    // later added Warnings for real to chat-service's EPermission enum, so it no longer demonstrates an
+    // unknown permission. A synthetic name that can never become a real permission keeps the tests'
+    // premise intact.
 
     /// <summary>
     /// Builds a JWT signed with a freshly-generated RSA keypair, carrying the same claim shape the
@@ -130,9 +135,9 @@ public class AuthenticationTests
     [Test]
     public void FromJWT_TokenWithPermissionUnknownToChatService_StillAuthenticates()
     {
-        // Reproduces the production incident: a moderator was granted "Warnings" (unknown to chat-service).
+        // Reproduces the production incident: a moderator was granted a permission unknown to chat-service.
         var (jwt, publicKeyPem) = CreateSignedJwt("moderator#123", isAdmin: true,
-            new[] { "Moderation", "Warnings" });
+            new[] { "Moderation", "UnknownToChatService" });
 
         var result = W3CUserAuthentication.FromJWT(jwt, publicKeyPem);
 
@@ -140,7 +145,7 @@ public class AuthenticationTests
         Assert.AreEqual("moderator#123", result.BattleTag);
         Assert.IsTrue(result.IsAdmin);
         Assert.IsTrue(result.Permissions.Contains(EPermission.Moderation), "Known permissions must be retained");
-        Assert.AreEqual(1, result.Permissions.Count, "The unknown 'Warnings' permission must be dropped, not crash the parse");
+        Assert.AreEqual(1, result.Permissions.Count, "The unknown permission must be dropped, not crash the parse");
     }
 
     [Test]
@@ -206,13 +211,13 @@ public class AuthenticationTests
     {
         // Acceptance 2 through the NEW mint path — mirrors
         // FromJWT_TokenWithPermissionUnknownToChatService_StillAuthenticates (PR #32).
-        var (jwt, publicKeyPem) = CreateSignedJwt("moderator#123", true, new[] { "Moderation", "Warnings" });
+        var (jwt, publicKeyPem) = CreateSignedJwt("moderator#123", true, new[] { "Moderation", "UnknownToChatService" });
 
         var result = W3CUserAuthentication.FromJWT(jwt, publicKeyPem, validateLifetime: true);
 
         Assert.IsNotNull(result);
         Assert.IsTrue(result.Permissions.Contains(EPermission.Moderation));
-        Assert.AreEqual(1, result.Permissions.Count, "Unknown 'Warnings' must be dropped, not crash the parse");
+        Assert.AreEqual(1, result.Permissions.Count, "Unknown permission must be dropped, not crash the parse");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChannelRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelRepositoryTests.cs
@@ -229,6 +229,41 @@ public class ChannelRepositoryTests : IntegrationTestBase
         CollectionAssert.AreEquivalent(new[] { a.Id, c.Id }, loaded.Select(x => x.Id).ToList());
     }
 
+    // 2026-08-05 PR36 feedback (Part 3): backs the CountNameJoinableMembershipsForUser rewrite — a
+    // server-side count of the Public/SemiPublic subset of a given id set, mirroring exactly what
+    // LoadByIds + a client-side type filter used to compute.
+    [Test]
+    public async Task CountNameJoinableAmongIds_CountsOnlyPublicAndSemiPublic_AmongGivenIds()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var pub = new ChatChannel { Type = ChannelType.Public, Name = "Pub", NormalizedName = "pub" };
+        var semi = new ChatChannel { Type = ChannelType.SemiPublic, Name = "Semi", NormalizedName = "semi" };
+        var sys = new ChatChannel { Type = ChannelType.System, SystemKind = SystemChannelKind.Match, SystemRef = "m1" };
+        var dm = new ChatChannel { Type = ChannelType.Dm, PairKey = DmPairKey.For("Peter#123", "Wolf#456") };
+        var otherPub = new ChatChannel { Type = ChannelType.Public, Name = "Other", NormalizedName = "other" };
+        await repo.Insert(pub);
+        await repo.Insert(semi);
+        await repo.Insert(sys);
+        await repo.Insert(dm);
+        await repo.Insert(otherPub);
+
+        // otherPub is deliberately excluded from the id set — it must NOT count even though it is
+        // name-joinable, proving the filter is (Id ∈ ids) AND (type), not type alone.
+        var count = await repo.CountNameJoinableAmongIds(new[] { pub.Id, semi.Id, sys.Id, dm.Id });
+
+        Assert.AreEqual(2, count);
+    }
+
+    [Test]
+    public async Task CountNameJoinableAmongIds_EmptyIds_ReturnsZero()
+    {
+        var repo = new ChannelRepository(MongoClient);
+
+        var count = await repo.CountNameJoinableAmongIds(Array.Empty<string>());
+
+        Assert.AreEqual(0, count);
+    }
+
     [Test]
     public async Task LoadAnyByNormalizedName_FindsAcrossTypes()
     {

--- a/W3ChampionsChatService.Tests/ChatHubBanUserTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubBanUserTests.cs
@@ -93,7 +93,8 @@ public class ChatHubBanUserTests : IntegrationTestBase
             chatAuthService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         _clients = new Mock<IHubCallerClients>();
         var callerProxy = new Mock<ISingleClientProxy>();

--- a/W3ChampionsChatService.Tests/ChatHubBanUserTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubBanUserTests.cs
@@ -79,6 +79,7 @@ public class ChatHubBanUserTests : IntegrationTestBase
             new FocusRegistry(),
             _onlineMemberRegistry,
             new MessageRateLimiter(),
+            new ReadRateLimiter(),
             TimeProvider.System,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
@@ -60,6 +60,7 @@ public class ChatHubConnectionTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
 
@@ -96,6 +97,7 @@ public class ChatHubConnectionTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _relationshipSource = new FakeRelationshipSource();
         _relationshipProvider = new RelationshipProvider(_relationshipSource, TimeProvider.System);
@@ -124,6 +126,7 @@ public class ChatHubConnectionTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             TimeProvider.System,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
@@ -611,7 +611,7 @@ public class ChatHubConnectionTests : IntegrationTestBase
     public async Task Connect_PrefetchesOwnSnapshot_NonFatalOnFailure()
     {
         // Follow-up spec §6: connect now AWAITS one relationship fetch BEFORE assembly (the bounded
-        // 1:1-DM snapshot needs the block list). The SEPARATE fire-and-forget PrefetchRelationshipSnapshot
+        // 1:1-DM snapshot needs the block list). The SEPARATE fire-and-forget PushFriendPresenceFromSnapshot
         // dispatch is handed that SAME (here: null, since the fetch failed) resolved snapshot directly and
         // never calls GetSnapshotAsync itself — so even on a sustained outage there is exactly ONE call to
         // the source for the whole connect, by construction, never a second independent retry. NON-FATAL
@@ -668,7 +668,7 @@ public class ChatHubConnectionTests : IntegrationTestBase
         Assert.IsTrue(_sessionRegistry.TryGetByConnectionId("conn-rel-await", out _));
         Assert.IsTrue(_sends.Contains(("conn-rel-await", ChatEvents.SessionState)));
 
-        // The fire-and-forget PrefetchRelationshipSnapshot dispatch (friend-presence, unchanged role) is
+        // The fire-and-forget PushFriendPresenceFromSnapshot dispatch (friend-presence, unchanged role) is
         // dispatched AFTER the awaited fetch above and handed that ALREADY-RESOLVED snapshot directly — it
         // never calls GetSnapshotAsync itself. Give it a brief moment to finish, then assert the source was
         // touched exactly once for the whole connect.

--- a/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
@@ -611,13 +611,12 @@ public class ChatHubConnectionTests : IntegrationTestBase
     public async Task Connect_PrefetchesOwnSnapshot_NonFatalOnFailure()
     {
         // Follow-up spec §6: connect now AWAITS one relationship fetch BEFORE assembly (the bounded
-        // 1:1-DM snapshot needs the block list), and the SEPARATE fire-and-forget
-        // PrefetchRelationshipSnapshot dispatch (cache-warm + friend-presence, unchanged role) still runs
-        // afterwards. NON-FATAL either way: even when the source throws for every attempt, the connect
-        // still succeeds (session registered + SessionState pushed). A failed fetch is NEVER cached
-        // (RelationshipProvider — "no negative caching"), so on a sustained outage BOTH call sites may
-        // independently retry the source — the count is therefore AT LEAST one, not pinned to exactly
-        // one the way the warm-cache happy path is (see the sibling test below).
+        // 1:1-DM snapshot needs the block list). The SEPARATE fire-and-forget PrefetchRelationshipSnapshot
+        // dispatch is handed that SAME (here: null, since the fetch failed) resolved snapshot directly and
+        // never calls GetSnapshotAsync itself — so even on a sustained outage there is exactly ONE call to
+        // the source for the whole connect, by construction, never a second independent retry. NON-FATAL
+        // either way: even when the source throws, the connect still succeeds (session registered +
+        // SessionState pushed).
         _relationshipSource.ShouldThrow = true;
 
         var ticket = _ticketStore.Mint(Identity(), DateTime.UtcNow);
@@ -635,8 +634,9 @@ public class ChatHubConnectionTests : IntegrationTestBase
             "the connect path must call the relationship source");
         Assert.AreEqual(BattleTag, await _relationshipSource.FirstFetch,
             "the fetch must be for the CONNECTING user's own snapshot");
-        Assert.GreaterOrEqual(_relationshipSource.FetchCount, 1,
-            "at least the required pre-assembly fetch must have called the source");
+        Assert.AreEqual(1, _relationshipSource.FetchCount,
+            "exactly ONE round-trip per connect, even on failure — the fire-and-forget dispatch never " +
+            "retries the source itself, so this holds true by construction, not by timing luck");
     }
 
     [Test]
@@ -668,13 +668,13 @@ public class ChatHubConnectionTests : IntegrationTestBase
         Assert.IsTrue(_sessionRegistry.TryGetByConnectionId("conn-rel-await", out _));
         Assert.IsTrue(_sends.Contains(("conn-rel-await", ChatEvents.SessionState)));
 
-        // The fire-and-forget PrefetchRelationshipSnapshot dispatch (cache-warm + friend-presence,
-        // unchanged role) is now dispatched AFTER the awaited fetch above, so its own GetSnapshotAsync
-        // call is a warm-CACHE hit rather than a second real source fetch — give it a brief moment to
-        // finish, then assert the source was touched exactly once for the whole connect.
+        // The fire-and-forget PrefetchRelationshipSnapshot dispatch (friend-presence, unchanged role) is
+        // dispatched AFTER the awaited fetch above and handed that ALREADY-RESOLVED snapshot directly — it
+        // never calls GetSnapshotAsync itself. Give it a brief moment to finish, then assert the source was
+        // touched exactly once for the whole connect.
         await Task.Delay(TimeSpan.FromMilliseconds(50));
         Assert.AreEqual(1, _relationshipSource.FetchCount,
-            "exactly ONE real source fetch for the whole connect — the fire-and-forget dispatch after " +
-            "the awaited fetch reuses the fresh cache instead of a duplicate wb round-trip");
+            "exactly ONE real source fetch for the whole connect — the fire-and-forget dispatch reuses the " +
+            "already-resolved snapshot instead of a duplicate wb round-trip");
     }
 }

--- a/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
@@ -138,7 +138,8 @@ public class ChatHubConnectionTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
@@ -610,10 +610,14 @@ public class ChatHubConnectionTests : IntegrationTestBase
     [Test]
     public async Task Connect_PrefetchesOwnSnapshot_NonFatalOnFailure()
     {
-        // C5 (Task 1, spec §6): connect warms the relationship cache with the CONNECTING user's own
-        // snapshot. It is fire-and-forget and NON-FATAL — even when the source throws, the connect still
-        // succeeds (session registered + SessionState pushed), and the source is called exactly once with
-        // the connecting battleTag.
+        // Follow-up spec §6: connect now AWAITS one relationship fetch BEFORE assembly (the bounded
+        // 1:1-DM snapshot needs the block list), and the SEPARATE fire-and-forget
+        // PrefetchRelationshipSnapshot dispatch (cache-warm + friend-presence, unchanged role) still runs
+        // afterwards. NON-FATAL either way: even when the source throws for every attempt, the connect
+        // still succeeds (session registered + SessionState pushed). A failed fetch is NEVER cached
+        // (RelationshipProvider — "no negative caching"), so on a sustained outage BOTH call sites may
+        // independently retry the source — the count is therefore AT LEAST one, not pinned to exactly
+        // one the way the warm-cache happy path is (see the sibling test below).
         _relationshipSource.ShouldThrow = true;
 
         var ticket = _ticketStore.Mint(Identity(), DateTime.UtcNow);
@@ -622,41 +626,55 @@ public class ChatHubConnectionTests : IntegrationTestBase
         await hub.OnConnectedAsync();
 
         Assert.IsTrue(_sessionRegistry.TryGetByConnectionId("conn-rel", out _),
-            "a failing relationship prefetch must NOT fail the connect — the session is still registered");
+            "a failing relationship fetch must NOT fail the connect — the session is still registered");
         Assert.IsTrue(_sends.Contains(("conn-rel", ChatEvents.SessionState)),
-            "the caller still receives its SessionState snapshot despite the prefetch failure");
+            "the caller still receives its SessionState snapshot despite the fetch failure");
 
-        // The prefetch is fire-and-forget; await its completion signal (bounded) rather than racing it.
         var observed = await Task.WhenAny(_relationshipSource.FirstFetch, Task.Delay(TimeSpan.FromSeconds(5)));
         Assert.AreSame(_relationshipSource.FirstFetch, observed,
-            "the connect-time prefetch must call the relationship source");
+            "the connect path must call the relationship source");
         Assert.AreEqual(BattleTag, await _relationshipSource.FirstFetch,
-            "the prefetch must fetch the CONNECTING user's own snapshot");
-        Assert.AreEqual(1, _relationshipSource.FetchCount, "connect prefetches exactly one snapshot");
+            "the fetch must be for the CONNECTING user's own snapshot");
+        Assert.GreaterOrEqual(_relationshipSource.FetchCount, 1,
+            "at least the required pre-assembly fetch must have called the source");
     }
 
     [Test]
-    public async Task Connect_RelationshipPrefetch_DoesNotBlockConnect()
+    public async Task Connect_AwaitsRelationshipSnapshot_BeforeAssembly_ThenPrefetchReusesWarmCache()
     {
-        // C5 (Task 1): the prefetch is fire-and-forget — a slow/unreachable wb read must NOT add latency
-        // to (or stall) a connect. Hold the fetch open for the whole connect via an unreleased gate; if
-        // OnConnectedAsync awaited the prefetch this would deadlock the test. It returns instead, with the
-        // session registered and SessionState pushed, while the fetch is still in flight.
+        // Follow-up spec §6: the connect path now AWAITS the caller's OWN relationship snapshot BEFORE
+        // assembling SessionState — the bounded 1:1-DM snapshot needs the block list to keep every
+        // blocked shell regardless of recency. This is a deliberate behavior change from the pre-§6 world
+        // where NOTHING on the connect path ever waited on a relationship fetch (it was purely a
+        // fire-and-forget cache warm). In production this wait is bounded by the wb source's own 2s
+        // HttpClient timeout; this fake source has no such cap, so the test drives it explicitly via
+        // ReleaseGate to prove the genuine block, then releases it to prove the connect resumes.
         var gate = new TaskCompletionSource();
         _relationshipSource.ReleaseGate = gate.Task;
 
         var ticket = _ticketStore.Mint(Identity(), DateTime.UtcNow);
-        var (hub, _) = BuildConnection("conn-rel-nb", ticket);
+        var (hub, _) = BuildConnection("conn-rel-await", ticket);
 
-        await hub.OnConnectedAsync();
+        var connectTask = hub.OnConnectedAsync();
 
-        Assert.IsTrue(_sessionRegistry.TryGetByConnectionId("conn-rel-nb", out _),
-            "the connect must complete without waiting on the relationship fetch");
-        Assert.IsTrue(_sends.Contains(("conn-rel-nb", ChatEvents.SessionState)),
-            "the caller receives its SessionState snapshot even while the prefetch is still in flight");
-        Assert.IsTrue(_relationshipSource.FirstFetch.IsCompleted,
-            "the prefetch was launched (the fetch started) even though the connect did not await it");
+        var stillPending = await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromMilliseconds(200)));
+        Assert.AreNotSame(connectTask, stillPending,
+            "the connect must NOT complete while the pre-assembly relationship fetch is still gated open");
 
-        gate.SetResult(); // release the background fetch so it can finish cleanly
+        gate.SetResult(); // release the gated fetch — connect resumes into assembly
+        var completed = await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.AreSame(connectTask, completed, "the connect completes once the relationship fetch resolves");
+
+        Assert.IsTrue(_sessionRegistry.TryGetByConnectionId("conn-rel-await", out _));
+        Assert.IsTrue(_sends.Contains(("conn-rel-await", ChatEvents.SessionState)));
+
+        // The fire-and-forget PrefetchRelationshipSnapshot dispatch (cache-warm + friend-presence,
+        // unchanged role) is now dispatched AFTER the awaited fetch above, so its own GetSnapshotAsync
+        // call is a warm-CACHE hit rather than a second real source fetch — give it a brief moment to
+        // finish, then assert the source was touched exactly once for the whole connect.
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        Assert.AreEqual(1, _relationshipSource.FetchCount,
+            "exactly ONE real source fetch for the whole connect — the fire-and-forget dispatch after " +
+            "the awaited fetch reuses the fresh cache instead of a duplicate wb round-trip");
     }
 }

--- a/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
@@ -585,17 +585,19 @@ public class ChatHubConnectionTests : IntegrationTestBase
     public async Task Disconnect_RemovesRegistryState()
     {
         // On disconnect the hub tears down every in-memory fan-out registry entry for the connection so
-        // nothing leaks past the socket's lifetime. FocusRegistry + MessageRateLimiter are populated by
-        // later hub methods (Tasks 9/11) and OnlineMemberRegistry is connect-seeded only when the user
-        // has channel-backed memberships (this fresh identity has none) — so seed all three directly to
-        // prove OnDisconnectedAsync removes every one.
+        // nothing leaks past the socket's lifetime. FocusRegistry is populated by a later hub method
+        // (Task 9) and OnlineMemberRegistry is connect-seeded only when the user has channel-backed
+        // memberships (this fresh identity has none) — so seed both directly to prove
+        // OnDisconnectedAsync removes every one. MessageRateLimiter is deliberately EXCLUDED from this
+        // teardown (2026-08-04 follow-up spec §1): its state is battleTag-keyed and must SURVIVE
+        // disconnect/reconnect — see MessageRateLimiterTests.HardThrottle_SurvivesReconnect_... and
+        // ChatHubSendMessageTests.Send_AutoThrottle_SurvivesReconnect_SameBattleTag for that coverage.
         var ticket = _ticketStore.Mint(Identity(), DateTime.UtcNow);
         var (hub, _) = BuildConnection("conn-1", ticket);
         await hub.OnConnectedAsync();
 
         _focusRegistry.Focus("conn-1", "chan-1", BattleTag);
         _onlineMemberRegistry.Join("chan-1", "conn-1", new MemberState(BattleTag, NotificationLevel.All, 0, ChannelType.Public));
-        _messageRateLimiter.TryAcquire("conn-1", "chan-1", DateTime.UtcNow);
 
         await hub.OnDisconnectedAsync(null);
 
@@ -603,8 +605,6 @@ public class ChatHubConnectionTests : IntegrationTestBase
             "FocusRegistry must hold no entry for the connection after disconnect");
         Assert.IsEmpty(_onlineMemberRegistry.GetMembers("chan-1"),
             "OnlineMemberRegistry must hold no entry for the connection after disconnect");
-        Assert.AreEqual(0, _messageRateLimiter.TrackedChannelCount("conn-1"),
-            "MessageRateLimiter must hold no bucket state for the connection after disconnect");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatHubConsentTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConsentTests.cs
@@ -165,7 +165,8 @@ public class ChatHubConsentTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingProxy(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubConsentTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConsentTests.cs
@@ -62,6 +62,7 @@ public class ChatHubConsentTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -108,6 +109,7 @@ public class ChatHubConsentTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _userSettings = new UserSettingsRepository(MongoClient);
         _dmInitiationTracker = new DmInitiationTracker();
@@ -151,6 +153,7 @@ public class ChatHubConsentTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
@@ -98,6 +98,7 @@ public class ChatHubDeletionTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             new MessageRateLimiter(),
+            new ReadRateLimiter(),
             TimeProvider.System,
             _channelRepository,
             new MembershipRepository(MongoClient, _channelRepository),

--- a/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
@@ -112,7 +112,8 @@ public class ChatHubDeletionTests : IntegrationTestBase
             chatAuthenticationService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         _clients.Setup(c => c.All).Returns(_mockAllProxy.Object);
         _clients.Setup(c => c.AllExcept(It.IsAny<System.Collections.Generic.IReadOnlyList<string>>())).Returns(_mockAllExceptProxy.Object);

--- a/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
@@ -127,7 +127,8 @@ public class ChatHubDmFocusTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
         var context = new Mock<HubCallerContext>();

--- a/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
@@ -61,6 +61,7 @@ public class ChatHubDmFocusTests : IntegrationTestBase
     private ChannelRepository _channelRepository;
     private MembershipRepository _membershipRepository;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
 
@@ -90,6 +91,7 @@ public class ChatHubDmFocusTests : IntegrationTestBase
         _channelRepository = new ChannelRepository(MongoClient);
         _membershipRepository = new MembershipRepository(MongoClient, _channelRepository);
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _assembler = new SessionStateAssembler(
             _membershipRepository,
@@ -113,6 +115,7 @@ public class ChatHubDmFocusTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -55,6 +55,7 @@ public class ChatHubDmSendTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -96,6 +97,7 @@ public class ChatHubDmSendTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _userSettings = new UserSettingsRepository(MongoClient);
         _dmInitiationTracker = new DmInitiationTracker();
@@ -139,6 +141,7 @@ public class ChatHubDmSendTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -153,7 +153,8 @@ public class ChatHubDmSendTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingProxy(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -492,6 +492,53 @@ public class ChatHubDmSendTests : IntegrationTestBase
         Assert.That(_harness.SignalCount(RecipientConn, ChatEvents.ChannelAdded), Is.EqualTo(1), "ChannelAdded fires ONCE (first materialization only)");
     }
 
+    [Test]
+    public async Task DmSend_OnlineRecipient_WhoseRegistryLacksTheShell_GetsReAnnouncedChannelAdded()
+    {
+        // An ESTABLISHED conversation: both durable membership rows exist, but the recipient's bounded
+        // connect snapshot excluded this older shell — so their OnlineMemberRegistry does NOT hold it.
+        var channel = await CreateDm(DmRequestState.Accepted);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = channel.Id,
+            BattleTag = Recipient,
+            NotificationLevel = NotificationLevel.All,
+            JoinedAt = Now,
+        });
+        SeedMember(InitiatorConn, Initiator, channel.Id);   // sender: session + registry seed
+        RegisterSession(RecipientConn, Recipient);          // recipient: ONLINE but NOT registry-seeded
+        var hub = BuildHub(InitiatorConn);
+
+        var result = await hub.SendMessage(channel.Id, "are you still there?");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        var added = _harness.PayloadFor(RecipientConn, ChatEvents.ChannelAdded) as ChannelAddedDto;
+        Assert.That(added, Is.Not.Null, "a snapshot-excluded shell is re-announced when a message arrives");
+        Assert.That(added.Focus, Is.False, "re-announce never auto-opens the DM");
+        Assert.That(_onlineMemberRegistry.IsMember(RecipientConn, channel.Id), Is.True,
+            "the re-announce re-seeds the recipient's registry so fan-out reaches them from this message on");
+    }
+
+    [Test]
+    public async Task DmSend_OnlineRecipient_AlreadySeeded_GetsNoReAnnounce()
+    {
+        var channel = await CreateDm(DmRequestState.Accepted);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = channel.Id,
+            BattleTag = Recipient,
+            NotificationLevel = NotificationLevel.All,
+            JoinedAt = Now,
+        });
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        SeedMember(RecipientConn, Recipient, channel.Id);   // recipient registry ALREADY holds the shell
+
+        await BuildHub(InitiatorConn).SendMessage(channel.Id, "ordinary message");
+
+        Assert.That(_harness.SignalCount(RecipientConn, ChatEvents.ChannelAdded), Is.EqualTo(0),
+            "no ChannelAdded spam on ordinary messages to an already-seeded recipient");
+    }
+
     // ------------------------------------------------------------------------------------------------
     // Shell-expiry maintenance (the C1-amendment gap closed) + regression pins
     // ------------------------------------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
@@ -109,7 +109,8 @@ public class ChatHubFocusTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
@@ -49,6 +49,7 @@ public class ChatHubFocusTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
 
@@ -72,6 +73,7 @@ public class ChatHubFocusTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _assembler = new SessionStateAssembler(
             _membershipRepository,
@@ -95,6 +97,7 @@ public class ChatHubFocusTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             TimeProvider.System,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -70,6 +70,7 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
@@ -104,6 +105,7 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _presenceInterestRegistry = new PresenceInterestRegistry();
         _userDirectory = new UserDirectoryRepository(MongoClient);
@@ -164,6 +166,7 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -178,7 +178,8 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             _presenceInterestRegistry,
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -398,8 +398,8 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
     {
         // Follow-up spec §6: the connect path now AWAITS one relationship fetch BEFORE assembly (the
         // bounded 1:1-DM snapshot needs the block list) and hands that ALREADY-RESOLVED snapshot straight
-        // to the fire-and-forget PrefetchRelationshipSnapshot dispatch, which no longer calls
-        // GetSnapshotAsync itself at all (see ChatHub.PrefetchRelationshipSnapshot — a duplicate wb
+        // to the fire-and-forget PushFriendPresenceFromSnapshot dispatch, which no longer calls
+        // GetSnapshotAsync itself at all (see ChatHub.PushFriendPresenceFromSnapshot — a duplicate wb
         // round-trip there would double load on wb during exactly the outage where it's least welcome).
         // That means the relationship SOURCE can no longer be gated to distinguish "connect awaits it" from
         // "the push rides behind it" — there is nothing left downstream of connect's own await that

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -40,15 +40,18 @@ namespace W3ChampionsChatService.Tests;
 /// friend-list control.
 /// </para>
 /// <para>
-/// DETERMINISM: the connect/disconnect friend push rides a FIRE-AND-FORGET background task (never
-/// awaited by <c>OnConnectedAsync</c>/<c>OnDisconnectedAsync</c>), so most tests set
-/// <see cref="FakeRelationshipSource.ReleaseGate"/> to <see cref="Task.CompletedTask"/> (already
-/// completed) — this removes the fetch's internal <c>await Task.Yield()</c> suspension entirely, so the
-/// WHOLE background chain (fetch → cache publish → friend push) runs SYNCHRONOUSLY to completion as part
-/// of the discarded call, observable immediately after <c>Connect</c>/<c>OnDisconnectedAsync</c> returns —
-/// no sleeps, no polling. The two "rides the existing task, no new await" tests deliberately do the
-/// OPPOSITE: they hold an UNRELEASED gate to force genuine asynchrony, proving the connect/disconnect path
-/// itself completes without waiting on it.
+/// DETERMINISM: the disconnect-side friend push rides a FIRE-AND-FORGET background task (never awaited
+/// by <c>OnDisconnectedAsync</c>), so most tests set <see cref="FakeRelationshipSource.ReleaseGate"/> to
+/// <see cref="Task.CompletedTask"/> (already completed) — this removes the fetch's internal
+/// <c>await Task.Yield()</c> suspension entirely, so the WHOLE background chain (fetch → cache publish →
+/// friend push) runs SYNCHRONOUSLY to completion as part of the discarded call, observable immediately
+/// after <c>Connect</c>/<c>OnDisconnectedAsync</c> returns — no sleeps, no polling. The disconnect-side
+/// "rides the existing task, no new await" test deliberately does the OPPOSITE: it holds an UNRELEASED
+/// gate to force genuine asynchrony, proving the disconnect path itself completes without waiting on it.
+/// Follow-up spec §6 changed the CONNECT side of this story: the connect path now AWAITS one
+/// relationship fetch before assembly (the bounded 1:1-DM snapshot needs the block list), so a held-open
+/// gate now blocks connect itself rather than being invisible to it — see
+/// <c>Connect_AwaitsRelationshipFetch_ThenFriendPushRidesTheWarmCache</c>, which pins that new contract.
 /// </para>
 /// </summary>
 public class ChatHubFriendPresenceTests : IntegrationTestBase
@@ -388,8 +391,15 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
     // ================================================================================================
 
     [Test]
-    public async Task Connect_PushRidesPrefetchTask_NoAwaitOnConnectPath()
+    public async Task Connect_AwaitsRelationshipFetch_ThenFriendPushRidesTheWarmCache()
     {
+        // Follow-up spec §6: the connect path now AWAITS one relationship fetch BEFORE assembly (the
+        // bounded 1:1-DM snapshot needs the block list) — a genuine change from the pre-§6 world where
+        // NOTHING on the connect path ever waited on a relationship fetch (the friend push rode a
+        // fire-and-forget task the connect path never touched). A held-open gate now blocks CONNECT
+        // ITSELF. Once released, the awaited fetch resolves and caches, and the SEPARATE fire-and-forget
+        // PrefetchRelationshipSnapshot dispatch reuses that warm cache to deliver the friend push —
+        // still without the connect path itself awaiting the push.
         const string SubjectTag = "Subject#1";
         const string FriendTag = "Friend#2";
         _friends[SubjectTag] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { FriendTag };
@@ -400,18 +410,21 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
         _relationshipSource.ReleaseGate = gate.Task; // hold the connecting user's fetch open indefinitely
 
         var subjectHub = BuildHub("conn-subject", _ticketStore.Mint(Identity(SubjectTag), DateTime.UtcNow));
-        await subjectHub.OnConnectedAsync(); // must return WITHOUT waiting on the held gate
+        var connectTask = subjectHub.OnConnectedAsync();
 
-        Assert.That(_sessionRegistry.TryGetByConnectionId("conn-subject", out _), Is.True,
-            "connect completed even though the relationship fetch (and the friend push riding it) is still stuck on the gate");
+        var stillPending = await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromMilliseconds(200)));
+        Assert.That(stillPending, Is.Not.SameAs(connectTask),
+            "connect must NOT complete while the pre-assembly relationship fetch is still gated open");
         Assert.That(FriendPresenceFor("conn-friend"), Is.Empty,
-            "the friend push has NOT happened yet — it is still blocked behind the fetch gate");
+            "the friend push has NOT happened yet — it rides behind the same gated fetch");
 
-        gate.SetResult(); // release the background fetch — the friend push rides it to completion
+        gate.SetResult(); // release — the awaited fetch resolves, then the fire-and-forget push rides the warm cache
+        var completed = await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromSeconds(5)));
+        Assert.That(completed, Is.SameAs(connectTask), "connect completes once the relationship fetch resolves");
 
+        Assert.That(_sessionRegistry.TryGetByConnectionId("conn-subject", out _), Is.True);
         Assert.That(FriendPresenceFor("conn-friend").Count(p => p.BattleTag == SubjectTag && p.Online), Is.EqualTo(1),
-            "once the fire-and-forget prefetch completes, the SAME background task delivers the friend push — " +
-            "proving it rides the existing task rather than adding a new await on the connect path");
+            "the friend push lands once the connect path's own gated fetch (now required) resolves");
     }
 
     // ================================================================================================

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -49,9 +49,12 @@ namespace W3ChampionsChatService.Tests;
 /// "rides the existing task, no new await" test deliberately does the OPPOSITE: it holds an UNRELEASED
 /// gate to force genuine asynchrony, proving the disconnect path itself completes without waiting on it.
 /// Follow-up spec §6 changed the CONNECT side of this story: the connect path now AWAITS one
-/// relationship fetch before assembly (the bounded 1:1-DM snapshot needs the block list), so a held-open
-/// gate now blocks connect itself rather than being invisible to it — see
-/// <c>Connect_AwaitsRelationshipFetch_ThenFriendPushRidesTheWarmCache</c>, which pins that new contract.
+/// relationship fetch before assembly (the bounded 1:1-DM snapshot needs the block list) and hands that
+/// resolved snapshot straight to the fire-and-forget dispatch, which never touches the relationship SOURCE
+/// itself anymore — so a gate on the source can no longer distinguish "connect awaits it" from "the push
+/// rides behind it". <c>Connect_AwaitsRelationshipFetch_ThenFriendPushRidesTheWarmCache</c> instead gates
+/// the push's own SignalR send (<see cref="HubPushCaptureHarness.GateSend"/>) to pin the still-true
+/// contract: connect never awaits the friend push.
 /// </para>
 /// </summary>
 public class ChatHubFriendPresenceTests : IntegrationTestBase
@@ -394,37 +397,39 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
     public async Task Connect_AwaitsRelationshipFetch_ThenFriendPushRidesTheWarmCache()
     {
         // Follow-up spec §6: the connect path now AWAITS one relationship fetch BEFORE assembly (the
-        // bounded 1:1-DM snapshot needs the block list) — a genuine change from the pre-§6 world where
-        // NOTHING on the connect path ever waited on a relationship fetch (the friend push rode a
-        // fire-and-forget task the connect path never touched). A held-open gate now blocks CONNECT
-        // ITSELF. Once released, the awaited fetch resolves and caches, and the SEPARATE fire-and-forget
-        // PrefetchRelationshipSnapshot dispatch reuses that warm cache to deliver the friend push —
-        // still without the connect path itself awaiting the push.
+        // bounded 1:1-DM snapshot needs the block list) and hands that ALREADY-RESOLVED snapshot straight
+        // to the fire-and-forget PrefetchRelationshipSnapshot dispatch, which no longer calls
+        // GetSnapshotAsync itself at all (see ChatHub.PrefetchRelationshipSnapshot — a duplicate wb
+        // round-trip there would double load on wb during exactly the outage where it's least welcome).
+        // That means the relationship SOURCE can no longer be gated to distinguish "connect awaits it" from
+        // "the push rides behind it" — there is nothing left downstream of connect's own await that
+        // touches the source. So this test gates the PUSH'S OWN SignalR send instead (HubPushCaptureHarness
+        // .GateSend) and proves connect completes and returns while that send is STILL in flight — i.e.
+        // genuinely fire-and-forget, not merely fast enough to look that way.
         const string SubjectTag = "Subject#1";
         const string FriendTag = "Friend#2";
         _friends[SubjectTag] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { FriendTag };
 
         await Connect("conn-friend", FriendTag);
 
-        var gate = new TaskCompletionSource();
-        _relationshipSource.ReleaseGate = gate.Task; // hold the connecting user's fetch open indefinitely
+        var pushGate = new TaskCompletionSource();
+        _harness.GateSend("conn-friend", pushGate.Task); // hold the friend-presence send open indefinitely
 
         var subjectHub = BuildHub("conn-subject", _ticketStore.Mint(Identity(SubjectTag), DateTime.UtcNow));
         var connectTask = subjectHub.OnConnectedAsync();
 
-        var stillPending = await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromMilliseconds(200)));
-        Assert.That(stillPending, Is.Not.SameAs(connectTask),
-            "connect must NOT complete while the pre-assembly relationship fetch is still gated open");
-        Assert.That(FriendPresenceFor("conn-friend"), Is.Empty,
-            "the friend push has NOT happened yet — it rides behind the same gated fetch");
-
-        gate.SetResult(); // release — the awaited fetch resolves, then the fire-and-forget push rides the warm cache
         var completed = await Task.WhenAny(connectTask, Task.Delay(TimeSpan.FromSeconds(5)));
-        Assert.That(completed, Is.SameAs(connectTask), "connect completes once the relationship fetch resolves");
-
+        Assert.That(completed, Is.SameAs(connectTask),
+            "connect must complete WITHOUT waiting on the friend-presence send — it is fire-and-forget");
         Assert.That(_sessionRegistry.TryGetByConnectionId("conn-subject", out _), Is.True);
+        Assert.That(FriendPresenceFor("conn-friend"), Is.Empty,
+            "the friend-presence send is still gated open at the moment connect returns — proof it was " +
+            "never awaited by the connect path, not just delivered quickly");
+
+        pushGate.SetResult(); // release — the in-flight send completes
+        await Task.Delay(TimeSpan.FromMilliseconds(50)); // let the fire-and-forget chain finish recording
         Assert.That(FriendPresenceFor("conn-friend").Count(p => p.BattleTag == SubjectTag && p.Online), Is.EqualTo(1),
-            "the friend push lands once the connect path's own gated fetch (now required) resolves");
+            "the friend push lands once its gated send is released");
     }
 
     // ================================================================================================

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -53,6 +53,7 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -91,6 +92,7 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _assembler = new SessionStateAssembler(
@@ -122,6 +124,7 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,
@@ -442,6 +445,61 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
             "no usable relationship snapshot at all must fail closed rather than risk an unfiltered page");
         Assert.IsNull(page.Conversations);
         Assert.AreEqual(ChatLimits.RelationshipRetryAfterSeconds, page.RetryAfterSeconds);
+    }
+
+    // ---------------------------------------------------------------------
+    // 2026-08-05 PR36 feedback, Part 3: the shared ReadRateLimiter guards GetConversations FIRST THING —
+    // before the cursor validation, the clamp, the relationship-snapshot fetch, and every Mongo read.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task GetConversations_OverReadLimit_ReturnsThrottled_WithRetryAfter()
+    {
+        var shell = await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-5));
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        // Exhaust the shared per-battleTag read budget directly on the SAME limiter instance the hub
+        // was built with — this is the ordering unit-test style the brief allows when the hub harness
+        // has no Mongo-call mocking: the limiter denial must fire before the method does ANY other work.
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Throttled, page.Code, "over the shared read budget must be rejected");
+        Assert.IsNull(page.Conversations, "a Throttled reject must never carry a payload");
+        Assert.IsNotNull(page.RetryAfterSeconds);
+        Assert.Greater(page.RetryAfterSeconds.Value, 0);
+
+        // Proves the denial fired BEFORE any Mongo work: a successful call would have seeded the caller's
+        // OnlineMemberRegistry with the pre-existing shell (step 7 of the method) — it was never reached.
+        Assert.IsFalse(_onlineMemberRegistry.IsMember("conn-1", shell.Id),
+            "a denied call must never reach the registry-seeding step, proving no Mongo/membership work ran");
+    }
+
+    [Test]
+    public async Task GetConversations_ReadLimit_IsIndependentPerBattleTag()
+    {
+        await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-5));
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+        var throttled = await hub.GetConversations(null, null, limit: 10);
+        Assert.AreEqual(ChatResultCode.Throttled, throttled.Code, "BattleTag's own budget is spent");
+
+        // A different caller (own connection + own session) is completely unaffected.
+        const string OtherCaller = "wolf#456";
+        RegisterSession("conn-2", OtherCaller);
+        var otherHub = BuildHub("conn-2");
+        var unaffected = await otherHub.GetConversations(null, null, limit: 10);
+        Assert.AreEqual(ChatResultCode.Ok, unaffected.Code, "a distinct battleTag has its own independent read budget");
     }
 
     // ---------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -136,7 +136,8 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -528,13 +528,14 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
         Assert.AreEqual(ChatResultCode.Ok, unaffected.Code, "a distinct battleTag has its own independent read budget");
     }
 
-    // Fix round 1, finding F4: proves the CROSS-METHOD sharing claim a limiter-level test cannot — a
-    // real GetConversations call and a real GetMessages call, on the SAME hub instance, drawing from the
-    // SAME injected ReadRateLimiter singleton. A second-instance mis-wiring in Startup.cs (each method
-    // getting its own limiter) would still pass every OTHER read-limit test in this file, since those
-    // only ever call TryAcquire directly on the test's own _readRateLimiter field — but it would fail
-    // this one, because GetMessages would then find an independent, still-full budget instead of the one
-    // GetConversations just drained.
+    // Fix round 1, finding F4: proves that a real GetConversations call and a real GetMessages call, on
+    // the SAME hub instance, draw from the SAME instance of the ReadRateLimiter this test injected via
+    // BuildHub — i.e. that GetConversations and GetMessages share ONE limiter reference inside ChatHub,
+    // not two independent ones. It does NOT — and cannot — detect a Startup.cs mis-wiring (e.g. each
+    // method's call site somehow resolving its own separate limiter instance from DI): BuildHub always
+    // constructs the hub with the test's own single _readRateLimiter field, so a Startup-level singleton
+    // regression would still pass this test unchanged. That composition-root guarantee is
+    // ReadRateLimiter_IsSingleton_SharedAcrossResolutions in StartupDependencyInjectionTests.cs.
     [Test]
     public async Task GetConversations_ReadLimit_SharedBudget_RealCallDrainsGetMessagesBudget()
     {

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -269,13 +269,19 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
         await _channelRepository.Insert(group);
         await _membershipRepository.Insert(new ChannelMembership
         {
-            ChannelId = group.Id, BattleTag = BattleTag, NotificationLevel = NotificationLevel.All, JoinedAt = Now,
+            ChannelId = group.Id,
+            BattleTag = BattleTag,
+            NotificationLevel = NotificationLevel.All,
+            JoinedAt = Now,
         });
         var pub = new ChatChannel { Type = ChannelType.Public, Name = "general", NormalizedName = "general", LastMessageAt = Now };
         await _channelRepository.Insert(pub);
         await _membershipRepository.Insert(new ChannelMembership
         {
-            ChannelId = pub.Id, BattleTag = BattleTag, NotificationLevel = NotificationLevel.All, JoinedAt = Now,
+            ChannelId = pub.Id,
+            BattleTag = BattleTag,
+            NotificationLevel = NotificationLevel.All,
+            JoinedAt = Now,
         });
         RegisterSession("conn-1", BattleTag);
         var hub = BuildHub("conn-1");

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -510,4 +510,90 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
         CollectionAssert.DoesNotContain(ids, otherChannel.Id,
             "GetConversations must only ever page the CALLER's own memberships");
     }
+
+    // ---------------------------------------------------------------------
+    // Final-review fix round — finding 1 (Important): pins the CROSS-REPO seam between chat-service's
+    // bounded connect snapshot (SessionStateAssembler.SelectSnapshotMemberships, which the launcher-e
+    // repo renders as its initial DM conversation list) and this hub's GetConversations cursor
+    // pagination (the launcher's "load more" scroll continuation). The launcher derives its first
+    // "load more" cursor from the LAST accepted shell it rendered from the snapshot — i.e. the
+    // snapshot's 30th-newest accepted shell (ChatLimits.DmSnapshotRecentConversations == 30). This test
+    // proves that specific handoff is gapless and non-overlapping: every accepted 1:1 conversation the
+    // snapshot's top-30 recency window excludes comes back, exactly once, on the very first
+    // GetConversations page taken from that cursor — the exact contract the launcher's initial-list ->
+    // infinite-scroll transition depends on.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task Handoff_SnapshotTopWindow_PlusFirstConversationsPage_CoversEveryAcceptedShell_NoGapNoDuplicate()
+    {
+        var t0 = Now;
+
+        // >= 31 accepted 1:1 shells, all fully-read (LastSeq == LastReadSeq == 0) so none of them can be
+        // kept via the snapshot's rule (e) unread carve-out — a clean, deterministic top-30/rest split
+        // purely by recency. 35 gives a comfortable margin over the required >= 31.
+        const int freshCount = 35;
+        var freshIds = new List<string>();
+        for (var i = 0; i < freshCount; i++)
+        {
+            var shell = await CreateDmShell($"{OtherPrefix}{i}#1", t0.AddMinutes(i));
+            freshIds.Add(shell.Id);
+        }
+
+        // Realism extras — a real connect snapshot is never JUST the top-30 recency window; it also
+        // mixes in the OTHER SelectSnapshotMemberships keep-rules. None of these three belong to the
+        // tracked freshIds set the coverage assertion below checks.
+        var pending = await CreateDmShell($"{OtherPrefix}pending#1", t0.AddMinutes(-1),
+            requestState: DmRequestState.Pending, initiatedBy: $"{OtherPrefix}pending#1");
+        var blockedCounterpart = $"{OtherPrefix}blocked#1";
+        _blocked[BattleTag] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { blockedCounterpart };
+        var blocked = await CreateDmShell(blockedCounterpart, t0.AddYears(-2));
+        var olderUnread = await CreateDmShell($"{OtherPrefix}unread-old#1", t0.AddDays(-100), lastSeq: 5, lastReadSeq: 1);
+
+        RegisterSession("conn-1", BattleTag);
+
+        // 1. Run the SAME assembler + relationship provider the real connect path uses to build the
+        // bounded snapshot.
+        var relationshipSnapshot = await _relationshipProvider.GetSnapshotAsync(BattleTag);
+        var identity = new W3CUserAuthentication { BattleTag = BattleTag, Name = "peter" };
+        var chatUser = new ChatUser(BattleTag, false, "peter", new ProfilePicture(), null, null);
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", Now, chatUser, relationshipSnapshot);
+
+        var snapshotAccepted = dto.Channels
+            .Where(c => c.Channel.Type == ChannelType.Dm && c.Channel.RequestState == DmRequestState.Accepted)
+            .OrderByDescending(c => c.Channel.LastMessageAt)
+            .ThenByDescending(c => c.Channel.Id, StringComparer.Ordinal)
+            .ToList();
+
+        // Sanity check on the scenario itself: top-30 recency window, PLUS the one rule-(e) unread
+        // carve-out (olderUnread), PLUS the rule-(c) blocked-but-still-Accepted shell (blocked) — both
+        // of which sort to the very bottom (older than every fresh shell), so neither one can land at
+        // index 29 and disturb the cursor derivation below.
+        Assert.AreEqual(ChatLimits.DmSnapshotRecentConversations + 2, snapshotAccepted.Count);
+
+        // 2. Derive the cursor EXACTLY the way the launcher does: from the 30th-newest accepted shell.
+        var cursorShell = snapshotAccepted[ChatLimits.DmSnapshotRecentConversations - 1].Channel;
+
+        // 3. The launcher's own first "load more" call.
+        var hub = BuildHub("conn-1");
+        var page = await hub.GetConversations(cursorShell.LastMessageAt, cursorShell.Id, limit: ChatLimits.ConversationsPageSize);
+        Assert.AreEqual(ChatResultCode.Ok, page.Code);
+
+        // 4. Coverage: every one of the >= 31 tracked fresh shells must appear in EXACTLY ONE of
+        // (snapshot, page) — no gap, no duplicate.
+        var snapshotFreshIds = snapshotAccepted.Select(c => c.Channel.Id).Where(freshIds.Contains).ToList();
+        var pageFreshIds = page.Conversations.Select(c => c.Channel.Id).Where(freshIds.Contains).ToList();
+
+        CollectionAssert.IsNotEmpty(pageFreshIds, "the first page must actually carry some of the shells the snapshot's top-30 window excluded");
+        CollectionAssert.AllItemsAreUnique(snapshotFreshIds.Concat(pageFreshIds).ToList(),
+            "no tracked shell may appear in BOTH the snapshot and the first page — that would double-render a conversation");
+        CollectionAssert.AreEquivalent(freshIds, snapshotFreshIds.Concat(pageFreshIds).ToList(),
+            "the snapshot's top-30 window plus the first GetConversations page must cover every accepted shell exactly once — no gap");
+
+        // The pending/blocked realism extras stay exactly where the OTHER §6/GetConversations tests
+        // already pin them — never in the paged "load more" result.
+        var pageIds = page.Conversations.Select(c => c.Channel.Id).ToList();
+        CollectionAssert.DoesNotContain(pageIds, pending.Id);
+        CollectionAssert.DoesNotContain(pageIds, blocked.Id);
+    }
 }

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -480,6 +480,32 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
             "a denied call must never reach the registry-seeding step, proving no Mongo/membership work ran");
     }
 
+    // Fix round 1, finding F2: the test above proves ordering relative to Mongo work, but a mutant that
+    // moved the limiter check past ONLY the cursor-pair validation (step 3, ChatHub.Dm.cs) — while still
+    // staying before every Mongo call — would slip through it undetected. This tripwire pins the limiter
+    // strictly before that validation too: a malformed one-half cursor from an over-budget caller would
+    // normally throw HubException at step 3; if the limiter runs FIRST THING as required, the denial
+    // fires before the cursor is ever inspected, so the call returns Throttled instead of throwing.
+    [Test]
+    public async Task GetConversations_OverReadLimit_WithMalformedCursor_ReturnsThrottled_NotHubException()
+    {
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+
+        // Exactly one cursor half supplied — malformed, and normally a client-bug HubException (step 3).
+        // If the limiter ever slipped below that validation, this line throws and the test fails.
+        var page = await hub.GetConversations(cursorLastMessageAt: Now, cursorChannelId: null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Throttled, page.Code,
+            "the read rate limit must run FIRST THING — strictly before the cursor-pair validation — so a " +
+            "malformed cursor from an over-budget caller returns Throttled rather than throwing HubException");
+    }
+
     [Test]
     public async Task GetConversations_ReadLimit_IsIndependentPerBattleTag()
     {

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -528,6 +528,40 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
         Assert.AreEqual(ChatResultCode.Ok, unaffected.Code, "a distinct battleTag has its own independent read budget");
     }
 
+    // Fix round 1, finding F4: proves the CROSS-METHOD sharing claim a limiter-level test cannot — a
+    // real GetConversations call and a real GetMessages call, on the SAME hub instance, drawing from the
+    // SAME injected ReadRateLimiter singleton. A second-instance mis-wiring in Startup.cs (each method
+    // getting its own limiter) would still pass every OTHER read-limit test in this file, since those
+    // only ever call TryAcquire directly on the test's own _readRateLimiter field — but it would fail
+    // this one, because GetMessages would then find an independent, still-full budget instead of the one
+    // GetConversations just drained.
+    [Test]
+    public async Task GetConversations_ReadLimit_SharedBudget_RealCallDrainsGetMessagesBudget()
+    {
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        // Spend all but one token directly, then make ONE real GetConversations call that consumes the
+        // very last token in the shared budget. No DM shell needs to exist — GetConversations returns Ok
+        // with an empty page, same as GetConversations_ReadLimit_IsIndependentPerBattleTag's "unaffected"
+        // case above.
+        for (var i = 0; i < ChatLimits.ReadBurst - 1; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+        var conversations = await hub.GetConversations(null, null, limit: 10);
+        Assert.AreEqual(ChatResultCode.Ok, conversations.Code,
+            "the last token in the shared budget is consumed by this real GetConversations call");
+
+        // A real GetMessages call, right after, must be denied. The channelId doesn't need to resolve to
+        // anything real: the limiter (guarded FIRST THING in GetMessages too, per finding F5) denies
+        // before the membership/channel-load steps are ever reached.
+        var messages = await hub.GetMessages("any-channel-id", beforeSeq: null, aroundSeq: null, limit: 10);
+        Assert.AreEqual(ChatResultCode.Throttled, messages.Code,
+            "GetMessages must be denied by the budget GetConversations just exhausted, proving both hub " +
+            "methods share ONE ReadRateLimiter instance");
+    }
+
     // ---------------------------------------------------------------------
     // Task 8 fix round — finding 4 (minor): a null-stamped LastMessageAt is data-impossible in
     // production (FindOrCreateDm always stamps it) but would otherwise dead-end the client's wire

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -16,6 +16,7 @@ using W3ChampionsChatService.Memberships;
 using W3ChampionsChatService.Messages;
 using W3ChampionsChatService.Mutes;
 using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Relationships;
 using W3ChampionsChatService.Sessions;
 using W3ChampionsChatService.Users;
 
@@ -26,7 +27,10 @@ namespace W3ChampionsChatService.Tests;
 /// caller's OLDER 1:1 Dm shells (the ones the bounded connect snapshot, Task 6, excludes), newest-first
 /// by (LastMessageAt, ChannelId). Direct-hub-instantiation idiom; scaffolding copied VERBATIM from
 /// <see cref="ChatHubGetMessagesTests"/> (same fields, same <see cref="IntegrationTestBase"/> base, same
-/// <c>BuildHub</c> ctor list, same <c>FixedNow</c>/<c>_time</c>).
+/// <c>BuildHub</c> ctor list, same <c>FixedNow</c>/<c>_time</c>), EXTENDED (Task 8 fix round) with a REAL
+/// <see cref="RelationshipProvider"/> over a <see cref="FakeRelationshipSource"/> (mirrors
+/// <see cref="ChatHubDmSendTests"/>) so blocked-shell exclusion and the relationship-outage fail-closed
+/// path are exercisable, instead of the throwaway <see cref="RelationshipProviderTestFactory"/>.
 /// </summary>
 public class ChatHubGetConversationsTests : IntegrationTestBase
 {
@@ -54,12 +58,20 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
     private FanOutEngine _fanOutEngine;
     private FakeTimeProvider _time;
 
+    // Task 8 fix round: per-tag blocked lists, read by the fake source's snapshot factory
+    // (OrdinalIgnoreCase) — mirrors ChatHubDmSendTests. Keyed by the CALLER's own battleTag (the block
+    // check is "does the caller's snapshot list this counterpart as blocked").
+    private readonly Dictionary<string, HashSet<string>> _blocked = new(StringComparer.OrdinalIgnoreCase);
+    private FakeRelationshipSource _relationshipSource;
+    private RelationshipProvider _relationshipProvider;
+
     private DateTime Now => _time.GetUtcNow().UtcDateTime;
 
     [SetUp]
     public void SetupBeforeEach()
     {
         _time = new FakeTimeProvider(FixedNow);
+        _blocked.Clear();
 
         _connectionMapping = new ConnectionMapping();
         _userDirectory = new UserDirectoryRepository(MongoClient);
@@ -89,6 +101,13 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
             _onlineMemberRegistry,
             _connectionMapping,
             new MentionInboxRepository(MongoClient));
+
+        _relationshipSource = new FakeRelationshipSource((tag, now) => new RelationshipSnapshot(
+            tag,
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            _blocked.TryGetValue(tag, out var b) ? b : new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            now));
+        _relationshipProvider = new RelationshipProvider(_relationshipSource, _time);
     }
 
     private ChatHub BuildHub(string connectionId)
@@ -111,7 +130,7 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
             _fanOutEngine,
             ViewersAccumulatorTestFactory.CreateIgnored(),
             new NoOpMentionInboxCleaner(),
-            RelationshipProviderTestFactory.CreateIgnored(),
+            _relationshipProvider,
             new UserSettingsRepository(MongoClient),
             new DmInitiationTracker(),
             _authService.Object,
@@ -135,16 +154,19 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
             new W3CUserAuthentication { BattleTag = battleTag, Name = battleTag.Split('#')[0] },
             null);
 
-    // One ACCEPTED 1:1 shell (viewer + counterpart) with the viewer's own membership row.
+    // One 1:1 shell (viewer + counterpart) with the viewer's own membership row. Defaults to an
+    // ACCEPTED shell initiated by the viewer; Task 8 fix round extends this with requestState/
+    // initiatedBy so pending-shell exclusion (both directions) is testable without a second helper.
     private async Task<ChatChannel> CreateDmShell(
-        string counterpart, DateTime lastMessageAt, long lastSeq = 0, long lastReadSeq = 0)
+        string counterpart, DateTime lastMessageAt, long lastSeq = 0, long lastReadSeq = 0,
+        DmRequestState requestState = DmRequestState.Accepted, string initiatedBy = null)
     {
         var channel = new ChatChannel
         {
             Type = ChannelType.Dm,
             PairKey = DmPairKey.For(BattleTag, counterpart),
-            RequestState = DmRequestState.Accepted,
-            RequestInitiatedBy = BattleTag,
+            RequestState = requestState,
+            RequestInitiatedBy = initiatedBy ?? BattleTag,
             LastSeq = lastSeq,
             LastMessageAt = lastMessageAt,
         };
@@ -298,5 +320,188 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
         var hub = BuildHub("conn-ghost");
         var page = await hub.GetConversations(null, null, limit: 10);
         Assert.AreEqual(ChatResultCode.PermissionDenied, page.Code);
+        Assert.IsNull(page.Conversations, "a PermissionDenied reject must never carry a payload");
+    }
+
+    // ---------------------------------------------------------------------
+    // Task 8 fix round — finding 1 (CRITICAL): pending shells must never page in. Pending requests ride
+    // the connect snapshot + request tray ONLY, in EITHER direction.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task GetConversations_ExcludesPendingShells_BothDirections()
+    {
+        var incoming = await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-120),
+            requestState: DmRequestState.Pending, initiatedBy: $"{OtherPrefix}0#1");
+        var outgoing = await CreateDmShell($"{OtherPrefix}1#1", Now.AddMinutes(-110),
+            requestState: DmRequestState.Pending, initiatedBy: BattleTag);
+        var accepted = await CreateDmShell($"{OtherPrefix}2#1", Now.AddMinutes(-100));
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Ok, page.Code);
+        var ids = page.Conversations.Select(c => c.Channel.Id).ToList();
+        CollectionAssert.DoesNotContain(ids, incoming.Id,
+            "an incoming pending request rides the tray only, never GetConversations");
+        CollectionAssert.DoesNotContain(ids, outgoing.Id,
+            "a caller-initiated pending request rides the tray only, never GetConversations");
+        CollectionAssert.Contains(ids, accepted.Id, "an accepted shell still pages normally");
+    }
+
+    // ---------------------------------------------------------------------
+    // Task 8 fix round — finding 2 (CRITICAL): a blocked counterpart's shell stays Blocked-tray-only
+    // (Task 6) — it must never page in as an ordinary, live conversation. A relationship-provider outage
+    // must fail closed (Throttled) rather than serve an unfiltered page.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task GetConversations_ExcludesBlockedCounterpartShells()
+    {
+        var blockedCounterpart = $"{OtherPrefix}0#1";
+        var unblockedCounterpart = $"{OtherPrefix}1#1";
+        _blocked[BattleTag] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { blockedCounterpart };
+        var blockedShell = await CreateDmShell(blockedCounterpart, Now.AddMonths(-24));
+        var unblockedShell = await CreateDmShell(unblockedCounterpart, Now.AddMonths(-24));
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Ok, page.Code);
+        var ids = page.Conversations.Select(c => c.Channel.Id).ToList();
+        CollectionAssert.DoesNotContain(ids, blockedShell.Id,
+            "a blocked counterpart's shell stays Blocked-tray-only (Task 6) — never pages in as an ordinary conversation");
+        CollectionAssert.Contains(ids, unblockedShell.Id, "an unblocked sibling shell still pages normally");
+    }
+
+    [Test]
+    public async Task GetConversations_RelationshipProviderUnavailable_ReturnsThrottled()
+    {
+        await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-5));
+        RegisterSession("conn-1", BattleTag);
+        _relationshipSource.ShouldThrow = true;
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Throttled, page.Code,
+            "no usable relationship snapshot at all must fail closed rather than risk an unfiltered page");
+        Assert.IsNull(page.Conversations);
+        Assert.AreEqual(ChatLimits.RelationshipRetryAfterSeconds, page.RetryAfterSeconds);
+    }
+
+    // ---------------------------------------------------------------------
+    // Task 8 fix round — finding 4 (minor): a null-stamped LastMessageAt is data-impossible in
+    // production (FindOrCreateDm always stamps it) but would otherwise dead-end the client's wire
+    // cursor — such a shell must be excluded from the page.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task GetConversations_ExcludesNullLastMessageAtShells()
+    {
+        var legacyChannel = new ChatChannel
+        {
+            Type = ChannelType.Dm,
+            PairKey = DmPairKey.For(BattleTag, $"{OtherPrefix}legacy#1"),
+            RequestState = DmRequestState.Accepted,
+            RequestInitiatedBy = BattleTag,
+            LastSeq = 0,
+            LastMessageAt = null,
+        };
+        await _channelRepository.Insert(legacyChannel);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = legacyChannel.Id,
+            BattleTag = BattleTag,
+            NotificationLevel = NotificationLevel.All,
+            LastReadSeq = 0,
+            JoinedAt = Now.AddYears(-1),
+        });
+        var normalShell = await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-5));
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        var ids = page.Conversations.Select(c => c.Channel.Id).ToList();
+        CollectionAssert.DoesNotContain(ids, legacyChannel.Id,
+            "a null-stamped LastMessageAt is data-impossible in production but must not dead-end the wire cursor");
+        CollectionAssert.Contains(ids, normalShell.Id);
+    }
+
+    // ---------------------------------------------------------------------
+    // Task 8 fix round — finding 7 (minor): remaining test gaps called out in code review.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public async Task GetConversations_TieBreaksOnChannelId_NoSkipOrDuplicateAcrossPageBoundary()
+    {
+        var tied = Now.AddMinutes(-10);
+        var shells = new List<ChatChannel>();
+        for (var i = 0; i < 3; i++)
+        {
+            shells.Add(await CreateDmShell($"{OtherPrefix}tie{i}#1", tied));
+        }
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var expectedOrder = shells.OrderByDescending(c => c.Id, StringComparer.Ordinal).Select(c => c.Id).ToList();
+
+        var seen = new List<string>();
+        DateTime? cursorTime = null;
+        string cursorId = null;
+        while (true)
+        {
+            var page = await hub.GetConversations(cursorTime, cursorId, limit: 2);
+            Assert.AreEqual(ChatResultCode.Ok, page.Code);
+            if (page.Conversations.Count == 0) break;
+            seen.AddRange(page.Conversations.Select(c => c.Channel.Id));
+            var last = page.Conversations[^1].Channel;
+            cursorTime = last.LastMessageAt;
+            cursorId = last.Id;
+            if (page.Conversations.Count < 2) break;
+        }
+
+        CollectionAssert.AreEqual(expectedOrder, seen,
+            "identical LastMessageAt must tie-break deterministically on ChannelId with no skip or duplicate across a page boundary");
+    }
+
+    [Test]
+    public async Task GetConversations_CrossCallerIsolation_OtherUsersShellsNeverAppear()
+    {
+        var mine = await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-5));
+
+        // A completely separate user's own Dm shell + membership row — never the caller's.
+        const string otherCaller = "shadow#999";
+        var otherChannel = new ChatChannel
+        {
+            Type = ChannelType.Dm,
+            PairKey = DmPairKey.For(otherCaller, $"{OtherPrefix}9#1"),
+            RequestState = DmRequestState.Accepted,
+            RequestInitiatedBy = otherCaller,
+            LastSeq = 0,
+            LastMessageAt = Now.AddMinutes(-1),
+        };
+        await _channelRepository.Insert(otherChannel);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = otherChannel.Id,
+            BattleTag = otherCaller,
+            NotificationLevel = NotificationLevel.All,
+            LastReadSeq = 0,
+            JoinedAt = Now.AddMinutes(-1),
+        });
+
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        var ids = page.Conversations.Select(c => c.Channel.Id).ToList();
+        CollectionAssert.Contains(ids, mine.Id);
+        CollectionAssert.DoesNotContain(ids, otherChannel.Id,
+            "GetConversations must only ever page the CALLER's own memberships");
     }
 }

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+using W3ChampionsChatService.Mentions;
+using W3ChampionsChatService.Memberships;
+using W3ChampionsChatService.Messages;
+using W3ChampionsChatService.Mutes;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Task 8 (2026-08-04 follow-up spec §6): <c>GetConversations</c> — the cursor-paginated read of the
+/// caller's OLDER 1:1 Dm shells (the ones the bounded connect snapshot, Task 6, excludes), newest-first
+/// by (LastMessageAt, ChannelId). Direct-hub-instantiation idiom; scaffolding copied VERBATIM from
+/// <see cref="ChatHubGetMessagesTests"/> (same fields, same <see cref="IntegrationTestBase"/> base, same
+/// <c>BuildHub</c> ctor list, same <c>FixedNow</c>/<c>_time</c>).
+/// </summary>
+public class ChatHubGetConversationsTests : IntegrationTestBase
+{
+    private const string BattleTag = "peter#123";
+    private const string OtherPrefix = "friend";
+
+    private static readonly DateTimeOffset FixedNow = new(2026, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private ConnectionMapping _connectionMapping;
+    private UserDirectoryRepository _userDirectory;
+    private MuteRepository _muteRepository;
+    private MuteReconciliationTestHarness _reconcileHarness;
+    private TicketStore _ticketStore;
+    private Mock<IChatAuthenticationService> _authService;
+
+    private ChannelRepository _channelRepository;
+    private MembershipRepository _membershipRepository;
+    private MessageRepository _messageRepository;
+    private SessionRegistry _sessionRegistry;
+    private FocusRegistry _focusRegistry;
+    private OnlineMemberRegistry _onlineMemberRegistry;
+    private MessageRateLimiter _messageRateLimiter;
+    private ChannelCreationRateLimiter _channelCreationRateLimiter;
+    private SessionStateAssembler _assembler;
+    private FanOutEngine _fanOutEngine;
+    private FakeTimeProvider _time;
+
+    private DateTime Now => _time.GetUtcNow().UtcDateTime;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _time = new FakeTimeProvider(FixedNow);
+
+        _connectionMapping = new ConnectionMapping();
+        _userDirectory = new UserDirectoryRepository(MongoClient);
+        _muteRepository = new MuteRepository(MongoClient);
+        _reconcileHarness = new MuteReconciliationTestHarness(_connectionMapping, _muteRepository);
+        _ticketStore = new TicketStore();
+
+        _authService = new Mock<IChatAuthenticationService>();
+        _authService.Setup(m => m.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .ReturnsAsync((W3CUserAuthentication id) =>
+                new ChatUserResolution(new ChatUser(id.BattleTag, id.IsAdmin, id.Name, new ProfilePicture(), null, null), true));
+
+        _channelRepository = new ChannelRepository(MongoClient);
+        _membershipRepository = new MembershipRepository(MongoClient, _channelRepository);
+        _messageRepository = new MessageRepository(MongoClient);
+        _sessionRegistry = new SessionRegistry();
+        _focusRegistry = new FocusRegistry();
+        _onlineMemberRegistry = new OnlineMemberRegistry();
+        _messageRateLimiter = new MessageRateLimiter();
+        _channelCreationRateLimiter = new ChannelCreationRateLimiter();
+        _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
+        _assembler = new SessionStateAssembler(
+            _membershipRepository,
+            _channelRepository,
+            _messageRepository,
+            _muteRepository,
+            _onlineMemberRegistry,
+            _connectionMapping,
+            new MentionInboxRepository(MongoClient));
+    }
+
+    private ChatHub BuildHub(string connectionId)
+    {
+        var hub = new ChatHub(
+            _connectionMapping,
+            _reconcileHarness.Service,
+            _ticketStore,
+            _sessionRegistry,
+            _userDirectory,
+            _assembler,
+            _focusRegistry,
+            _onlineMemberRegistry,
+            _messageRateLimiter,
+            _time,
+            _channelRepository,
+            _membershipRepository,
+            _channelCreationRateLimiter,
+            _messageRepository,
+            _fanOutEngine,
+            ViewersAccumulatorTestFactory.CreateIgnored(),
+            new NoOpMentionInboxCleaner(),
+            RelationshipProviderTestFactory.CreateIgnored(),
+            new UserSettingsRepository(MongoClient),
+            new DmInitiationTracker(),
+            _authService.Object,
+            MentionFanOutTestFactory.CreateIgnored(MongoClient),
+            new PresenceInterestRegistry(),
+            new MentionInboxRepository(MongoClient));
+
+        hub.Clients = new Mock<IHubCallerClients>().Object;
+
+        var context = new Mock<HubCallerContext>();
+        context.Setup(c => c.ConnectionId).Returns(connectionId);
+        hub.Context = context.Object;
+        hub.Groups = new Mock<IGroupManager>().Object;
+
+        return hub;
+    }
+
+    private void RegisterSession(string connectionId, string battleTag) =>
+        _sessionRegistry.Register(
+            connectionId,
+            new W3CUserAuthentication { BattleTag = battleTag, Name = battleTag.Split('#')[0] },
+            null);
+
+    // One ACCEPTED 1:1 shell (viewer + counterpart) with the viewer's own membership row.
+    private async Task<ChatChannel> CreateDmShell(
+        string counterpart, DateTime lastMessageAt, long lastSeq = 0, long lastReadSeq = 0)
+    {
+        var channel = new ChatChannel
+        {
+            Type = ChannelType.Dm,
+            PairKey = DmPairKey.For(BattleTag, counterpart),
+            RequestState = DmRequestState.Accepted,
+            RequestInitiatedBy = BattleTag,
+            LastSeq = lastSeq,
+            LastMessageAt = lastMessageAt,
+        };
+        await _channelRepository.Insert(channel);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = channel.Id,
+            BattleTag = BattleTag,
+            NotificationLevel = NotificationLevel.All,
+            LastReadSeq = lastReadSeq,
+            JoinedAt = lastMessageAt,
+        });
+        return channel;
+    }
+
+    [Test]
+    public async Task GetConversations_PagesNewestFirst_WithoutOverlapOrGaps()
+    {
+        var t0 = Now;
+        var all = new List<ChatChannel>();
+        for (var i = 0; i < 25; i++)
+        {
+            all.Add(await CreateDmShell($"{OtherPrefix}{i}#1", t0.AddMinutes(i)));
+        }
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var seen = new List<string>();
+        DateTime? cursorTime = null;
+        string cursorId = null;
+        while (true)
+        {
+            var page = await hub.GetConversations(cursorTime, cursorId, limit: 10);
+            Assert.AreEqual(ChatResultCode.Ok, page.Code);
+            if (page.Conversations.Count == 0) break;
+
+            // Newest-first within each page, strictly older than the cursor.
+            for (var i = 1; i < page.Conversations.Count; i++)
+            {
+                Assert.LessOrEqual(
+                    page.Conversations[i].Channel.LastMessageAt.Value,
+                    page.Conversations[i - 1].Channel.LastMessageAt.Value);
+            }
+            seen.AddRange(page.Conversations.Select(c => c.Channel.Id));
+            var last = page.Conversations[^1].Channel;
+            cursorTime = last.LastMessageAt;
+            cursorId = last.Id;
+            if (page.Conversations.Count < 10) break;
+        }
+
+        CollectionAssert.AreEquivalent(all.Select(c => c.Id), seen, "every shell exactly once — no gaps, no dupes");
+        Assert.AreEqual(all[24].Id, seen[0], "the newest shell comes first");
+    }
+
+    [Test]
+    public async Task GetConversations_SeedsRegistry_SoAPagedConversationAcceptsSends()
+    {
+        var shell = await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-90));
+        RegisterSession("conn-1", BattleTag);
+        _connectionMapping.RegisterUser("conn-1", new ChatUser(BattleTag, false, "peter", new ProfilePicture(), null, null));
+        _connectionMapping.SetMute("conn-1", MuteStatus.None, DateTime.MinValue);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+        Assert.AreEqual(ChatResultCode.Ok, page.Code);
+        Assert.IsTrue(_onlineMemberRegistry.IsMember("conn-1", shell.Id),
+            "every returned shell is seeded into the caller's registry");
+
+        var send = await hub.SendMessage(shell.Id, "picking this back up");
+        Assert.AreEqual(ChatResultCode.Ok, send.Code, "a paged conversation is immediately usable");
+    }
+
+    [Test]
+    public async Task GetConversations_ReturnsUnreadCounts()
+    {
+        var shell = await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-5), lastSeq: 1, lastReadSeq: 0);
+        await _messageRepository.Insert(new ChannelMessage
+        {
+            ChannelId = shell.Id,
+            Seq = 1,
+            Sender = new MessageSender { BattleTag = $"{OtherPrefix}0#1", Name = "friend0" },
+            Content = "unread hello",
+            SentAt = Now.AddMinutes(-5),
+        });
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        var dto = page.Conversations.Single(c => c.Channel.Id == shell.Id);
+        Assert.AreEqual(1, dto.UnreadCount, "the D7 user-visible unread count rides each paged shell");
+        Assert.IsTrue(dto.HasUnread);
+    }
+
+    [Test]
+    public async Task GetConversations_ExcludesNonDmChannels()
+    {
+        await CreateDmShell($"{OtherPrefix}0#1", Now.AddMinutes(-1));
+        var group = new ChatChannel { Type = ChannelType.GroupDm, Name = "the gang", LastMessageAt = Now };
+        await _channelRepository.Insert(group);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = group.Id, BattleTag = BattleTag, NotificationLevel = NotificationLevel.All, JoinedAt = Now,
+        });
+        var pub = new ChatChannel { Type = ChannelType.Public, Name = "general", NormalizedName = "general", LastMessageAt = Now };
+        await _channelRepository.Insert(pub);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = pub.Id, BattleTag = BattleTag, NotificationLevel = NotificationLevel.All, JoinedAt = Now,
+        });
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        Assert.AreEqual(1, page.Conversations.Count, "GetConversations pages 1:1 Dm shells ONLY");
+        Assert.AreEqual(ChannelType.Dm, page.Conversations[0].Channel.Type);
+    }
+
+    [Test]
+    public async Task GetConversations_ClampsLimit()
+    {
+        for (var i = 0; i < ChatLimits.ConversationsPageSize + 5; i++)
+        {
+            await CreateDmShell($"{OtherPrefix}{i}#1", Now.AddMinutes(i));
+        }
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10_000);
+
+        Assert.AreEqual(ChatLimits.ConversationsPageSize, page.Conversations.Count,
+            "an oversized limit is clamped down, never rejected (the MessagePageSize precedent)");
+    }
+
+    [Test]
+    public void GetConversations_HalfCursor_ThrowsHubException()
+    {
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        Assert.ThrowsAsync<HubException>(() => hub.GetConversations(Now, null, limit: 10),
+            "cursorLastMessageAt without cursorChannelId is a client bug");
+        Assert.ThrowsAsync<HubException>(() => hub.GetConversations(null, "some-id", limit: 10),
+            "cursorChannelId without cursorLastMessageAt is a client bug");
+    }
+
+    [Test]
+    public async Task GetConversations_NoSession_ReturnsPermissionDenied()
+    {
+        var hub = BuildHub("conn-ghost");
+        var page = await hub.GetConversations(null, null, limit: 10);
+        Assert.AreEqual(ChatResultCode.PermissionDenied, page.Code);
+    }
+}

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -262,6 +262,51 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
         Assert.IsTrue(dto.HasUnread);
     }
 
+    // 2026-08-05 PR36 feedback (Part 1): unread hydration for the whole page now runs through ONE batched
+    // CountUserVisibleAfterMany aggregation instead of one CountUserVisibleAfter round-trip per shell.
+    // Pins that distinct per-shell cursors on the SAME page never cross-contaminate each other's counts.
+    [Test]
+    public async Task GetConversations_ReturnsCorrectUnreadCounts_ForMultipleShellsOnOnePage_ViaBatchedQuery()
+    {
+        var shellA = await CreateDmShell($"{OtherPrefix}a#1", Now.AddMinutes(-1), lastSeq: 2, lastReadSeq: 0);
+        for (var seq = 1L; seq <= 2; seq++)
+        {
+            await _messageRepository.Insert(new ChannelMessage
+            {
+                ChannelId = shellA.Id,
+                Seq = seq,
+                Sender = new MessageSender { BattleTag = $"{OtherPrefix}a#1", Name = "friendA" },
+                Content = $"a-{seq}",
+                SentAt = Now.AddMinutes(-1),
+            });
+        }
+
+        var shellB = await CreateDmShell($"{OtherPrefix}b#1", Now.AddMinutes(-2), lastSeq: 3, lastReadSeq: 1);
+        for (var seq = 1L; seq <= 3; seq++)
+        {
+            await _messageRepository.Insert(new ChannelMessage
+            {
+                ChannelId = shellB.Id,
+                Seq = seq,
+                Sender = new MessageSender { BattleTag = $"{OtherPrefix}b#1", Name = "friendB" },
+                Content = $"b-{seq}",
+                SentAt = Now.AddMinutes(-2),
+            });
+        }
+
+        // No messages at all for shellC — a genuine zero that must not pick up A's or B's $or-branch match.
+        var shellC = await CreateDmShell($"{OtherPrefix}c#1", Now.AddMinutes(-3), lastSeq: 0, lastReadSeq: 0);
+
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var page = await hub.GetConversations(null, null, limit: 10);
+
+        Assert.AreEqual(2, page.Conversations.Single(c => c.Channel.Id == shellA.Id).UnreadCount, "shellA: 2 visible rows after cursor 0");
+        Assert.AreEqual(2, page.Conversations.Single(c => c.Channel.Id == shellB.Id).UnreadCount, "shellB: rows 2,3 after cursor 1");
+        Assert.AreEqual(0, page.Conversations.Single(c => c.Channel.Id == shellC.Id).UnreadCount, "shellC: no messages — must not leak another shell's count");
+    }
+
     [Test]
     public async Task GetConversations_ExcludesNonDmChannels()
     {

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -320,6 +320,49 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task GetMessages_FullBannedNonMember_PublicChannel_Denied()
+    {
+        // A full-banned caller must not be able to read Public history through the §4 non-member
+        // fallthrough — mirrors JoinChannel's full-ban gate (ChatHub.Channels.cs) and the catalog-hiding
+        // rule in SessionStateAssembler. Must resolve to the SAME NotMember a non-member got before this
+        // task's fallthrough existed — indistinguishable, no new information disclosure.
+        var channel = await CreateChannel(); // Public by default
+        await SeedMessage(channel.Id, OtherBattleTag, "hello public");
+        RegisterSession("conn-1", BattleTag);
+        // Deliberately NO membership seed — a full-banned non-member reaching the Public fallthrough.
+        // Seed the mute cache the SAME way the connect flow does (SessionStateAssembler.SeedLegacyMuteCache
+        // -> ConnectionMapping.SetMute), mirroring JoinChannel_FullBanned_PublicChannel_ReturnsPermissionDenied.
+        _connectionMapping.SetMute("conn-1", MuteStatus.Full, Now.AddDays(1));
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.NotMember, result.Code,
+            "a full-banned non-member must not read Public history via the §4 fallthrough");
+        Assert.IsNull(result.Messages);
+    }
+
+    [Test]
+    public async Task GetMessages_FullBannedNonMemberModerator_PublicChannel_Denied()
+    {
+        // The Moderation role claim must not bypass the full-ban gate: a non-member moderator who is
+        // ALSO full-banned is denied exactly like any other full-banned non-member — the ban check runs
+        // in step 3, strictly before step 4's moderator/user branch split.
+        var channel = await CreateChannel(); // Public by default
+        await SeedMessage(channel.Id, OtherBattleTag, "hello public");
+        RegisterModeratorSession("mod-conn", ModeratorBattleTag);
+        // Deliberately NO membership seed for the moderator.
+        _connectionMapping.SetMute("mod-conn", MuteStatus.Full, Now.AddDays(1));
+        var hub = BuildHub("mod-conn");
+
+        var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.NotMember, result.Code,
+            "a full-banned non-member moderator is still denied — the Moderation claim does not bypass the ban gate");
+        Assert.IsNull(result.Messages);
+    }
+
+    [Test]
     public async Task GetMessages_UnknownChannel_ReturnsNotFound()
     {
         RegisterSession("conn-1", BattleTag);

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -351,7 +351,7 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
     {
         // The Moderation role claim must not bypass the full-ban gate: a non-member moderator who is
         // ALSO full-banned is denied exactly like any other full-banned non-member — the ban check runs
-        // in step 3, strictly before step 4's moderator/user branch split.
+        // in step 4, strictly before step 5's moderator/user branch split.
         var channel = await CreateChannel(); // Public by default
         await SeedMessage(channel.Id, OtherBattleTag, "hello public");
         RegisterModeratorSession("mod-conn", ModeratorBattleTag);
@@ -488,28 +488,6 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
         var otherHub = BuildHub("conn-2");
         var unaffected = await otherHub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
         Assert.AreEqual(ChatResultCode.Ok, unaffected.Code, "a distinct battleTag has its own independent read budget");
-    }
-
-    [Test]
-    public async Task GetMessages_ReadLimit_SharedBudget_WithGetConversationsStyleUsage()
-    {
-        // Deliverable 4: "all acquisitions share one bucket per battleTag" — proven at the hub level by
-        // spending the WHOLE budget via direct TryAcquire calls (standing in for a prior GetConversations
-        // burst against the SAME singleton instance production wires into both methods) and confirming
-        // GetMessages is denied by the very next call, with none of ITS OWN calls having been needed to
-        // exhaust the budget.
-        var channel = await CreateChannel();
-        SeedMember("conn-1", BattleTag, channel.Id);
-        var hub = BuildHub("conn-1");
-
-        for (var i = 0; i < ChatLimits.ReadBurst; i++)
-        {
-            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
-        }
-
-        var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
-        Assert.AreEqual(ChatResultCode.Throttled, result.Code,
-            "GetMessages must be denied once the SHARED budget is spent, even though none of the spending calls went through GetMessages itself");
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -675,10 +653,10 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
         Assert.IsNull(result.Messages);
     }
 
-    // 2026-08-04 follow-up (Minor finding): step 4's comment previously read as if the privileged
+    // 2026-08-04 follow-up (Minor finding): step 5's comment previously read as if the privileged
     // ForModerator view were NEVER reachable outside the REST endpoint. That is imprecise for Public
-    // channels specifically — step 3's non-member Public fallthrough (§4) lets a NON-MEMBER moderator
-    // reach step 4's moderator branch too, so they get the SAME ForModerator projection (deleted rows +
+    // channels specifically — step 4's non-member Public fallthrough (§4) lets a NON-MEMBER moderator
+    // reach step 5's moderator branch too, so they get the SAME ForModerator projection (deleted rows +
     // every author's real shadow flag) a member-moderator would, through THIS hub method. Pinning that
     // explicitly so the behavior is a chosen, tested outcome rather than an accidental side effect of
     // the §4 fallthrough. The full-banned variant of this exact scenario is already covered by
@@ -694,13 +672,13 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
 
         RegisterModeratorSession("mod-conn", ModeratorBattleTag);
         // Deliberately NO membership seed and NO full-ban — a non-member moderator reaching the Public
-        // fallthrough (step 3) with a clean mute status.
+        // fallthrough (step 4) with a clean mute status.
         var hub = BuildHub("mod-conn");
 
         var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
 
         Assert.AreEqual(ChatResultCode.Ok, result.Code,
-            "a non-member moderator reads a Public channel via step 3's fallthrough, then step 4's moderator branch");
+            "a non-member moderator reads a Public channel via step 4's fallthrough, then step 5's moderator branch");
         CollectionAssert.AreEqual(
             new[] { normal.Seq, deleted.Seq, foreignShadow.Seq },
             result.Messages.Select(m => m.Seq).ToArray(),

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -55,6 +55,7 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -85,6 +86,7 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _assembler = new SessionStateAssembler(
@@ -109,6 +111,7 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,
@@ -386,6 +389,99 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
 
         Assert.AreEqual(ChatResultCode.PermissionDenied, result.Code);
         Assert.IsNull(result.Messages);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // 2026-08-05 PR36 feedback, Part 3: GetMessages shares the SAME ReadRateLimiter instance/budget as
+    // GetConversations (per the task report's scope determination — old/current shipped clients already
+    // treat any non-Ok GetMessages result as a silent no-op). Guarded BEFORE any DB work.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task GetMessages_OverReadLimit_ReturnsThrottled_WithRetryAfter()
+    {
+        var channel = await CreateChannel();
+        SeedMember("conn-1", BattleTag, channel.Id);
+        await SeedMessage(channel.Id, BattleTag, "hello");
+        var hub = BuildHub("conn-1");
+
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+
+        var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Throttled, result.Code, "over the shared read budget must be rejected");
+        Assert.IsNull(result.Messages, "a Throttled reject must never carry a payload");
+        Assert.IsNotNull(result.RetryAfterSeconds);
+        Assert.Greater(result.RetryAfterSeconds.Value, 0);
+    }
+
+    [Test]
+    public async Task GetMessages_OverReadLimit_UnknownChannel_ReturnsThrottled_NotNotFound()
+    {
+        // Ordering proof (no Mongo-call mocking available in this hub harness — see
+        // GetMessages_UnknownChannel_ReturnsNotFound above for the SAME unknown-channel call succeeding
+        // through to a Mongo-backed NotFound when the limiter is NOT exhausted): if the rate limiter ran
+        // AFTER the channel load, an unknown channelId would still reach Mongo and come back NotFound. It
+        // instead comes back Throttled, proving the limiter denies BEFORE the channel load ever runs.
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+
+        var result = await hub.GetMessages("no-such-channel-id", beforeSeq: null, aroundSeq: null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Throttled, result.Code,
+            "the read-abuse guard must deny BEFORE the channel load — an unknown channel must never reach Mongo once denied");
+        Assert.IsNull(result.Messages);
+    }
+
+    [Test]
+    public async Task GetMessages_ReadLimit_IsIndependentPerBattleTag()
+    {
+        var channel = await CreateChannel();
+        SeedMember("conn-1", BattleTag, channel.Id);
+        var hub = BuildHub("conn-1");
+
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+        var throttled = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
+        Assert.AreEqual(ChatResultCode.Throttled, throttled.Code, "BattleTag's own budget is spent");
+
+        const string OtherBattleTag2 = "shadow#999";
+        SeedMember("conn-2", OtherBattleTag2, channel.Id);
+        var otherHub = BuildHub("conn-2");
+        var unaffected = await otherHub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
+        Assert.AreEqual(ChatResultCode.Ok, unaffected.Code, "a distinct battleTag has its own independent read budget");
+    }
+
+    [Test]
+    public async Task GetMessages_ReadLimit_SharedBudget_WithGetConversationsStyleUsage()
+    {
+        // Deliverable 4: "all acquisitions share one bucket per battleTag" — proven at the hub level by
+        // spending the WHOLE budget via direct TryAcquire calls (standing in for a prior GetConversations
+        // burst against the SAME singleton instance production wires into both methods) and confirming
+        // GetMessages is denied by the very next call, with none of ITS OWN calls having been needed to
+        // exhaust the budget.
+        var channel = await CreateChannel();
+        SeedMember("conn-1", BattleTag, channel.Id);
+        var hub = BuildHub("conn-1");
+
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+
+        var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
+        Assert.AreEqual(ChatResultCode.Throttled, result.Code,
+            "GetMessages must be denied once the SHARED budget is spent, even though none of the spending calls went through GetMessages itself");
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -274,7 +274,9 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
     [Test]
     public async Task GetMessages_NonMember_ReturnsNotMember()
     {
-        var channel = await CreateChannel();
+        // SemiPublic — public rooms are non-member-readable since the §4 mention-jump allowance; every
+        // other type keeps the wall.
+        var channel = await CreateChannel(type: ChannelType.SemiPublic);
         RegisterSession("conn-1", BattleTag);
         // Deliberately no membership seed — the caller has a live session but is not a member.
         var hub = BuildHub("conn-1");
@@ -283,6 +285,38 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
 
         Assert.AreEqual(ChatResultCode.NotMember, result.Code);
         Assert.IsNull(result.Messages);
+    }
+
+    [Test]
+    public async Task GetMessages_NonMember_PublicChannel_ReturnsHistory()
+    {
+        var channel = await CreateChannel(); // Public by default
+        var seeded = await SeedMessage(channel.Id, OtherBattleTag, "hello public");
+        RegisterSession("conn-1", BattleTag);
+        // Deliberately NO membership seed — the mention-inbox jump into an unjoined public room (§4).
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: seeded.Seq, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code, "public-room history is readable without membership");
+        Assert.AreEqual(1, result.Messages.Count);
+        Assert.AreEqual(seeded.Seq, result.Messages[0].Seq);
+    }
+
+    [Test]
+    public async Task GetMessages_NonMember_PublicChannel_StillAppliesUserVisibleFilter()
+    {
+        var channel = await CreateChannel();
+        await SeedMessage(channel.Id, OtherBattleTag, "visible");
+        await SeedMessage(channel.Id, OtherBattleTag, "shadow-hidden", shadow: true);
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        Assert.AreEqual(1, result.Messages.Count, "the non-member read uses the SAME UserVisible-filtered path");
+        Assert.AreEqual("visible", result.Messages[0].Content);
     }
 
     [Test]
@@ -457,7 +491,10 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
     [Test]
     public async Task GetMessages_Moderator_NonMember_StillNotMember()
     {
-        var channel = await CreateChannel();
+        // SemiPublic — public rooms are non-member-readable since the §4 mention-jump allowance; every
+        // other type keeps the wall. On a PUBLIC channel a non-member (moderator or not) now falls
+        // through to the read path instead of NotMember.
+        var channel = await CreateChannel(type: ChannelType.SemiPublic);
         // A moderator with a live session but NO membership in the channel.
         RegisterModeratorSession("mod-conn", ModeratorBattleTag);
         var hub = BuildHub("mod-conn");

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -550,6 +550,40 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
         Assert.IsNull(result.Messages);
     }
 
+    // 2026-08-04 follow-up (Minor finding): step 4's comment previously read as if the privileged
+    // ForModerator view were NEVER reachable outside the REST endpoint. That is imprecise for Public
+    // channels specifically — step 3's non-member Public fallthrough (§4) lets a NON-MEMBER moderator
+    // reach step 4's moderator branch too, so they get the SAME ForModerator projection (deleted rows +
+    // every author's real shadow flag) a member-moderator would, through THIS hub method. Pinning that
+    // explicitly so the behavior is a chosen, tested outcome rather than an accidental side effect of
+    // the §4 fallthrough. The full-banned variant of this exact scenario is already covered by
+    // GetMessages_FullBannedNonMemberModerator_PublicChannel_Denied — extended here, not duplicated.
+    [Test]
+    public async Task GetMessages_NonMemberModerator_PublicChannel_ReturnsForModeratorProjection()
+    {
+        var channel = await CreateChannel(); // Public by default
+        var normal = await SeedMessage(channel.Id, BattleTag, "visible to everyone");
+        var deleted = await SeedMessage(channel.Id, BattleTag, "will be deleted");
+        var foreignShadow = await SeedMessage(channel.Id, OtherBattleTag, "shadow from someone else", shadow: true);
+        await _messageRepository.MarkDeleted(deleted.Id, "Mod#1", Now);
+
+        RegisterModeratorSession("mod-conn", ModeratorBattleTag);
+        // Deliberately NO membership seed and NO full-ban — a non-member moderator reaching the Public
+        // fallthrough (step 3) with a clean mute status.
+        var hub = BuildHub("mod-conn");
+
+        var result = await hub.GetMessages(channel.Id, beforeSeq: null, aroundSeq: null, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code,
+            "a non-member moderator reads a Public channel via step 3's fallthrough, then step 4's moderator branch");
+        CollectionAssert.AreEqual(
+            new[] { normal.Seq, deleted.Seq, foreignShadow.Seq },
+            result.Messages.Select(m => m.Seq).ToArray(),
+            "a non-member moderator gets the SAME ForModerator projection a member-moderator would — deleted and every author's shadow rows included");
+        Assert.IsTrue(result.Messages.Single(m => m.Seq == deleted.Seq).Deleted, "the deleted row carries the REAL deleted flag");
+        Assert.IsTrue(result.Messages.Single(m => m.Seq == foreignShadow.Seq).Shadow, "a foreign author's shadow row carries the REAL shadow flag");
+    }
+
     [Test]
     public async Task GetMessages_Moderator_Paging_SeqAnchoredAcrossFlaggedRows()
     {

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -441,6 +441,34 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
         Assert.IsNull(result.Messages);
     }
 
+    // Fix round 1, finding F5: the limiter now runs absolutely FIRST in GetMessages too (moved above the
+    // malformed-arg guard), mirroring GetConversations' ordering exactly instead of the narrower
+    // "before the first DB read" ordering it used before. Pin it the same way GetConversations' own
+    // tripwire (F2) does: supplying BOTH beforeSeq and aroundSeq is normally a client-bug HubException
+    // (step 3) — if the limiter ever slipped below that guard, this call would throw instead of
+    // returning Throttled.
+    [Test]
+    public async Task GetMessages_OverReadLimit_WithMalformedArgs_ReturnsThrottled_NotHubException()
+    {
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_readRateLimiter.TryAcquire(BattleTag, Now).Allowed);
+        }
+
+        // beforeSeq AND aroundSeq both set — malformed, and normally a client-bug HubException (step 3).
+        // If the limiter ever slipped below that guard, this line throws and the test fails.
+        var result = await hub.GetMessages("any-channel-id", beforeSeq: 1, aroundSeq: 2, limit: 10);
+
+        Assert.AreEqual(ChatResultCode.Throttled, result.Code,
+            "the read rate limit must run FIRST THING — strictly before the malformed-arg guard — so a " +
+            "malformed (beforeSeq + aroundSeq both set) call from an over-budget caller returns Throttled " +
+            "rather than throwing HubException");
+        Assert.IsNull(result.Messages);
+    }
+
     [Test]
     public async Task GetMessages_ReadLimit_IsIndependentPerBattleTag()
     {

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -123,7 +123,8 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubGroupCreateTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupCreateTests.cs
@@ -142,7 +142,8 @@ public class ChatHubGroupCreateTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubGroupCreateTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupCreateTests.cs
@@ -49,6 +49,7 @@ public class ChatHubGroupCreateTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -85,6 +86,7 @@ public class ChatHubGroupCreateTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _userSettings = new UserSettingsRepository(MongoClient);
         _dmInitiationTracker = new DmInitiationTracker();
@@ -128,6 +130,7 @@ public class ChatHubGroupCreateTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
@@ -59,6 +59,7 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
     private MembershipRepository _membershipRepository;
     private MessageRepository _messageRepository;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -94,6 +95,7 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _userSettings = new UserSettingsRepository(MongoClient);
         _dmInitiationTracker = new DmInitiationTracker();
@@ -138,6 +140,7 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
@@ -152,7 +152,8 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubMarkReadTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMarkReadTests.cs
@@ -54,6 +54,7 @@ public class ChatHubMarkReadTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -84,6 +85,7 @@ public class ChatHubMarkReadTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _assembler = new SessionStateAssembler(
@@ -108,6 +110,7 @@ public class ChatHubMarkReadTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubMarkReadTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMarkReadTests.cs
@@ -122,7 +122,8 @@ public class ChatHubMarkReadTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
@@ -85,7 +85,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
             new MentionInboxRepository(MongoClient));
     }
 
-    private ChatHub BuildHub(string connectionId)
+    private ChatHub BuildHub(string connectionId, NotificationPreferenceRepository notificationPreferenceRepository = null)
     {
         var hub = new ChatHub(
             _connectionMapping,
@@ -112,7 +112,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            _notificationPreferenceRepository);
+            notificationPreferenceRepository ?? _notificationPreferenceRepository);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 
@@ -744,5 +744,35 @@ public class ChatHubMembershipTests : IntegrationTestBase
         var inbox = new MentionInboxRepository(MongoClient);
         Assert.That(await inbox.LoadForUser(BattleTag.ToLowerInvariant()), Has.Count.EqualTo(1),
             "a persisted level other than None must not keep suppressing a mention after leaving");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // PR36 follow-up (D2), fix round 1 (F5) — the pref upsert is a SECONDARY, best-effort write: a
+    // failure there must never turn an already-applied membership level change into an error response.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task SetNotificationLevel_PrefUpsertThrows_MembershipStillAppliesAndReturnsOk()
+    {
+        var channel = await CreateChannel("general");
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1", new ThrowingNotificationPreferenceRepository(MongoClient));
+        await hub.JoinChannel("general");
+
+        var result = await hub.SetNotificationLevel(channel.Id, NotificationLevel.None);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code,
+            "a failed pref upsert must not fail an already-applied membership level change");
+        var persisted = await _membershipRepository.Load(channel.Id, BattleTag);
+        Assert.AreEqual(NotificationLevel.None, persisted.NotificationLevel,
+            "the membership update itself must still have gone through, unaffected by the pref-write failure");
+    }
+
+    // A NotificationPreferenceRepository whose Upsert always throws — simulating a Mongo write failure on
+    // the secondary preference-persistence path, to prove SetNotificationLevel's best-effort posture (F5).
+    private sealed class ThrowingNotificationPreferenceRepository(MongoClient client) : NotificationPreferenceRepository(client)
+    {
+        public override Task<NotificationPreference> Upsert(string battleTag, string channelId, NotificationLevel level, DateTime now) =>
+            Task.FromException<NotificationPreference>(new InvalidOperationException("simulated NotificationPreference upsert failure"));
     }
 }

--- a/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
@@ -50,6 +50,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
 
@@ -74,6 +75,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _assembler = new SessionStateAssembler(
             _membershipRepository,
@@ -97,6 +99,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             TimeProvider.System,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Moq;
+using MongoDB.Driver;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Channels;
@@ -44,6 +45,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
 
     private ChannelRepository _channelRepository;
     private MembershipRepository _membershipRepository;
+    private NotificationPreferenceRepository _notificationPreferenceRepository;
     private SessionRegistry _sessionRegistry;
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
@@ -67,6 +69,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
 
         _channelRepository = new ChannelRepository(MongoClient);
         _membershipRepository = new MembershipRepository(MongoClient, _channelRepository);
+        _notificationPreferenceRepository = new NotificationPreferenceRepository(MongoClient);
         _sessionRegistry = new SessionRegistry();
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
@@ -109,7 +112,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            _notificationPreferenceRepository);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 
@@ -532,5 +535,214 @@ public class ChatHubMembershipTests : IntegrationTestBase
         var result = await hub.SetNotificationLevel("some-channel-id", NotificationLevel.None);
 
         Assert.AreEqual(ChatResultCode.PermissionDenied, result.Code);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // PR36 follow-up (D2) — notification-preference persistence across leave/rejoin. SetNotificationLevel
+    // writes the pref (Public/SemiPublic only), LeaveChannel stays a hard membership delete (unchanged),
+    // and JoinChannel seeds a (re)joined membership from the persisted pref when one exists. The
+    // "mention stays suppressed after leaving" leg builds a REAL MentionFanOut (mirrors the
+    // MentionFanOutTests.cs harness) over the SAME _membershipRepository/_notificationPreferenceRepository
+    // this hub uses, so the consult path is exercised end-to-end rather than asserted only at the
+    // repository layer.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task SetNotificationLevel_Public_UpsertsPreference()
+    {
+        var channel = await CreateChannel("general");
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+        await hub.JoinChannel("general");
+
+        await hub.SetNotificationLevel(channel.Id, NotificationLevel.None);
+
+        var pref = await _notificationPreferenceRepository.Load(BattleTag, channel.Id);
+        Assert.IsNotNull(pref, "an explicit set on a Public channel must persist a NotificationPreference row");
+        Assert.AreEqual(NotificationLevel.None, pref.NotificationLevel);
+    }
+
+    [Test]
+    public async Task SetNotificationLevel_SemiPublic_UpsertsPreference()
+    {
+        var channel = await CreateChannel("semi-room", ChannelType.SemiPublic);
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+        await hub.JoinChannel("semi-room");
+
+        await hub.SetNotificationLevel(channel.Id, NotificationLevel.All);
+
+        var pref = await _notificationPreferenceRepository.Load(BattleTag, channel.Id);
+        Assert.IsNotNull(pref, "SemiPublic is name-joinable too — the pref must persist");
+        Assert.AreEqual(NotificationLevel.All, pref.NotificationLevel);
+    }
+
+    [Test]
+    public async Task SetNotificationLevel_GroupDm_NoPreferenceWritten()
+    {
+        // ACL-governed types are not user-leavable in the room-catalog sense — the pref collection must
+        // stay bounded to the room catalog (Public/SemiPublic only).
+        var channel = await CreateChannel("group-1", ChannelType.GroupDm);
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+        await DirectlyJoin(channel.Id, BattleTag);
+
+        var result = await hub.SetNotificationLevel(channel.Id, NotificationLevel.None);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code, "None is a valid level on a GroupDm (no Public All-gate)");
+        var pref = await _notificationPreferenceRepository.Load(BattleTag, channel.Id);
+        Assert.IsNull(pref, "a GroupDm level change must NOT write a NotificationPreference row");
+    }
+
+    [Test]
+    public async Task SetNotificationLevel_Public_RepeatedSets_LastWriteWins()
+    {
+        var channel = await CreateChannel("general");
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+        await hub.JoinChannel("general");
+
+        await hub.SetNotificationLevel(channel.Id, NotificationLevel.None);
+        await hub.SetNotificationLevel(channel.Id, NotificationLevel.Mentions);
+        await hub.SetNotificationLevel(channel.Id, NotificationLevel.None);
+
+        var pref = await _notificationPreferenceRepository.Load(BattleTag, channel.Id);
+        Assert.IsNotNull(pref);
+        Assert.AreEqual(NotificationLevel.None, pref.NotificationLevel, "the LAST set must win, not accumulate duplicate rows");
+
+        var db = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName);
+        var rowCount = await db.GetCollection<NotificationPreference>(ChatCollections.NotificationPreferences)
+            .CountDocumentsAsync(p => p.BattleTag == BattleTag.ToLowerInvariant() && p.ChannelId == channel.Id);
+        Assert.AreEqual(1, rowCount, "repeated sets must upsert the SAME row, never accumulate duplicates");
+    }
+
+    [Test]
+    public async Task JoinChannel_Rejoin_SeedsMembership_FromPersistedPreference_None()
+    {
+        var channel = await CreateChannel("general");
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+        await hub.JoinChannel("general");
+        await hub.SetNotificationLevel(channel.Id, NotificationLevel.None);
+        await hub.LeaveChannel(channel.Id);
+
+        // Between leave and rejoin: no membership row, but the pref survives independently.
+        Assert.IsNull(await _membershipRepository.Load(channel.Id, BattleTag), "leave must still hard-delete the membership row");
+        Assert.AreEqual(NotificationLevel.None, (await _notificationPreferenceRepository.Load(BattleTag, channel.Id)).NotificationLevel);
+
+        var rejoin = await hub.JoinChannel("general");
+
+        Assert.AreEqual(ChatResultCode.Ok, rejoin.Code);
+        Assert.AreEqual(NotificationLevel.None, rejoin.Membership.NotificationLevel,
+            "a rejoin must seed from the persisted preference, not the fresh-join Mentions default");
+        var persisted = await _membershipRepository.Load(channel.Id, BattleTag);
+        Assert.AreEqual(NotificationLevel.None, persisted.NotificationLevel);
+        var registryMember = _onlineMemberRegistry.GetMembers(channel.Id).Single();
+        Assert.AreEqual(NotificationLevel.None, registryMember.NotificationLevel,
+            "OnlineMemberRegistry must be seeded with the persisted level too, not just the returned DTO");
+    }
+
+    [Test]
+    public async Task JoinChannel_FirstJoin_NoPersistedPreference_DefaultsToMentions()
+    {
+        // Control for the rejoin test above: a genuinely first-time join (no prior SetNotificationLevel
+        // for this user+channel) must still fall back to the Mentions default, not e.g. an implicit None.
+        var channel = await CreateChannel("brand-new-room-2");
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.JoinChannel("brand-new-room-2");
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        Assert.AreEqual(NotificationLevel.Mentions, result.Membership.NotificationLevel);
+        Assert.IsNull(await _notificationPreferenceRepository.Load(BattleTag, channel.Id),
+            "no pref was ever set — nothing should have been written by the seed-path read");
+    }
+
+    [Test]
+    public async Task Lifecycle_SetNone_Leave_MentionInThatRoom_StaysSuppressed_ViaPersistedPreference()
+    {
+        // D2 end-to-end: join -> set None -> leave -> a THIRD party's mention in that room must still be
+        // suppressed for the departed user, via the persisted pref (not membership, which is now gone).
+        var channel = await CreateChannel("general");
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+        await hub.JoinChannel("general");
+        await hub.SetNotificationLevel(channel.Id, NotificationLevel.None);
+        await hub.LeaveChannel(channel.Id);
+
+        Assert.IsNull(await _membershipRepository.Load(channel.Id, BattleTag));
+
+        // The Public non-member branch also requires directory-resolvability (follow-up spec §4) —
+        // independent of the pref, mirroring MentionFanOutTests' SeedDirectory convention.
+        await _userDirectory.Upsert(new UserDirectoryEntry
+        {
+            BattleTag = BattleTag.ToLowerInvariant(),
+            DisplayBattleTag = BattleTag,
+            NormalizedName = BattleTag.ToLowerInvariant(),
+            LastSeenAt = DateTime.UtcNow,
+        });
+
+        var harness = new HubPushCaptureHarness();
+        var fanOut = new MentionFanOut(
+            harness.HubContext, _sessionRegistry, _membershipRepository, new MentionInboxRepository(MongoClient),
+            _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), _notificationPreferenceRepository);
+
+        var now = DateTime.UtcNow;
+        var message = new W3ChampionsChatService.Messages.ChannelMessage
+        {
+            ChannelId = channel.Id,
+            Seq = 1,
+            Sender = new W3ChampionsChatService.Messages.MessageSender { BattleTag = "someone#1", Name = "Someone" },
+            Content = "hey there",
+            SentAt = now,
+            ExpiresAt = ExpiryCalculator.ForChannelMessage(ChannelType.Public, now),
+        };
+        await fanOut.NotifyAsync(channel, message, new[] { BattleTag }, now);
+
+        var inbox = new MentionInboxRepository(MongoClient);
+        Assert.That(await inbox.LoadForUser(BattleTag.ToLowerInvariant()), Is.Empty,
+            "the persisted None preference keeps a mention suppressed for a room the user already left");
+    }
+
+    [Test]
+    public async Task Lifecycle_SetMentions_Leave_MentionInThatRoom_StillDelivered()
+    {
+        // Only an explicit None suppresses — leaving with any OTHER last-set level must deliver normally.
+        var channel = await CreateChannel("general");
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1");
+        await hub.JoinChannel("general"); // fresh-join default is already Mentions
+        await hub.SetNotificationLevel(channel.Id, NotificationLevel.Mentions);
+        await hub.LeaveChannel(channel.Id);
+
+        await _userDirectory.Upsert(new UserDirectoryEntry
+        {
+            BattleTag = BattleTag.ToLowerInvariant(),
+            DisplayBattleTag = BattleTag,
+            NormalizedName = BattleTag.ToLowerInvariant(),
+            LastSeenAt = DateTime.UtcNow,
+        });
+
+        var harness = new HubPushCaptureHarness();
+        var fanOut = new MentionFanOut(
+            harness.HubContext, _sessionRegistry, _membershipRepository, new MentionInboxRepository(MongoClient),
+            _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), _notificationPreferenceRepository);
+
+        var now = DateTime.UtcNow;
+        var message = new W3ChampionsChatService.Messages.ChannelMessage
+        {
+            ChannelId = channel.Id,
+            Seq = 1,
+            Sender = new W3ChampionsChatService.Messages.MessageSender { BattleTag = "someone#1", Name = "Someone" },
+            Content = "hey there",
+            SentAt = now,
+            ExpiresAt = ExpiryCalculator.ForChannelMessage(ChannelType.Public, now),
+        };
+        await fanOut.NotifyAsync(channel, message, new[] { BattleTag }, now);
+
+        var inbox = new MentionInboxRepository(MongoClient);
+        Assert.That(await inbox.LoadForUser(BattleTag.ToLowerInvariant()), Has.Count.EqualTo(1),
+            "a persisted level other than None must not keep suppressing a mention after leaving");
     }
 }

--- a/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
@@ -108,7 +108,8 @@ public class ChatHubMembershipTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMentionInboxTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionInboxTests.cs
@@ -118,7 +118,8 @@ public class ChatHubMentionInboxTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            _mentionInboxRepository);
+            _mentionInboxRepository,
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMentionInboxTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionInboxTests.cs
@@ -48,6 +48,7 @@ public class ChatHubMentionInboxTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -78,6 +79,7 @@ public class ChatHubMentionInboxTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _mentionInboxRepository = new MentionInboxRepository(MongoClient);
@@ -104,6 +106,7 @@ public class ChatHubMentionInboxTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubMentionSearchTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionSearchTests.cs
@@ -118,7 +118,8 @@ public class ChatHubMentionSearchTests : IntegrationTestBase
             authService ?? _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            _mentionInboxRepository);
+            _mentionInboxRepository,
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMentionSearchTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionSearchTests.cs
@@ -48,6 +48,7 @@ public class ChatHubMentionSearchTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -78,6 +79,7 @@ public class ChatHubMentionSearchTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _mentionInboxRepository = new MentionInboxRepository(MongoClient);
@@ -104,6 +106,7 @@ public class ChatHubMentionSearchTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
@@ -146,7 +146,8 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         var callerProxy = new Mock<ISingleClientProxy>();

--- a/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
@@ -60,6 +60,7 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -98,6 +99,7 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _userSettings = new UserSettingsRepository(MongoClient);
@@ -132,6 +134,7 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubOpenDmTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubOpenDmTests.cs
@@ -132,7 +132,8 @@ public class ChatHubOpenDmTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubOpenDmTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubOpenDmTests.cs
@@ -46,6 +46,7 @@ public class ChatHubOpenDmTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -80,6 +81,7 @@ public class ChatHubOpenDmTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _userSettings = new UserSettingsRepository(MongoClient);
@@ -118,6 +120,7 @@ public class ChatHubOpenDmTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubPresenceReadTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceReadTests.cs
@@ -49,6 +49,7 @@ public class ChatHubPresenceReadTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private FanOutEngine _fanOutEngine;
     private CountingUserDirectoryRepository _userDirectory;
@@ -80,6 +81,7 @@ public class ChatHubPresenceReadTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _userDirectory = new CountingUserDirectoryRepository(MongoClient);
@@ -132,6 +134,7 @@ public class ChatHubPresenceReadTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubPresenceReadTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceReadTests.cs
@@ -146,7 +146,8 @@ public class ChatHubPresenceReadTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
@@ -56,6 +56,7 @@ public class ChatHubPresenceTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
@@ -88,6 +89,7 @@ public class ChatHubPresenceTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _presenceInterestRegistry = new PresenceInterestRegistry();
         _userDirectory = new UserDirectoryRepository(MongoClient);
@@ -140,6 +142,7 @@ public class ChatHubPresenceTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
@@ -154,7 +154,8 @@ public class ChatHubPresenceTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             _presenceInterestRegistry, // SHARED — same instance the engine reads
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
@@ -213,7 +213,13 @@ public class ChatHubPresenceTests : IntegrationTestBase
 
     // ---- Mongo seed helpers ------------------------------------------------------------------------
 
-    private async Task<ChatChannel> CreateChannel(string name, ChannelType type)
+    // Follow-up spec §6: SessionStateAssembler.SelectSnapshotMemberships now reads channel.PairKey for
+    // every non-pending 1:1 Dm (the blocked-shell keep) — a REAL Dm channel always carries one
+    // (ChannelRepository.FindOrCreateDm always sets it via DmPairKey.For; the collection's unique
+    // partial index enforces Type==Dm ⇒ PairKey present). dmBattleTagA/B are therefore REQUIRED for
+    // ChannelType.Dm so this fixture can never manufacture the data-impossible shape (a Dm channel with
+    // no PairKey) that used to slip past every test that never exercised the connect snapshot's DM slice.
+    private async Task<ChatChannel> CreateChannel(string name, ChannelType type, string dmBattleTagA = null, string dmBattleTagB = null)
     {
         var channel = new ChatChannel
         {
@@ -224,6 +230,11 @@ public class ChatHubPresenceTests : IntegrationTestBase
         };
         if (type == ChannelType.Dm)
         {
+            if (dmBattleTagA == null || dmBattleTagB == null)
+            {
+                throw new ArgumentException("CreateChannel(ChannelType.Dm, ...) requires both dmBattleTagA and dmBattleTagB to build a real PairKey");
+            }
+            channel.PairKey = DmPairKey.For(dmBattleTagA, dmBattleTagB);
             channel.RequestState = DmRequestState.Accepted;
         }
         await _channelRepository.Insert(channel);
@@ -265,7 +276,7 @@ public class ChatHubPresenceTests : IntegrationTestBase
         const string AliceTag = "Alice#1";
         const string XavierTag = "Xavier#9";
 
-        var dm = await CreateChannel("dm-ax", ChannelType.Dm);
+        var dm = await CreateChannel("dm-ax", ChannelType.Dm, AliceTag, XavierTag);
         await SeedMembership(dm.Id, AliceTag);
         await SeedMembership(dm.Id, XavierTag);
 
@@ -296,13 +307,13 @@ public class ChatHubPresenceTests : IntegrationTestBase
         const string CharlieTag = "Charlie#7";
         const string YoungTag = "Young#5";
 
-        var dmAx = await CreateChannel("dm-ax", ChannelType.Dm);
+        var dmAx = await CreateChannel("dm-ax", ChannelType.Dm, AliceTag, XavierTag);
         await SeedMembership(dmAx.Id, AliceTag);
         await SeedMembership(dmAx.Id, XavierTag);
 
         // Charlie is GENUINELY wired: online, and focused on an UNRELATED DM (with Young), so Charlie
         // is a live watcher — just not of Xavier.
-        var dmCy = await CreateChannel("dm-cy", ChannelType.Dm);
+        var dmCy = await CreateChannel("dm-cy", ChannelType.Dm, CharlieTag, YoungTag);
         await SeedMembership(dmCy.Id, CharlieTag);
         await SeedMembership(dmCy.Id, YoungTag);
 
@@ -362,7 +373,7 @@ public class ChatHubPresenceTests : IntegrationTestBase
         const string AliceTag = "Alice#1";
         const string XavierTag = "Xavier#9";
 
-        var dm = await CreateChannel("dm-ax", ChannelType.Dm);
+        var dm = await CreateChannel("dm-ax", ChannelType.Dm, AliceTag, XavierTag);
         await SeedMembership(dm.Id, AliceTag);
         await SeedMembership(dm.Id, XavierTag);
 

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -104,7 +104,8 @@ public class ChatHubSendMessageTests : IntegrationTestBase
             _mentionPushHarness.HubContext,
             _sessionRegistry,
             _membershipRepository,
-            _mentionInboxRepository);
+            _mentionInboxRepository,
+            _userDirectory);
         _assembler = new SessionStateAssembler(
             _membershipRepository,
             _channelRepository,
@@ -729,8 +730,11 @@ public class ChatHubSendMessageTests : IntegrationTestBase
     // C6 "strip & deliver as plain" (Marco decision 3): a message is NEVER rejected because of its
     // mentions' access/resolvability. An unresolvable/garbage tag, or a tag naming a NON-member, delivers
     // VERBATIM (the client renders the invalid <@…> as plain) and simply produces no inbox entry + no
-    // notification — the membership wall in MentionFanOut is the sole authority on who is notified. These
-    // exercise the full SendMessage pipeline end-to-end (real MentionFanOut + inbox repo + push harness).
+    // notification — the membership wall in MentionFanOut is the sole authority on who is notified. Since
+    // follow-up spec §4, that wall is widened for PUBLIC channels: a directory-RESOLVABLE non-member of a
+    // Public channel now DOES get an entry + notification (only an unresolvable tag still gets nothing
+    // there); Dm/GroupDm/SemiPublic/System keep the unconditional membership wall. These exercise the full
+    // SendMessage pipeline end-to-end (real MentionFanOut + inbox repo + push harness).
     // ---------------------------------------------------------------------------------------------
 
     [Test]
@@ -753,7 +757,7 @@ public class ChatHubSendMessageTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task Mention_ResolvableNonMemberOfPublicChannel_Ok_NoInboxEntry()
+    public async Task Mention_ResolvableNonMemberOfPublicChannel_Ok_GetsInboxEntryAndPush()
     {
         var channel = await CreateChannel("general");
         SeedMember("conn-1", BattleTag, channel.Id);
@@ -765,11 +769,10 @@ public class ChatHubSendMessageTests : IntegrationTestBase
         var result = await hub.SendMessage(channel.Id, $"hey {Mention("stranger#1")}");
 
         Assert.AreEqual(ChatResultCode.Ok, result.Code, "mentioning a resolvable non-member of a public channel is legal — no reject");
-        Assert.IsEmpty(await _mentionInboxRepository.LoadForUser("stranger#1"),
-            "a non-member of a Public channel gets NO inbox entry — the uniform membership wall applies to every channel type");
-        Assert.AreEqual(0, _mentionPushHarness.SignalCount("conn-stranger", ChatEvents.MentionNotified),
-            "and no MentionNotified push");
-        Assert.IsEmpty(_mentionPushHarness.AllSignals, "the only mention target was a non-member — nobody is notified");
+        Assert.AreEqual(1, (await _mentionInboxRepository.LoadForUser("stranger#1")).Count,
+            "follow-up spec §4: a directory-resolvable non-member of a PUBLIC channel now gets an inbox entry — the membership wall is widened away for Public rooms only");
+        Assert.AreEqual(1, _mentionPushHarness.SignalCount("conn-stranger", ChatEvents.MentionNotified),
+            "and the targeted MentionNotified push");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -349,6 +349,12 @@ public class ChatHubSendMessageTests : IntegrationTestBase
             await hub.SendMessage(channel.Id, $"spam-{i}");
         }
 
+        // A REAL relaunch: conn-1 actually disconnects — running the hub's full disconnect teardown
+        // (FocusRegistry/OnlineMemberRegistry/etc. all torn down) — BEFORE conn-2 is ever seeded. This
+        // is what proves MessageRateLimiter state survives actual disconnect (locking in the removed
+        // ChatHub.cs RemoveConnection call), not merely that a second connection can coexist.
+        await hub.OnDisconnectedAsync(null);
+
         // "Relaunch": a brand-new connection, SAME battleTag. Pre-§1 this was a clean slate.
         SeedMember("conn-2", BattleTag, channel.Id);
         var reconnected = BuildHub("conn-2");

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -586,7 +586,8 @@ public class ChatHubSendMessageTests : IntegrationTestBase
 
     // ---------------------------------------------------------------------------------------------
     // C6 Task 5 — mention fan-out (D3/D4), end-to-end through the SendMessage pipeline. These exercise
-    // the step-7.75 call site (validated mention list → MentionFanOut → durable entry + targeted event),
+    // the step-8 call site (fix round 1 F2b renumbered it — validated mention list → MentionFanOut →
+    // durable entry + targeted event),
     // the shadow call-site skip, focus-irrelevance, and the sender-ack fault isolation. The per-rule
     // eligibility boundary is covered directly in MentionFanOutTests.
     // ---------------------------------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -105,7 +105,7 @@ public class ChatHubSendMessageTests : IntegrationTestBase
             _sessionRegistry,
             _membershipRepository,
             _mentionInboxRepository,
-            _userDirectory);
+            _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), new NotificationPreferenceRepository(MongoClient));
         _assembler = new SessionStateAssembler(
             _membershipRepository,
             _channelRepository,
@@ -142,7 +142,8 @@ public class ChatHubSendMessageTests : IntegrationTestBase
             _authService.Object,
             _mentionFanOut,
             new PresenceInterestRegistry(),
-            _mentionInboxRepository);
+            _mentionInboxRepository,
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         var callerProxy = new Mock<ISingleClientProxy>();

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -336,6 +336,28 @@ public class ChatHubSendMessageTests : IntegrationTestBase
         Assert.AreEqual(1, notices, "Exactly one ThrottleNotice must be pushed on the single auto-throttle escalation");
     }
 
+    [Test]
+    public async Task Send_AutoThrottle_SurvivesReconnect_SameBattleTag()
+    {
+        var channel = await CreateChannel("general");
+        SeedMember("conn-1", BattleTag, channel.Id);
+        var hub = BuildHub("conn-1");
+
+        // Drive conn-1 into hard auto-throttle: burst, then threshold violations (frozen clock — no refill).
+        for (var i = 0; i < ChatLimits.PerChannelBurst + ChatLimits.AutoThrottleViolationThreshold; i++)
+        {
+            await hub.SendMessage(channel.Id, $"spam-{i}");
+        }
+
+        // "Relaunch": a brand-new connection, SAME battleTag. Pre-§1 this was a clean slate.
+        SeedMember("conn-2", BattleTag, channel.Id);
+        var reconnected = BuildHub("conn-2");
+        var result = await reconnected.SendMessage(channel.Id, "back for more");
+
+        Assert.AreEqual(ChatResultCode.Throttled, result.Code, "the auto-throttle must survive the reconnect");
+        Assert.IsTrue(result.RetryAfterSeconds > 0);
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Membership / channel resolution
     // ---------------------------------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -773,6 +773,7 @@ public class ChatHubSendMessageTests : IntegrationTestBase
             "follow-up spec §4: a directory-resolvable non-member of a PUBLIC channel now gets an inbox entry — the membership wall is widened away for Public rooms only");
         Assert.AreEqual(1, _mentionPushHarness.SignalCount("conn-stranger", ChatEvents.MentionNotified),
             "and the targeted MentionNotified push");
+        Assert.AreEqual(1, _mentionPushHarness.AllSignals.Count, "exactly one push — targeted at the stranger, nobody else");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -56,6 +56,7 @@ public class ChatHubSendMessageTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -96,6 +97,7 @@ public class ChatHubSendMessageTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _mentionPushHarness = new HubPushCaptureHarness();
@@ -128,6 +130,7 @@ public class ChatHubSendMessageTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubSettingsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSettingsTests.cs
@@ -40,6 +40,7 @@ public class ChatHubSettingsTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
     private FanOutEngine _fanOutEngine;
@@ -63,6 +64,7 @@ public class ChatHubSettingsTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
         _userSettings = new UserSettingsRepository(MongoClient);
@@ -94,6 +96,7 @@ public class ChatHubSettingsTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ChatHubSettingsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSettingsTests.cs
@@ -108,7 +108,8 @@ public class ChatHubSettingsTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatLimitsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatLimitsTests.cs
@@ -46,7 +46,10 @@ public class ChatLimitsTests
         Assert.AreEqual(100, ChatLimits.MessagePageSize);
         Assert.AreEqual(5, ChatLimits.AutoThrottleViolationThreshold);
         Assert.AreEqual(TimeSpan.FromSeconds(60), ChatLimits.AutoThrottleWindow);
-        Assert.AreEqual(TimeSpan.FromSeconds(60), ChatLimits.AutoThrottleDuration);
+        CollectionAssert.AreEqual(
+            new[] { TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60) },
+            ChatLimits.AutoThrottleTierDurations);
+        Assert.AreEqual(TimeSpan.FromMinutes(10), ChatLimits.AutoThrottleTierDecay);
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatLimitsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatLimitsTests.cs
@@ -90,6 +90,20 @@ public class ChatLimitsTests
     }
 
     [Test]
+    public void ConversationsPageSize_IsAtLeastLauncherPageSize()
+    {
+        // Cross-repo contract (Task 8 fix round, finding 3): the launcher's client-side page size
+        // (CONVERSATIONS_PAGE_SIZE = 30, launcher-e chat plumbing) drives GetConversations' Count &lt;
+        // limit end-detection (see GetConversationsResult's doc comment). That end-detection is only
+        // sound when a caller's requested limit never exceeds this cap — a launcher paging at 30 while
+        // this cap ever dropped below 30 would get a silently-clamped, potentially-short page and could
+        // stop pagination early. Pinned here so a future change to either constant is caught at CI time.
+        Assert.GreaterOrEqual(ChatLimits.ConversationsPageSize, 30,
+            "the launcher's CONVERSATIONS_PAGE_SIZE = 30 depends on ChatLimits.ConversationsPageSize " +
+            "staying >= 30 for GetConversations' Count < limit end-detection to remain sound");
+    }
+
+    [Test]
     public void DefaultChatRooms_NormalizeToDistinctKeys()
     {
         // C3 Task 3: Guards the static SessionStateAssembler.CatalogOrder initialization invariant.

--- a/W3ChampionsChatService.Tests/ChatLimitsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatLimitsTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using NUnit.Framework;
 using W3ChampionsChatService.Domain;
 
@@ -50,6 +51,20 @@ public class ChatLimitsTests
             new[] { TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60) },
             ChatLimits.AutoThrottleTierDurations);
         Assert.AreEqual(TimeSpan.FromMinutes(10), ChatLimits.AutoThrottleTierDecay);
+    }
+
+    [Test]
+    public void AutoThrottleTierDurations_AreAllBelowTierDecay()
+    {
+        // Pins the invariant documented at AutoThrottleTierDurations' declaration: MessageRateLimiter's
+        // quiescent prune treats AutoThrottleTierDecay as "definitely idle, safe to evict" for a user's
+        // ENTIRE state (buckets, violations, ladder, and any active hard throttle). That is only true if
+        // no tier duration can outlive the decay horizon — otherwise a still-hard-throttled user could be
+        // pruned mid-penalty and get a silent clean slate on their very next send.
+        Assert.IsTrue(
+            ChatLimits.AutoThrottleTierDurations.All(tier => tier < ChatLimits.AutoThrottleTierDecay),
+            "every AutoThrottleTierDurations entry must be strictly less than AutoThrottleTierDecay, or " +
+            "MessageRateLimiter's quiescent prune could evict a still-hard-throttled user's state early");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatLimitsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatLimitsTests.cs
@@ -122,7 +122,7 @@ public class ChatLimitsTests
         // entry and letting a later call recreate it fresh (a full ReadBurst-token bucket) is only
         // behaviour-preserving if a LIVE bucket, left untouched for that same idle duration, would ALSO
         // have refilled all the way back to capacity — i.e. the prune horizon must exceed the bucket's
-        // own full-refill time (ReadBurst / ReadRefillPerSecond seconds = 6s).
+        // own full-refill time (ReadBurst / ReadRefillPerSecond seconds = 12s).
         var fullRefillTime = TimeSpan.FromSeconds((double)ChatLimits.ReadBurst / ChatLimits.ReadRefillPerSecond);
         Assert.Greater(ChatLimits.ReadRateLimiterPruneHorizon, fullRefillTime,
             "ReadRateLimiterPruneHorizon must strictly exceed the bucket's full-refill time, or a pruned " +

--- a/W3ChampionsChatService.Tests/ChatLimitsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatLimitsTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 
 namespace W3ChampionsChatService.Tests;
@@ -85,5 +87,20 @@ public class ChatLimitsTests
         Assert.AreEqual(100, ChatLimits.MentionAckBatchMax);
         Assert.AreEqual(200, ChatLimits.MentionInboxMaxEntries);
         Assert.AreEqual(200, ChatLimits.PresenceQueryMaxBattleTags);
+    }
+
+    [Test]
+    public void DefaultChatRooms_NormalizeToDistinctKeys()
+    {
+        // C3 Task 3: Guards the static SessionStateAssembler.CatalogOrder initialization invariant.
+        // If any two DefaultChatRooms.Rooms entries normalize to the same key (via ChannelNames.Normalize:
+        // trim + ToLowerInvariant), the ToDictionary call at static init throws KeyAlreadyExistsException
+        // → TypeInitializationException on every connect (full outage). This test pins the invariant at CI time.
+        Assert.IsNotEmpty(DefaultChatRooms.Rooms, "DefaultChatRooms.Rooms must be non-empty");
+        var normalizedNames = DefaultChatRooms.Rooms.Select(ChannelNames.Normalize).ToList();
+        var distinctCount = normalizedNames.Distinct().Count();
+        Assert.AreEqual(normalizedNames.Count, distinctCount,
+            "all DefaultChatRooms.Rooms entries must normalize to distinct keys, or " +
+            "SessionStateAssembler.CatalogOrder's static ToDictionary initialization will crash with TypeInitializationException");
     }
 }

--- a/W3ChampionsChatService.Tests/ChatLimitsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatLimitsTests.cs
@@ -107,7 +107,9 @@ public class ChatLimitsTests
     public void ReadRateLimiterConstants_MatchPr36FeedbackPart3()
     {
         // 2026-08-05 PR36 feedback, Part 3 — NOT spec §13; hard-coded, adjust here only.
-        Assert.AreEqual(30, ChatLimits.ReadBurst);
+        // Fix round 1, finding F1: ReadBurst raised 30 -> 60 (sized for connect fan-out, not a
+        // per-user-action handful of loads — see ChatLimits.ReadBurst's doc comment).
+        Assert.AreEqual(60, ChatLimits.ReadBurst);
         Assert.AreEqual(5, ChatLimits.ReadRefillPerSecond);
         Assert.AreEqual(TimeSpan.FromMinutes(2), ChatLimits.ReadRateLimiterPruneHorizon);
     }

--- a/W3ChampionsChatService.Tests/ChatLimitsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatLimitsTests.cs
@@ -104,6 +104,30 @@ public class ChatLimitsTests
     }
 
     [Test]
+    public void ReadRateLimiterConstants_MatchPr36FeedbackPart3()
+    {
+        // 2026-08-05 PR36 feedback, Part 3 — NOT spec §13; hard-coded, adjust here only.
+        Assert.AreEqual(30, ChatLimits.ReadBurst);
+        Assert.AreEqual(5, ChatLimits.ReadRefillPerSecond);
+        Assert.AreEqual(TimeSpan.FromMinutes(2), ChatLimits.ReadRateLimiterPruneHorizon);
+    }
+
+    [Test]
+    public void ReadRateLimiterPruneHorizon_ExceedsBucketFullRefillTime()
+    {
+        // Pins the invariant documented at ReadRateLimiterPruneHorizon's declaration — mirrors
+        // AutoThrottleTierDurations_AreAllBelowTierDecay above, but for ReadRateLimiter: pruning an idle
+        // entry and letting a later call recreate it fresh (a full ReadBurst-token bucket) is only
+        // behaviour-preserving if a LIVE bucket, left untouched for that same idle duration, would ALSO
+        // have refilled all the way back to capacity — i.e. the prune horizon must exceed the bucket's
+        // own full-refill time (ReadBurst / ReadRefillPerSecond seconds = 6s).
+        var fullRefillTime = TimeSpan.FromSeconds((double)ChatLimits.ReadBurst / ChatLimits.ReadRefillPerSecond);
+        Assert.Greater(ChatLimits.ReadRateLimiterPruneHorizon, fullRefillTime,
+            "ReadRateLimiterPruneHorizon must strictly exceed the bucket's full-refill time, or a pruned " +
+            "entry recreated fresh could diverge from what a live, un-pruned bucket would actually hold");
+    }
+
+    [Test]
     public void DefaultChatRooms_NormalizeToDistinctKeys()
     {
         // C3 Task 3: Guards the static SessionStateAssembler.CatalogOrder initialization invariant.

--- a/W3ChampionsChatService.Tests/CleanupJobsTests.cs
+++ b/W3ChampionsChatService.Tests/CleanupJobsTests.cs
@@ -68,4 +68,25 @@ public class CleanupJobsTests : IntegrationTestBase
         Assert.AreEqual(1, (await membershipRepo.LoadForUser("NoDirectoryEntry#3")).Count,
             "users unknown to the directory are conservatively kept");
     }
+
+    // Fix round 1 (F6): PruneIdleMemberships also sweeps the SAME idle users' NotificationPreference rows
+    // — that carrier has no TTL of its own (PR36 D2 — deliberately durable across an ordinary leave/
+    // rejoin), so this job is its ONLY GC path and must not let it outlive every other trace of the user.
+    [Test]
+    public async Task IdleMembershipPruning_AlsoRemovesNotificationPreferencesOfIdleUsers()
+    {
+        var directoryRepo = new UserDirectoryRepository(MongoClient);
+        var prefsRepo = new NotificationPreferenceRepository(MongoClient);
+        var now = DateTime.UtcNow;
+
+        await directoryRepo.Upsert(new UserDirectoryEntry { BattleTag = "Idle#1", NormalizedName = "idle#1", LastSeenAt = now.AddDays(-400) });
+        await directoryRepo.Upsert(new UserDirectoryEntry { BattleTag = "Active#2", NormalizedName = "active#2", LastSeenAt = now.AddDays(-5) });
+        await prefsRepo.Upsert("Idle#1", "chan1", NotificationLevel.None, now.AddDays(-500));
+        await prefsRepo.Upsert("Active#2", "chan1", NotificationLevel.None, now.AddDays(-500));
+
+        await new CleanupJobs(MongoClient).PruneIdleMemberships(now);
+
+        Assert.IsNull(await prefsRepo.Load("Idle#1", "chan1"), "the idle user's persisted preference must be pruned too");
+        Assert.IsNotNull(await prefsRepo.Load("Active#2", "chan1"), "the active user's preference must survive");
+    }
 }

--- a/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
@@ -200,7 +200,8 @@ public class DmGroupIntegrationTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
@@ -72,6 +72,7 @@ public class DmGroupIntegrationTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
@@ -115,6 +116,7 @@ public class DmGroupIntegrationTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _userDirectory = new UserDirectoryRepository(MongoClient);
         _muteRepository = new MuteRepository(MongoClient);
@@ -186,6 +188,7 @@ public class DmGroupIntegrationTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/DomainPrimitivesTests.cs
+++ b/W3ChampionsChatService.Tests/DomainPrimitivesTests.cs
@@ -28,4 +28,32 @@ public class DomainPrimitivesTests
     {
         Assert.AreEqual("peter#123|wolf#456", DmPairKey.For("WOLF#456", "peter#123"));
     }
+
+    [Test]
+    public void CounterpartOf_ReturnsTheOtherHalf()
+    {
+        var pairKey = DmPairKey.For("Peter#123", "Wolf#456");
+
+        Assert.AreEqual("wolf#456", DmPairKey.CounterpartOf(pairKey, "Peter#123"));
+        Assert.AreEqual("peter#123", DmPairKey.CounterpartOf(pairKey, "Wolf#456"));
+    }
+
+    // 2026-08-04 follow-up (Minor finding): CounterpartOf's parts[0] comparison must be
+    // StringComparison.OrdinalIgnoreCase (the pre-hoist ResolveDmCounterpart behavior), not a plain
+    // ordinal ==. parts[0] is normally lowercased by DmPairKey.For and the incoming battleTag is
+    // lowercased via ToLowerInvariant before comparing — but ToLowerInvariant is not guaranteed to fold
+    // every code point identically to what an OrdinalIgnoreCase match tolerates, so an ordinal-only
+    // comparison could spuriously miss and hand back the CALLER'S OWN tag as its "counterpart" instead
+    // of the real one. Constructs a pair-key with an uppercase first half directly (bypassing
+    // DmPairKey.For's own lowercasing) to pin that a casing mismatch on parts[0] itself still resolves
+    // correctly — this regresses under a plain ordinal `==`.
+    [Test]
+    public void CounterpartOf_MatchesFirstHalfCaseInsensitively()
+    {
+        const string pairKey = "PETER#123|wolf#456";
+
+        Assert.AreEqual("wolf#456", DmPairKey.CounterpartOf(pairKey, "peter#123"),
+            "an OrdinalIgnoreCase match against parts[0] must resolve to the real counterpart, not fall " +
+            "through to returning the caller's own tag");
+    }
 }

--- a/W3ChampionsChatService.Tests/FanOutRegistryTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutRegistryTests.cs
@@ -321,6 +321,54 @@ public class FanOutRegistryTests
         Assert.DoesNotThrow(() => _memberRegistry.AdvanceLastReadSeq("channel-a", "conn-unknown", 42));
     }
 
+    // ---------------------------------------------------------------------
+    // OnlineMemberRegistry.JoinPreservingReadCursor (Task 8 fix round, finding 5) — the
+    // GetConversations-safe sibling of Join: preserves an existing, possibly-newer LastReadSeq
+    // (Math.Max) instead of a plain overwrite, so a concurrent MarkRead landing between the caller's
+    // stale DB read and this seed can never be regressed back down.
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void JoinPreservingReadCursor_NoExistingEntry_BehavesLikeJoin()
+    {
+        _memberRegistry.JoinPreservingReadCursor("channel-a", "conn-1", new MemberState("peter#123", NotificationLevel.All, 5, ChannelType.Dm));
+
+        Assert.That(_memberRegistry.GetMembers("channel-a").Single().LastReadSeq, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void JoinPreservingReadCursor_ExistingHigherLastReadSeq_IsPreserved()
+    {
+        _memberRegistry.Join("channel-a", "conn-1", new MemberState("peter#123", NotificationLevel.All, 10, ChannelType.Dm));
+
+        _memberRegistry.JoinPreservingReadCursor("channel-a", "conn-1", new MemberState("peter#123", NotificationLevel.All, 3, ChannelType.Dm));
+
+        Assert.That(_memberRegistry.GetMembers("channel-a").Single().LastReadSeq, Is.EqualTo(10),
+            "a stale DB-loaded LastReadSeq must never regress a newer registry value (e.g. a concurrent MarkRead)");
+    }
+
+    [Test]
+    public void JoinPreservingReadCursor_ExistingLowerLastReadSeq_Advances()
+    {
+        _memberRegistry.Join("channel-a", "conn-1", new MemberState("peter#123", NotificationLevel.All, 3, ChannelType.Dm));
+
+        _memberRegistry.JoinPreservingReadCursor("channel-a", "conn-1", new MemberState("peter#123", NotificationLevel.All, 10, ChannelType.Dm));
+
+        Assert.That(_memberRegistry.GetMembers("channel-a").Single().LastReadSeq, Is.EqualTo(10));
+    }
+
+    [Test]
+    public void JoinPreservingReadCursor_UpdatesOtherFieldsEvenWhenSeqIsPreserved()
+    {
+        _memberRegistry.Join("channel-a", "conn-1", new MemberState("peter#123", NotificationLevel.All, 10, ChannelType.Dm));
+
+        _memberRegistry.JoinPreservingReadCursor("channel-a", "conn-1", new MemberState("peter#123", NotificationLevel.Mentions, 3, ChannelType.Dm));
+
+        var member = _memberRegistry.GetMembers("channel-a").Single();
+        Assert.That(member.LastReadSeq, Is.EqualTo(10));
+        Assert.That(member.NotificationLevel, Is.EqualTo(NotificationLevel.Mentions));
+    }
+
     [Test]
     public void GetMembers_UnknownChannel_ReturnsEmpty()
     {

--- a/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
@@ -170,7 +170,8 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
@@ -71,6 +71,7 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
@@ -103,6 +104,7 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _userDirectory = new UserDirectoryRepository(MongoClient);
         _muteRepository = new MuteRepository(MongoClient);
@@ -156,6 +158,7 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/HubPushCaptureHarness.cs
+++ b/W3ChampionsChatService.Tests/HubPushCaptureHarness.cs
@@ -37,6 +37,12 @@ public sealed class HubPushCaptureHarness
     // capture list since both are read/written from the same Client(connectionId) callback.
     private readonly Dictionary<string, Exception> _throwingConnections = new();
 
+    // ConnectionIds configured (via GateSend) to await a caller-supplied Task before recording —
+    // lets a test hold a specific connection's send genuinely in flight (never landing until released)
+    // to prove some caller does NOT await it (fire-and-forget), as opposed to just being fast. Guarded by
+    // lock (_sends) alongside the other lookup dictionaries for the same reason.
+    private readonly Dictionary<string, Task> _gatedConnections = new();
+
     public HubPushCaptureHarness()
     {
         var hubClients = new Mock<IHubClients>();
@@ -50,9 +56,11 @@ public sealed class HubPushCaptureHarness
                     .Returns<string, object[], CancellationToken>((method, args, _) =>
                     {
                         Exception exceptionToThrow;
+                        Task gate;
                         lock (_sends)
                         {
                             _throwingConnections.TryGetValue(connectionId, out exceptionToThrow);
+                            _gatedConnections.TryGetValue(connectionId, out gate);
                         }
 
                         if (exceptionToThrow != null)
@@ -60,17 +68,28 @@ public sealed class HubPushCaptureHarness
                             return Task.FromException(exceptionToThrow);
                         }
 
-                        lock (_sends)
-                        {
-                            _sends.Add((connectionId, method, args.Length > 0 ? args[0] : null));
-                        }
-                        return Task.CompletedTask;
+                        return RecordAsync(connectionId, method, args, gate);
                     });
                 return proxy.Object;
             });
 
         _hubContextMock = new Mock<IHubContext<ChatHub>>();
         _hubContextMock.Setup(h => h.Clients).Returns(hubClients.Object);
+    }
+
+    // Awaits the gate (if any) BEFORE recording — so a test asserting on SignalsFor/PayloadFor/etc while
+    // the gate is held observes NOTHING for this send yet, and only sees it after release.
+    private async Task RecordAsync(string connectionId, string method, object[] args, Task gate)
+    {
+        if (gate != null)
+        {
+            await gate;
+        }
+
+        lock (_sends)
+        {
+            _sends.Add((connectionId, method, args.Length > 0 ? args[0] : null));
+        }
     }
 
     /// <summary>
@@ -84,6 +103,23 @@ public sealed class HubPushCaptureHarness
         lock (_sends)
         {
             _throwingConnections[connectionId] = exception ?? new InvalidOperationException($"Simulated send failure for connection '{connectionId}'");
+        }
+    }
+
+    /// <summary>
+    /// Configures every subsequent <c>SendAsync</c>/<c>SendCoreAsync</c> call to <paramref
+    /// name="connectionId"/> to await <paramref name="gate"/> before it records the signal (or completes
+    /// at all) — holds that connection's send genuinely in flight so a test can prove some caller does
+    /// NOT await it (fire-and-forget) rather than merely being fast enough to race past. While the gate is
+    /// held, <see cref="SignalsFor"/>/<see cref="PayloadFor"/>/<see cref="SignalCount"/> report NOTHING for
+    /// this send; once <paramref name="gate"/> completes the signal is recorded as normal. Other
+    /// connections are unaffected.
+    /// </summary>
+    public void GateSend(string connectionId, Task gate)
+    {
+        lock (_sends)
+        {
+            _gatedConnections[connectionId] = gate;
         }
     }
 

--- a/W3ChampionsChatService.Tests/MembershipRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/MembershipRepositoryTests.cs
@@ -173,6 +173,34 @@ public class MembershipRepositoryTests : IntegrationTestBase
         Assert.AreEqual(2, count);
     }
 
+    // 2026-08-05 PR36 feedback (Part 3): a user with zero memberships must short-circuit to 0 without
+    // the second (channel-count) round-trip ever needing to run against a real id set.
+    [Test]
+    public async Task CountNameJoinableMembershipsForUser_ZeroMemberships_ReturnsZero()
+    {
+        var membershipRepo = new MembershipRepository(MongoClient, new ChannelRepository(MongoClient));
+
+        var count = await membershipRepo.CountNameJoinableMembershipsForUser("Nobody#999");
+
+        Assert.AreEqual(0, count);
+    }
+
+    // 2026-08-05 PR36 feedback (Part 3): CountNameJoinableMembershipsForUser was rewritten from a
+    // full-document double-load to a projected ChannelId read + a server-side CountDocumentsAsync — pins
+    // the projection itself returns exactly the caller's own channel ids, nobody else's.
+    [Test]
+    public async Task LoadChannelIdsForUser_ReturnsOnlyThatUsersChannelIds()
+    {
+        var membershipRepo = new MembershipRepository(MongoClient, new ChannelRepository(MongoClient));
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = "chan1", BattleTag = "Peter#123", JoinedAt = DateTime.UtcNow });
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = "chan2", BattleTag = "Peter#123", JoinedAt = DateTime.UtcNow });
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = "chan1", BattleTag = "Wolf#456", JoinedAt = DateTime.UtcNow });
+
+        var ids = await membershipRepo.LoadChannelIdsForUser("Peter#123");
+
+        CollectionAssert.AreEquivalent(new[] { "chan1", "chan2" }, ids);
+    }
+
     // ── C5 Task 2 — DM/group repository foundation additions ─────────────────────────────
 
     [Test]

--- a/W3ChampionsChatService.Tests/MembershipRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/MembershipRepositoryTests.cs
@@ -44,6 +44,30 @@ public class MembershipRepositoryTests : IntegrationTestBase
         CollectionAssert.AreEquivalent(new[] { "chan1", "chan2" }, mine.Select(m => m.ChannelId).ToList());
     }
 
+    // 2026-08-04 follow-up (carried launcher-review item): LoadForUser had no explicit sort, so
+    // SessionStateDto.Channels order was Mongo-arbitrary — the launcher relies on server order to
+    // preserve "join order" for name-joinable (SemiPublic) channels across a reconnect. Pinned here at
+    // scrambled INSERTION order against distinct, out-of-insertion-order JoinedAt stamps: the returned
+    // list must come back JoinedAt-ascending regardless of when each row was written.
+    [Test]
+    public async Task LoadForUser_ReturnsChannelsInJoinedAtAscendingOrder_RegardlessOfInsertionOrder()
+    {
+        var repo = new MembershipRepository(MongoClient, new ChannelRepository(MongoClient));
+        var t0 = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // Inserted in scrambled order: chan3 (oldest JoinedAt) written FIRST, chan1 (newest) written LAST.
+        await repo.Insert(new ChannelMembership { ChannelId = "chan3", BattleTag = "Peter#123", JoinedAt = t0 });
+        await repo.Insert(new ChannelMembership { ChannelId = "chan1", BattleTag = "Peter#123", JoinedAt = t0.AddMinutes(10) });
+        await repo.Insert(new ChannelMembership { ChannelId = "chan2", BattleTag = "Peter#123", JoinedAt = t0.AddMinutes(5) });
+
+        var mine = await repo.LoadForUser("Peter#123");
+
+        CollectionAssert.AreEqual(
+            new[] { "chan3", "chan2", "chan1" },
+            mine.Select(m => m.ChannelId).ToList(),
+            "LoadForUser must return rows JoinedAt-ascending, not insertion/natural order");
+    }
+
     [Test]
     public async Task DuplicateMembership_IsRejectedByUniqueIndex()
     {

--- a/W3ChampionsChatService.Tests/MembershipRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/MembershipRepositoryTests.cs
@@ -91,8 +91,34 @@ public class MembershipRepositoryTests : IntegrationTestBase
         Assert.AreEqual(1, unique["key"]["ChannelId"].ToInt32());
         Assert.AreEqual(1, unique["key"]["BattleTag"].ToInt32());
 
-        var byUser = indexes.Single(i => i["name"] == "ix_battleTag");
+        // 2026-08-04 follow-up: ix_battleTag was extended to a compound (BattleTag, JoinedAt) index so
+        // LoadForUser's JoinedAt-ascending sort (see that method's doc) is index-served rather than an
+        // in-memory sort behind an index-only BattleTag scan.
+        var byUser = indexes.Single(i => i["name"] == "ix_battleTag_joinedAt");
         Assert.AreEqual(1, byUser["key"]["BattleTag"].ToInt32());
+        Assert.AreEqual(1, byUser["key"]["JoinedAt"].ToInt32());
+
+        Assert.IsFalse(indexes.Any(i => i["name"] == "ix_battleTag"),
+            "the superseded single-field index must be gone after ensure");
+    }
+
+    [Test]
+    public async Task MembershipIndexes_EnsureIsIdempotent_AgainstPreMigrationDatabase()
+    {
+        // Simulate a database that still carries the OLD-named single-field index from before this
+        // migration — Ensure must best-effort drop it (swallowing IndexNotFound is the OTHER branch,
+        // covered by MembershipIndexes_AreCreated running against a fresh DB) and still converge on the
+        // new compound index, never throw. Mirrors MessageRepositoryTests' equivalent D6 migration test.
+        var memberships = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName).GetCollection<ChannelMembership>(ChatCollections.ChannelMemberships);
+        await memberships.Indexes.CreateOneAsync(new CreateIndexModel<ChannelMembership>(
+            Builders<ChannelMembership>.IndexKeys.Ascending(m => m.BattleTag),
+            new CreateIndexOptions { Name = "ix_battleTag" }));
+
+        Assert.DoesNotThrowAsync(() => ChatDomainIndexes.EnsureAllAsync(MongoClient));
+
+        var indexes = await (await memberships.Indexes.ListAsync()).ToListAsync();
+        Assert.IsFalse(indexes.Any(i => i["name"] == "ix_battleTag"), "the pre-existing old-named index must be dropped");
+        Assert.IsTrue(indexes.Any(i => i["name"] == "ix_battleTag_joinedAt"), "the new compound index must exist");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/MentionFanOutTestFactory.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTestFactory.cs
@@ -3,6 +3,7 @@ using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Memberships;
 using W3ChampionsChatService.Mentions;
 using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
 
 namespace W3ChampionsChatService.Tests;
 
@@ -30,6 +31,7 @@ internal static class MentionFanOutTestFactory
             harness.HubContext,
             new SessionRegistry(),
             new MembershipRepository(mongoClient, channelRepository),
-            new MentionInboxRepository(mongoClient));
+            new MentionInboxRepository(mongoClient),
+            new UserDirectoryRepository(mongoClient));
     }
 }

--- a/W3ChampionsChatService.Tests/MentionFanOutTestFactory.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTestFactory.cs
@@ -32,6 +32,8 @@ internal static class MentionFanOutTestFactory
             new SessionRegistry(),
             new MembershipRepository(mongoClient, channelRepository),
             new MentionInboxRepository(mongoClient),
-            new UserDirectoryRepository(mongoClient));
+            new UserDirectoryRepository(mongoClient),
+            RelationshipProviderTestFactory.CreateIgnored(),
+            new NotificationPreferenceRepository(mongoClient));
     }
 }

--- a/W3ChampionsChatService.Tests/MentionFanOutTests.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTests.cs
@@ -12,6 +12,7 @@ using W3ChampionsChatService.Memberships;
 using W3ChampionsChatService.Mentions;
 using W3ChampionsChatService.Messages;
 using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Relationships;
 using W3ChampionsChatService.Sessions;
 using W3ChampionsChatService.Users;
 
@@ -38,6 +39,14 @@ namespace W3ChampionsChatService.Tests;
 /// asserts the control DID get an entry + event — so the test fails against a do-nothing stub AND
 /// against an over-permissive filter, not just one of the two.
 /// </para>
+/// <para>
+/// PR36 follow-up (D1/D2): a sixth eligibility rule — the TARGET has not blocked the sender — and a
+/// notification-preference consult path (Public non-member branch) round out the class doc's six-rule
+/// list. The default <see cref="_fanOut"/> below wires a NEVER-blocking <see cref="IRelationshipProvider"/>
+/// (<see cref="RelationshipProviderTestFactory.CreateIgnored"/>) so every PRE-EXISTING test above is
+/// unaffected; D1/D2-specific tests build their OWN <see cref="MentionFanOut"/> with a purpose-built
+/// provider/pref, mirroring the existing <c>faultyFanOut</c> per-test-customization idiom.
+/// </para>
 /// </summary>
 public class MentionFanOutTests : IntegrationTestBase
 {
@@ -55,6 +64,7 @@ public class MentionFanOutTests : IntegrationTestBase
     private MentionFanOut _fanOut;
     private FakeTimeProvider _time;
     private UserDirectoryRepository _userDirectory;
+    private NotificationPreferenceRepository _notificationPreferenceRepository;
 
     private DateTime Now => _time.GetUtcNow().UtcDateTime;
 
@@ -68,7 +78,8 @@ public class MentionFanOutTests : IntegrationTestBase
         _sessionRegistry = new SessionRegistry();
         _harness = new HubPushCaptureHarness();
         _userDirectory = new UserDirectoryRepository(MongoClient);
-        _fanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), new NotificationPreferenceRepository(MongoClient));
+        _notificationPreferenceRepository = new NotificationPreferenceRepository(MongoClient);
+        _fanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), _notificationPreferenceRepository);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -399,6 +410,144 @@ public class MentionFanOutTests : IntegrationTestBase
             "lock-in: join + NotificationLevel.None remains the opt-out even now that non-members are mentionable");
         Assert.That(await InboxOf("control#1"), Has.Count.EqualTo(1),
             "the eligible control member still gets the mention — proves this isn't vacuously true against a do-nothing fan-out");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // PR36 follow-up (D1) — block suppression: the TARGET's own block list, consulted LAST and only for
+    // an otherwise-eligible target. Each test builds its OWN MentionFanOut over a purpose-built
+    // IRelationshipProvider (mirrors the ThrowingInsertRepository/faultyFanOut per-test-customization
+    // idiom below), so the default _fanOut (a never-blocking provider) stays untouched for every other
+    // test in this class.
+    // ---------------------------------------------------------------------------------------------
+
+    // Builds a real RelationshipProvider (the production cache/fail-closed policy) over a
+    // FakeRelationshipSource whose snapshot for `blockingTargetTag` lists `blockedBattleTag` as blocked;
+    // every other tag resolves to an empty (no friends, no blocks) snapshot.
+    private MentionFanOut BuildFanOutWithBlock(string blockingTargetTag, string blockedBattleTag)
+    {
+        var source = new FakeRelationshipSource((tag, snapshotNow) =>
+            string.Equals(tag, blockingTargetTag, StringComparison.OrdinalIgnoreCase)
+                ? new RelationshipSnapshot(tag, new HashSet<string>(), new HashSet<string> { blockedBattleTag }, snapshotNow)
+                : new RelationshipSnapshot(tag, new HashSet<string>(), new HashSet<string>(), snapshotNow));
+        var provider = new RelationshipProvider(source, _time);
+        return new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, provider, _notificationPreferenceRepository);
+    }
+
+    [Test]
+    public async Task Notify_BlockedTarget_MemberBranch_NoEntryNoEvent_ControlMemberStillNotified()
+    {
+        // "wolf#456" is a fully joined, level-All member who has blocked the sender — D1 must suppress
+        // the entry + event for them even though every OTHER eligibility rule (a)-(e) is satisfied.
+        await SeedMembership("wolf#456", NotificationLevel.All);
+        RegisterSession("conn-wolf", "wolf#456");
+        await SeedMembership("frank#789", NotificationLevel.All);
+        RegisterSession("conn-frank", "frank#789");
+
+        var fanOut = BuildFanOutWithBlock(blockingTargetTag: "wolf#456", blockedBattleTag: Sender);
+
+        await fanOut.NotifyAsync(Channel(), Message(), new[] { "wolf#456", "frank#789" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Is.Empty,
+            "a joined member who has blocked the sender gets NO inbox entry");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(0), "and NO live push");
+        Assert.That(await InboxOf("frank#789"), Has.Count.EqualTo(1),
+            "a non-blocking member control (test 3: non-blocked targets in the same message) still gets the mention");
+        Assert.That(MentionEventCount("conn-frank"), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Notify_BlockedTarget_PublicNonMemberBranch_NoEntryNoEvent_ControlMemberStillNotified()
+    {
+        // "wolf#456" is a directory-resolvable NON-member of a Public room (follow-up spec §4 eligible)
+        // who has blocked the sender — D1 applies uniformly across BOTH the member and non-member
+        // branches, not just the member one.
+        await SeedDirectory("wolf#456");
+        RegisterSession("conn-wolf", "wolf#456");
+        await SeedMembership("control#1");
+
+        var fanOut = BuildFanOutWithBlock(blockingTargetTag: "wolf#456", blockedBattleTag: Sender);
+
+        await fanOut.NotifyAsync(Channel(), Message(), new[] { "wolf#456", "control#1" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Is.Empty,
+            "a directory-resolvable non-member who has blocked the sender gets NO entry");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(0));
+        Assert.That(await InboxOf("control#1"), Has.Count.EqualTo(1), "the eligible member control still fires");
+    }
+
+    [Test]
+    public async Task Notify_BlockCheckThrows_DeliversFailOpen_NoSuppressionOfOtherwiseEligibleTarget()
+    {
+        // A relationship-provider outage (e.g. RelationshipUnavailableException after the stale-cache
+        // fallback is also exhausted — simulated directly via a throwing provider double, mirroring the
+        // ThrowingInsertRepository idiom) must DELIVER the mention rather than suppress it: an outage
+        // must never blanket-mute every mention or break the send pipeline.
+        await SeedMembership("wolf#456", NotificationLevel.All);
+        RegisterSession("conn-wolf", "wolf#456");
+
+        var fanOut = new MentionFanOut(
+            _harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory,
+            new ThrowingRelationshipProvider(), _notificationPreferenceRepository);
+
+        await fanOut.NotifyAsync(Channel(), Message(), new[] { "wolf#456" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Has.Count.EqualTo(1),
+            "a relationship-provider failure fails OPEN — the mention is still delivered, not suppressed");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(1), "and the live push still fires");
+    }
+
+    // Always throws, simulating a relationship-provider outage with nothing cached to fall back to
+    // (RelationshipUnavailableException) — proves NotifyAsync's LOCAL catch around the block check
+    // (not the outer per-target catch, which would instead SKIP the target — the wrong, fail-closed
+    // outcome this test guards against).
+    private sealed class ThrowingRelationshipProvider : IRelationshipProvider
+    {
+        public Task<RelationshipSnapshot> GetSnapshotAsync(string battleTag) =>
+            throw new RelationshipUnavailableException(battleTag, new InvalidOperationException("relationship provider unavailable (test)"));
+
+        public void Invalidate(string battleTag)
+        {
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // PR36 follow-up (D2) — the non-member Public consult path: a persisted NotificationPreference row
+    // (written by ChatHub.SetNotificationLevel, independent of ChannelMembership's lifecycle) silences a
+    // mention for a target with NO membership row. The hub-level lifecycle (join → set None → leave →
+    // rejoin) is covered end-to-end in ChatHubMembershipTests; these tests isolate MentionFanOut's OWN
+    // consult-path behavior directly.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task PublicChannel_NonMember_WithPersistedPreferenceNone_StaysSuppressed()
+    {
+        await SeedDirectory("wolf#456");
+        RegisterSession("conn-wolf", "wolf#456");
+        await SeedMembership("control#1");
+        // No membership row for wolf — simulates a prior leave. The persisted pref is what must silence it.
+        await _notificationPreferenceRepository.Upsert("wolf#456", ChannelId, NotificationLevel.None, Now);
+
+        await _fanOut.NotifyAsync(Channel(), Message(), new[] { "wolf#456", "control#1" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Is.Empty,
+            "a non-member with a persisted NotificationLevel.None preference for this channel stays silenced");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(0));
+        Assert.That(await InboxOf("control#1"), Has.Count.EqualTo(1), "the eligible control still gets the mention");
+    }
+
+    [Test]
+    public async Task PublicChannel_NonMember_WithPersistedPreferenceMentions_Delivers()
+    {
+        // Only an explicit None suppresses — any OTHER persisted level must deliver normally.
+        await SeedDirectory("wolf#456");
+        RegisterSession("conn-wolf", "wolf#456");
+        await _notificationPreferenceRepository.Upsert("wolf#456", ChannelId, NotificationLevel.Mentions, Now);
+
+        await _fanOut.NotifyAsync(Channel(), Message(), new[] { "wolf#456" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Has.Count.EqualTo(1),
+            "a persisted level other than None must not suppress the mention");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(1));
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/MentionFanOutTests.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTests.cs
@@ -28,7 +28,11 @@ namespace W3ChampionsChatService.Tests;
 /// <para>
 /// The five eligibility rules (D3): (a) message NOT shadow; (b) target ≠ sender (case-insensitive);
 /// (c) target has a <c>channel_memberships</c> row for THIS channel — the Dm/GroupDm excerpt PRIVACY
-/// WALL; (d) membership <c>NotificationLevel != None</c>; (e) membership is NOT currently
+/// WALL — EXCEPT for <see cref="ChannelType.Public"/> rooms (follow-up spec §4), where a target with NO
+/// membership row is still eligible provided the tag resolves to a <see cref="UserDirectoryRepository"/>
+/// row, since a public room's excerpt is public content and the membership wall protects nothing there;
+/// Dm/GroupDm/SemiPublic/System are unaffected and keep the membership wall exactly as before;
+/// (d) membership <c>NotificationLevel != None</c>; (e) membership is NOT currently
 /// decline-suppressed (<c>DeclinedUntil</c> unset or already elapsed vs. <c>now</c>). Every
 /// negative-eligibility test below ALSO mentions an eligible CONTROL member in the SAME call and
 /// asserts the control DID get an entry + event — so the test fails against a do-nothing stub AND

--- a/W3ChampionsChatService.Tests/MentionFanOutTests.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTests.cs
@@ -370,12 +370,15 @@ public class MentionFanOutTests : IntegrationTestBase
     public async Task SemiPublicChannel_NonMember_EvenWithDirectoryRow_GetsNothing()
     {
         await SeedDirectory("wolf#456");
+        RegisterSession("conn-wolf", "wolf#456");
         await SeedMembership("control#1", channelId: ChannelId);
 
         await _fanOut.NotifyAsync(Channel(ChannelType.SemiPublic), Message(), new[] { "wolf#456", "control#1" }, Now);
 
         Assert.That(await InboxOf("wolf#456"), Is.Empty,
             "§4 widens PUBLIC rooms only — SemiPublic keeps the membership wall");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(0),
+            "the wall blocks the live push too, not just the inbox entry, even though wolf is online");
         Assert.That(await InboxOf("control#1"), Has.Count.EqualTo(1));
     }
 
@@ -384,11 +387,14 @@ public class MentionFanOutTests : IntegrationTestBase
     {
         await SeedDirectory("silent#1");
         await SeedMembership("silent#1", NotificationLevel.None);
+        await SeedMembership("control#1");
 
-        await _fanOut.NotifyAsync(Channel(), Message(), new[] { "silent#1" }, Now);
+        await _fanOut.NotifyAsync(Channel(), Message(), new[] { "silent#1", "control#1" }, Now);
 
         Assert.That(await InboxOf("silent#1"), Is.Empty,
             "lock-in: join + NotificationLevel.None remains the opt-out even now that non-members are mentionable");
+        Assert.That(await InboxOf("control#1"), Has.Count.EqualTo(1),
+            "the eligible control member still gets the mention — proves this isn't vacuously true against a do-nothing fan-out");
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/MentionFanOutTests.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTests.cs
@@ -13,6 +13,7 @@ using W3ChampionsChatService.Mentions;
 using W3ChampionsChatService.Messages;
 using W3ChampionsChatService.Protocol;
 using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
 
 namespace W3ChampionsChatService.Tests;
 
@@ -49,6 +50,7 @@ public class MentionFanOutTests : IntegrationTestBase
     private HubPushCaptureHarness _harness;
     private MentionFanOut _fanOut;
     private FakeTimeProvider _time;
+    private UserDirectoryRepository _userDirectory;
 
     private DateTime Now => _time.GetUtcNow().UtcDateTime;
 
@@ -61,7 +63,8 @@ public class MentionFanOutTests : IntegrationTestBase
         _mentionInboxRepository = new MentionInboxRepository(MongoClient);
         _sessionRegistry = new SessionRegistry();
         _harness = new HubPushCaptureHarness();
-        _fanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository);
+        _userDirectory = new UserDirectoryRepository(MongoClient);
+        _fanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory);
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -86,6 +89,15 @@ public class MentionFanOutTests : IntegrationTestBase
             NotificationLevel = level,
             JoinedAt = Now,
             DeclinedUntil = declinedUntil,
+        });
+
+    private Task SeedDirectory(string battleTag) =>
+        _userDirectory.Upsert(new UserDirectoryEntry
+        {
+            BattleTag = battleTag.ToLowerInvariant(),
+            DisplayBattleTag = battleTag,
+            NormalizedName = battleTag.ToLowerInvariant(),
+            LastSeenAt = Now,
         });
 
     private static ChatChannel Channel(ChannelType type = ChannelType.Public) =>
@@ -208,7 +220,9 @@ public class MentionFanOutTests : IntegrationTestBase
     [Test]
     public async Task Notify_NonMember_NoEntryNoEvent_ControlMemberStillNotified()
     {
-        // stranger#1 is resolvable content but NOT a member of this channel → no entry/event.
+        // stranger#1 has NO membership row AND no user_directory row, so it stays ineligible even
+        // now that Public rooms are membership-independent (§4): the wall this documents for Public
+        // is directory-resolvability, not membership — stranger#1 has neither.
         RegisterSession("conn-stranger", "stranger#1");
         await SeedMembership("wolf#456", NotificationLevel.All);
         RegisterSession("conn-wolf", "wolf#456");
@@ -323,6 +337,61 @@ public class MentionFanOutTests : IntegrationTestBase
     }
 
     // ---------------------------------------------------------------------------------------------
+    // Follow-up spec §4 — PUBLIC rooms are mentionable without joining (membership-independent fan-out)
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task PublicChannel_NonMember_WithDirectoryRow_GetsEntryAndPush()
+    {
+        await SeedDirectory("wolf#456");
+        RegisterSession("conn-wolf", "wolf#456");
+        // Deliberately NO membership row: follow-up spec §4 — public rooms are mentionable without joining.
+
+        await _fanOut.NotifyAsync(Channel(), Message(), new[] { "wolf#456" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Has.Count.EqualTo(1),
+            "a directory-resolvable NON-member of a PUBLIC room gets a mention-inbox entry");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(1), "and the targeted MentionNotified push");
+    }
+
+    [Test]
+    public async Task PublicChannel_NonMember_WithoutDirectoryRow_GetsNothing()
+    {
+        await SeedMembership("control#1");
+        // "ghost#999" has neither a membership nor a user_directory row — an unresolvable tag.
+        await _fanOut.NotifyAsync(Channel(), Message(), new[] { "ghost#999", "control#1" }, Now);
+
+        Assert.That(await InboxOf("ghost#999"), Is.Empty,
+            "an unresolvable tag still notifies nobody (garbage `<@…>` markup stays inert)");
+        Assert.That(await InboxOf("control#1"), Has.Count.EqualTo(1), "the eligible control member still fires");
+    }
+
+    [Test]
+    public async Task SemiPublicChannel_NonMember_EvenWithDirectoryRow_GetsNothing()
+    {
+        await SeedDirectory("wolf#456");
+        await SeedMembership("control#1", channelId: ChannelId);
+
+        await _fanOut.NotifyAsync(Channel(ChannelType.SemiPublic), Message(), new[] { "wolf#456", "control#1" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Is.Empty,
+            "§4 widens PUBLIC rooms only — SemiPublic keeps the membership wall");
+        Assert.That(await InboxOf("control#1"), Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task PublicChannel_JoinedMember_WithNotificationLevelNone_StaysSilenced()
+    {
+        await SeedDirectory("silent#1");
+        await SeedMembership("silent#1", NotificationLevel.None);
+
+        await _fanOut.NotifyAsync(Channel(), Message(), new[] { "silent#1" }, Now);
+
+        Assert.That(await InboxOf("silent#1"), Is.Empty,
+            "lock-in: join + NotificationLevel.None remains the opt-out even now that non-members are mentionable");
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // Shadow (defense-in-depth in-method guard; the call-site skip is covered end-to-end in
     // ChatHubSendMessageTests.ShadowSender_MentionsOthers_...)
     // ---------------------------------------------------------------------------------------------
@@ -410,7 +479,7 @@ public class MentionFanOutTests : IntegrationTestBase
 
         // A repository whose Insert throws for wolf ONLY — simulating a single-target Mongo write failure.
         var throwingInbox = new ThrowingInsertRepository(MongoClient, "wolf#456");
-        var faultyFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, throwingInbox);
+        var faultyFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, throwingInbox, _userDirectory);
 
         Assert.DoesNotThrowAsync(() => faultyFanOut.NotifyAsync(Channel(), Message(), new[] { "wolf#456", "frank#789" }, Now),
             "a single target's failed insert must be fault-isolated — NotifyAsync must not throw");

--- a/W3ChampionsChatService.Tests/MentionFanOutTests.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTests.cs
@@ -519,9 +519,13 @@ public class MentionFanOutTests : IntegrationTestBase
     }
 
     // Always throws, simulating a relationship-provider outage with nothing cached to fall back to
-    // (RelationshipUnavailableException) — proves NotifyAsync's LOCAL catch around the block check
-    // (not the outer per-target catch, which would instead SKIP the target — the wrong, fail-closed
-    // outcome this test guards against).
+    // (RelationshipUnavailableException) — proves NotifyAsync's LOCAL catch inside IsBlockedFailOpenAsync
+    // is what keeps the block check fail-open. After the three-stage restructure there is no OUTER
+    // per-target catch around stage 2's Task.WhenAll that could instead skip just this target: were
+    // IsBlockedFailOpenAsync's internal catch removed, the exception would escape the WhenAll, escape
+    // NotifyAsync entirely (uncaught at the ChatHub.Messaging.cs step 8 call site), and turn this
+    // already-persisted send's Ok ack into an ERROR ack — worse than merely skipping the target, and
+    // worse than the fail-open delivery this test asserts.
     private sealed class ThrowingRelationshipProvider : IRelationshipProvider
     {
         public Task<RelationshipSnapshot> GetSnapshotAsync(string battleTag) =>

--- a/W3ChampionsChatService.Tests/MentionFanOutTests.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTests.cs
@@ -68,7 +68,7 @@ public class MentionFanOutTests : IntegrationTestBase
         _sessionRegistry = new SessionRegistry();
         _harness = new HubPushCaptureHarness();
         _userDirectory = new UserDirectoryRepository(MongoClient);
-        _fanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory);
+        _fanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), new NotificationPreferenceRepository(MongoClient));
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -489,7 +489,7 @@ public class MentionFanOutTests : IntegrationTestBase
 
         // A repository whose Insert throws for wolf ONLY — simulating a single-target Mongo write failure.
         var throwingInbox = new ThrowingInsertRepository(MongoClient, "wolf#456");
-        var faultyFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, throwingInbox, _userDirectory);
+        var faultyFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, throwingInbox, _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), new NotificationPreferenceRepository(MongoClient));
 
         Assert.DoesNotThrowAsync(() => faultyFanOut.NotifyAsync(Channel(), Message(), new[] { "wolf#456", "frank#789" }, Now),
             "a single target's failed insert must be fault-isolated — NotifyAsync must not throw");

--- a/W3ChampionsChatService.Tests/MentionFanOutTests.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTests.cs
@@ -550,6 +550,26 @@ public class MentionFanOutTests : IntegrationTestBase
         Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(1));
     }
 
+    // Fix round 1 (F3): battleTag normalization was unpinned here — every OTHER test in this section
+    // writes and reads under the SAME (already-lowercase) casing, so a mutation removing
+    // NotificationPreferenceRepository.NormalizeTag's ToLowerInvariant() would pass all of them. Seeding
+    // the pref under one casing and mentioning under a DIFFERENT casing forces the mismatch to matter.
+    [Test]
+    public async Task PublicChannel_NonMember_WithPersistedPreferenceNone_MixedCase_PinsNormalizeTag()
+    {
+        await SeedDirectory("wolf#456");
+        RegisterSession("conn-wolf", "wolf#456");
+        await SeedMembership("control#1");
+        await _notificationPreferenceRepository.Upsert("Wolf#456", ChannelId, NotificationLevel.None, Now);
+
+        await _fanOut.NotifyAsync(Channel(), Message(), new[] { "WOLF#456", "control#1" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Is.Empty,
+            "the persisted None preference must suppress regardless of write/read casing mismatch");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(0));
+        Assert.That(await InboxOf("control#1"), Has.Count.EqualTo(1), "the eligible control still gets the mention");
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Shadow (defense-in-depth in-method guard; the call-site skip is covered end-to-end in
     // ChatHubSendMessageTests.ShadowSender_MentionsOthers_...)

--- a/W3ChampionsChatService.Tests/MentionFanOutTests.cs
+++ b/W3ChampionsChatService.Tests/MentionFanOutTests.cs
@@ -455,6 +455,28 @@ public class MentionFanOutTests : IntegrationTestBase
         Assert.That(MentionEventCount("conn-frank"), Is.EqualTo(1));
     }
 
+    // Fix round 1 (F8): D1 suppression is type-agnostic (the class doc says "ALL channel types"), but was
+    // only pinned against a Public channel above — a GroupDm variant of the SAME member-branch scenario
+    // proves the walled-channel path (which never reaches the Public non-member branch) still applies it.
+    [Test]
+    public async Task Notify_BlockedTarget_MemberBranch_GroupDm_NoEntryNoEvent_ControlMemberStillNotified()
+    {
+        await SeedMembership("wolf#456", NotificationLevel.All);
+        RegisterSession("conn-wolf", "wolf#456");
+        await SeedMembership("frank#789", NotificationLevel.All);
+        RegisterSession("conn-frank", "frank#789");
+
+        var fanOut = BuildFanOutWithBlock(blockingTargetTag: "wolf#456", blockedBattleTag: Sender);
+
+        await fanOut.NotifyAsync(Channel(ChannelType.GroupDm), Message(content: "secret plans"), new[] { "wolf#456", "frank#789" }, Now);
+
+        Assert.That(await InboxOf("wolf#456"), Is.Empty,
+            "a GroupDm member who has blocked the sender gets NO inbox entry — D1 applies to walled channels too");
+        Assert.That(MentionEventCount("conn-wolf"), Is.EqualTo(0), "and NO live push");
+        Assert.That(await InboxOf("frank#789"), Has.Count.EqualTo(1), "a non-blocking member control still gets the mention");
+        Assert.That(MentionEventCount("conn-frank"), Is.EqualTo(1));
+    }
+
     [Test]
     public async Task Notify_BlockedTarget_PublicNonMemberBranch_NoEntryNoEvent_ControlMemberStillNotified()
     {

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -130,7 +130,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         // so a hub's own SendMessage(<@tag>) fans out a genuine mention-inbox entry AND a capturable,
         // targeted MentionNotified through the one shared capture (unlike the CreateIgnored factory the
         // moderation/DM suites use, whose push goes to a throwaway sink and whose session registry is empty).
-        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository);
+        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory);
         // The REAL C6 T7 cleaner, so a moderator DeleteMessage/PurgeMessagesFromUser physically removes the
         // referenced mention-inbox rows in this suite too (acceptance 3).
         _mentionCleaner = new MentionInboxCleaner(MongoClient);
@@ -525,7 +525,8 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
     // >5 distinct rejected (the COUNT cap); an unresolvable mention is NOT rejected — it delivers verbatim
     // and simply notifies nobody (strip & deliver as plain); exactly 5 valid mentions fan out to EXACTLY
     // those 5 members (a co-present non-mentioned member and the sender get nothing); a mentioned resolvable
-    // NON-member gets no notification (the membership wall).
+    // NON-member of this PUBLIC channel DOES get notified (follow-up spec §4 — Public rooms are
+    // membership-independent for a directory-resolvable target).
     // ============================================================================================
 
     [Test]
@@ -595,17 +596,19 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         Assert.That(await _mentionInboxRepository.LoadForUser(BystanderTag), Is.Empty, "...and gets no inbox entry");
         Assert.That(MentionNotifiedFor("conn-valauthor"), Is.Empty, "the sender is never self-notified");
 
-        // --- Non-member leg: a mentioned resolvable NON-member gets NOTHING (the membership wall).
+        // --- Non-member leg (follow-up spec §4): a mentioned resolvable NON-member of this PUBLIC channel
+        // NOW gets notified — the membership wall is widened away for Public rooms specifically, since a
+        // directory-resolvable target's tag proves resolvability without needing a membership row.
         _time.Advance(TimeSpan.FromSeconds(2));
         var mixed = await aHub.SendMessage(channel.Id, $"ping <@{members[0]}> and <@{NonMemberTag}>");
         Assert.That(mixed.Code, Is.EqualTo(ChatResultCode.Ok), "mentioning a resolvable non-member is legal content");
 
-        Assert.That(MentionNotifiedFor("conn-stranger"), Is.Empty,
-            "a mentioned NON-member — resolvable AND online — receives NO notification (the excerpt privacy wall)");
-        Assert.That(await _mentionInboxRepository.LoadForUser(NonMemberTag), Is.Empty,
-            "...and gets NO inbox entry, even though the send that named them succeeded");
+        Assert.That(MentionNotifiedFor("conn-stranger"), Has.Count.EqualTo(1),
+            "a mentioned NON-member of a PUBLIC channel — resolvable AND online — DOES receive a notification (§4)");
+        Assert.That(await _mentionInboxRepository.LoadForUser(NonMemberTag), Has.Count.EqualTo(1),
+            "...and gets an inbox entry too");
         Assert.That(MentionNotifiedFor(memberConns[members[0]]), Has.Count.EqualTo(2),
-            "the co-mentioned actual member DID get a second event from that same send — proving the wall, not a total no-op");
+            "the co-mentioned actual member DID get a second event from that same send");
     }
 
     // ============================================================================================
@@ -980,7 +983,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         var hubContextMock = new Mock<IHubContext<ChatHub>>();
         hubContextMock.Setup(h => h.Clients).Returns(clientsMock.Object);
 
-        var fanOut = new MentionFanOut(hubContextMock.Object, _sessionRegistry, _membershipRepository, _mentionInboxRepository);
+        var fanOut = new MentionFanOut(hubContextMock.Object, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory);
         var message = new ChannelMessage
         {
             ChannelId = channel.Id,

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -288,7 +288,13 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
 
     // ---- Mongo seed helpers ------------------------------------------------------------------------
 
-    private async Task<ChatChannel> CreateChannel(string name, ChannelType type = ChannelType.Public)
+    // Follow-up spec §6: SessionStateAssembler.SelectSnapshotMemberships now reads channel.PairKey for
+    // every non-pending 1:1 Dm (the blocked-shell keep) — a REAL Dm channel always carries one
+    // (ChannelRepository.FindOrCreateDm always sets it via DmPairKey.For; the collection's unique
+    // partial index enforces Type==Dm ⇒ PairKey present). dmBattleTagA/B are therefore REQUIRED for
+    // ChannelType.Dm so this fixture can never manufacture the data-impossible shape (a Dm channel with
+    // no PairKey) that used to slip past every test that never exercised the connect snapshot's DM slice.
+    private async Task<ChatChannel> CreateChannel(string name, ChannelType type = ChannelType.Public, string dmBattleTagA = null, string dmBattleTagB = null)
     {
         var channel = new ChatChannel
         {
@@ -299,6 +305,11 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         };
         if (type == ChannelType.Dm)
         {
+            if (dmBattleTagA == null || dmBattleTagB == null)
+            {
+                throw new ArgumentException("CreateChannel(ChannelType.Dm, ...) requires both dmBattleTagA and dmBattleTagB to build a real PairKey");
+            }
+            channel.PairKey = DmPairKey.For(dmBattleTagA, dmBattleTagB);
             channel.RequestState = DmRequestState.Accepted;
         }
         await _channelRepository.Insert(channel);
@@ -709,7 +720,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         const string BystanderTag = "Cara#3";  // genuinely wired, focused on an UNRELATED DM
         const string YoungTag = "Young#5";
 
-        var dmAx = await CreateChannel("dm-ax", ChannelType.Dm);
+        var dmAx = await CreateChannel("dm-ax", ChannelType.Dm, AliceTag, XavierTag);
         await SeedMembership(dmAx.Id, AliceTag);
         await SeedMembership(dmAx.Id, XavierTag);
 
@@ -717,7 +728,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         await SeedMembership(grpAx.Id, AliceTag, role: MembershipRole.Owner);
         await SeedMembership(grpAx.Id, XavierTag);
 
-        var dmCy = await CreateChannel("dm-cy", ChannelType.Dm);
+        var dmCy = await CreateChannel("dm-cy", ChannelType.Dm, BystanderTag, YoungTag);
         await SeedMembership(dmCy.Id, BystanderTag);
         await SeedMembership(dmCy.Id, YoungTag);
 

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -510,6 +510,46 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         Assert.That((await bHub.GetMentionInbox()).Entries, Is.Empty, "and no durable inbox entry either");
     }
 
+    // Fix round 1 (F2b) ordering pin: ChatHub.Messaging.cs's SendMessage now awaits the channel fan-out
+    // (FanOutEngine.OnMessagePersisted, which pushes MessageReceived to FOCUSED viewers) BEFORE the
+    // mention fan-out (MentionFanOut.NotifyAsync, which pushes the targeted MentionNotified) — see that
+    // method's step 7.75/8 comments for why. For a member who is BOTH focused on the channel AND the
+    // mention's target, both events land on the SAME connection, so the dispatch order is directly
+    // observable. Both services are constructed (SetupBeforeEach) against the ONE shared
+    // HubPushCaptureHarness — its `_sends` list is a single lock-guarded, insertion-ordered list across
+    // ALL connections, and SignalsFor(connectionId) filters that ONE list without reordering — so the
+    // index comparison below reflects the real cross-service dispatch order, not two independent capture
+    // lists that happen to agree.
+    [Test]
+    public async Task MentionOfFocusedMember_EndToEnd_MessageReceivedPrecedesMentionNotified()
+    {
+        const string ATag = "author#1";
+        const string BTag = "bob#2";
+
+        var channel = await CreateChannel("W3C Lounge", ChannelType.Public);
+        await SeedMembership(channel.Id, ATag);
+        await SeedMembership(channel.Id, BTag);
+
+        var aHub = await Connect("conn-a", ATag);
+        var bHub = await Connect("conn-b", BTag);
+        Assert.That((await bHub.FocusChannel(channel.Id)).Code, Is.EqualTo(ChatResultCode.Ok),
+            "B must be FOCUSED on the channel to receive MessageReceived (FanOutEngine's focused-viewers-only guardrail)");
+
+        var send = await aHub.SendMessage(channel.Id, $"hey <@{BTag}> look at this");
+        Assert.That(send.Code, Is.EqualTo(ChatResultCode.Ok));
+
+        var signals = _harness.SignalsFor("conn-b").ToList();
+        var messageReceivedIndex = signals.FindIndex(s => s.Method == ChatEvents.MessageReceived);
+        var mentionNotifiedIndex = signals.FindIndex(s => s.Method == ChatEvents.MentionNotified);
+
+        Assert.That(messageReceivedIndex, Is.GreaterThanOrEqualTo(0), "sanity: B (focused) received MessageReceived");
+        Assert.That(mentionNotifiedIndex, Is.GreaterThanOrEqualTo(0), "sanity: B (mentioned) received MentionNotified");
+        Assert.That(messageReceivedIndex, Is.LessThan(mentionNotifiedIndex),
+            "F2b: the channel fan-out's MessageReceived must be DISPATCHED before the mention fan-out's " +
+            "MentionNotified for a target who is both focused and mentioned — pinning the accepted ordering " +
+            "(and its sender-ack latency trade, see ChatHub.Messaging.cs's F2b comment) as a tested outcome");
+    }
+
     // ============================================================================================
     // Slate 2 — ModerationDelete_ScrubsInbox_EndToEnd (acceptance 3).
     // A real mention → moderator DeleteMessage physically removes the referenced inbox entry; and a

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -84,6 +84,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
     private MembershipRepository _membershipRepository;
     private MessageRepository _messageRepository;
     private MentionInboxRepository _mentionInboxRepository;
+    private NotificationPreferenceRepository _notificationPreferenceRepository;
     private MentionFanOut _mentionFanOut;       // the REAL C6 T5 writer, pushing through the shared harness
     private MentionInboxCleaner _mentionCleaner; // the REAL C6 T7 cleaner (physical mention_inbox delete)
     private SessionStateAssembler _assembler;
@@ -95,6 +96,11 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
     // Per-tag friends, read by the fake source's snapshot factory (OrdinalIgnoreCase) — only the friend-
     // presence test populates this; every other test's connects resolve an empty friends set (no push).
     private readonly Dictionary<string, HashSet<string>> _friends = new(StringComparer.OrdinalIgnoreCase);
+
+    // Per-tag blocks, read by the SAME fake source's snapshot factory (fix round 1, F9) — only the D1
+    // block-suppression test below populates this; every other test's mentions resolve an empty block
+    // list (no suppression), identical to the pre-F9 always-empty CreateIgnored() stub.
+    private readonly Dictionary<string, HashSet<string>> _blocked = new(StringComparer.OrdinalIgnoreCase);
 
     // Every Clients.Caller/Client push + every Context.Abort(), in order, across ALL connections. The
     // cross-connection fan-out pushes (MentionNotified/PresenceChanged/FriendPresenceChanged) go to
@@ -108,6 +114,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
     {
         _hubSends.Clear();
         _friends.Clear();
+        _blocked.Clear();
         _time = new FakeTimeProvider(new DateTimeOffset(T0, TimeSpan.Zero));
         _harness = new HubPushCaptureHarness();
 
@@ -126,11 +133,28 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         _membershipRepository = new MembershipRepository(MongoClient, _channelRepository);
         _messageRepository = new MessageRepository(MongoClient);
         _mentionInboxRepository = new MentionInboxRepository(MongoClient);
+        _notificationPreferenceRepository = new NotificationPreferenceRepository(MongoClient);
+
+        // Built BEFORE _mentionFanOut below (fix round 1, F9) — the REAL C5 D1 provider, so the fan-out's
+        // own D1 block check can be exercised end-to-end by this suite rather than a never-blocking stub.
+        _relationshipSource = new FakeRelationshipSource((tag, now) => new RelationshipSnapshot(
+            tag,
+            _friends.TryGetValue(tag, out var f) ? f : new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            _blocked.TryGetValue(tag, out var b) ? b : new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            now));
+        // Makes every fetch resolve SYNCHRONOUSLY (no genuine suspension), so the fire-and-forget friend push
+        // is deterministically observable right after Connect/disconnect return (mirrors ChatHubFriendPresenceTests).
+        _relationshipSource.ReleaseGate = Task.CompletedTask;
+        _relationshipProvider = new RelationshipProvider(_relationshipSource, _time);
+
         // The REAL C6 T5 writer, wired to the SHARED harness + session registry + membership/inbox repos —
         // so a hub's own SendMessage(<@tag>) fans out a genuine mention-inbox entry AND a capturable,
         // targeted MentionNotified through the one shared capture (unlike the CreateIgnored factory the
         // moderation/DM suites use, whose push goes to a throwaway sink and whose session registry is empty).
-        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), new NotificationPreferenceRepository(MongoClient));
+        // Fix round 1 (F9): wired with the REAL _relationshipProvider above (was
+        // RelationshipProviderTestFactory.CreateIgnored()) — behavior was identical while the fake source's
+        // block list was always empty, but this lets the suite exercise D1 end-to-end too.
+        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, _relationshipProvider, _notificationPreferenceRepository);
         // The REAL C6 T7 cleaner, so a moderator DeleteMessage/PurgeMessagesFromUser physically removes the
         // referenced mention-inbox rows in this suite too (acceptance 3).
         _mentionCleaner = new MentionInboxCleaner(MongoClient);
@@ -157,16 +181,6 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
-
-        _relationshipSource = new FakeRelationshipSource((tag, now) => new RelationshipSnapshot(
-            tag,
-            _friends.TryGetValue(tag, out var f) ? f : new HashSet<string>(StringComparer.OrdinalIgnoreCase),
-            new HashSet<string>(StringComparer.OrdinalIgnoreCase),
-            now));
-        // Makes every fetch resolve SYNCHRONOUSLY (no genuine suspension), so the fire-and-forget friend push
-        // is deterministically observable right after Connect/disconnect return (mirrors ChatHubFriendPresenceTests).
-        _relationshipSource.ReleaseGate = Task.CompletedTask;
-        _relationshipProvider = new RelationshipProvider(_relationshipSource, _time);
     }
 
     // ============================================================================================
@@ -214,8 +228,8 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
             _authService.Object,
             _mentionFanOut,                     // REAL fan-out through the shared harness
             _presenceInterestRegistry,          // SHARED — same instance the engine reads
-            _mentionInboxRepository,
-            new NotificationPreferenceRepository(MongoClient));           // SHARED — the read/ack store
+            _mentionInboxRepository,            // SHARED — the read/ack store
+            _notificationPreferenceRepository); // SHARED — same instance _mentionFanOut reads (fix round 1, F9)
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));
@@ -463,6 +477,34 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         Assert.That(finalInbox.Select(e => e.ReadAt), Has.All.Not.Null, "every entry now carries a ReadAt");
         Assert.That(await _mentionInboxRepository.LoadForUser(BTag), Has.Count.EqualTo(3),
             "the durable rows all survive until the 30d TTL — read is a field flip, never a delete");
+    }
+
+    // Fix round 1 (F9): now that _mentionFanOut is wired with the fixture's REAL _relationshipProvider
+    // (over the fake source, block-controlled by _blocked), D1 block suppression can be exercised
+    // end-to-end through a real SendMessage → real MentionFanOut → real RelationshipProvider chain,
+    // rather than only unit-tested against MentionFanOut directly (MentionFanOutTests).
+    [Test]
+    public async Task MentionOfBlockingTarget_EndToEnd_NoInboxEntry_NoMentionNotified()
+    {
+        const string ATag = "author#1";
+        const string BTag = "bob#2";
+
+        var channel = await CreateChannel("W3C Lounge", ChannelType.Public);
+        await SeedMembership(channel.Id, ATag);
+        await SeedMembership(channel.Id, BTag);
+
+        // B has blocked A — D1 direction: it's the TARGET's own block list that suppresses.
+        _blocked[BTag] = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ATag };
+
+        var aHub = await Connect("conn-a", ATag);
+        var bHub = await Connect("conn-b", BTag);
+
+        var send = await aHub.SendMessage(channel.Id, $"hey <@{BTag}> you there?");
+
+        Assert.That(send.Code, Is.EqualTo(ChatResultCode.Ok), "the message itself still sends and renders normally");
+        Assert.That(MentionNotifiedFor("conn-b"), Is.Empty,
+            "a target who has blocked the sender gets NO MentionNotified push, end-to-end through the real RelationshipProvider");
+        Assert.That((await bHub.GetMentionInbox()).Entries, Is.Empty, "and no durable inbox entry either");
     }
 
     // ============================================================================================

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -130,7 +130,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         // so a hub's own SendMessage(<@tag>) fans out a genuine mention-inbox entry AND a capturable,
         // targeted MentionNotified through the one shared capture (unlike the CreateIgnored factory the
         // moderation/DM suites use, whose push goes to a throwaway sink and whose session registry is empty).
-        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory);
+        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), new NotificationPreferenceRepository(MongoClient));
         // The REAL C6 T7 cleaner, so a moderator DeleteMessage/PurgeMessagesFromUser physically removes the
         // referenced mention-inbox rows in this suite too (acceptance 3).
         _mentionCleaner = new MentionInboxCleaner(MongoClient);
@@ -214,7 +214,8 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
             _authService.Object,
             _mentionFanOut,                     // REAL fan-out through the shared harness
             _presenceInterestRegistry,          // SHARED — same instance the engine reads
-            _mentionInboxRepository);           // SHARED — the read/ack store
+            _mentionInboxRepository,
+            new NotificationPreferenceRepository(MongoClient));           // SHARED — the read/ack store
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));
@@ -996,7 +997,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         var hubContextMock = new Mock<IHubContext<ChatHub>>();
         hubContextMock.Setup(h => h.Clients).Returns(clientsMock.Object);
 
-        var fanOut = new MentionFanOut(hubContextMock.Object, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory);
+        var fanOut = new MentionFanOut(hubContextMock.Object, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), new NotificationPreferenceRepository(MongoClient));
         var message = new ChannelMessage
         {
             ChannelId = channel.Id,

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -566,7 +566,9 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
             "the over-cap send allocated no seq and persisted nothing");
 
         // --- Strip & deliver as plain: an UNRESOLVABLE mention is NOT rejected — it delivers VERBATIM and
-        // simply notifies nobody (the fan-out membership wall drops the non-member target). NOT TooLong.
+        // simply notifies nobody. This channel is Public, so membership is not the gate here (§4) — the
+        // fan-out drops "nobody#404" because it has NO user_directory row, the directory-resolvability
+        // check §4 substitutes for the membership wall on Public rooms. NOT TooLong.
         var unresolvableContent = "who is <@nobody#404>";
         var unresolvable = await aHub.SendMessage(channel.Id, unresolvableContent);
         Assert.That(unresolvable.Code, Is.EqualTo(ChatResultCode.Ok),
@@ -574,7 +576,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         Assert.That((await _messageRepository.Load(unresolvable.MessageId)).Content, Is.EqualTo(unresolvableContent),
             "the message delivers verbatim — the invalid <@…> token is kept as plain text");
         Assert.That(await _mentionInboxRepository.LoadForUser("nobody#404"), Is.Empty,
-            "the unresolvable target gets no inbox entry (nobody is a member)");
+            "the unresolvable target gets no inbox entry (nobody#404 has no user_directory row — unresolvable, not merely a non-member)");
         Assert.That((await _channelRepository.Load(channel.Id)).LastSeq, Is.EqualTo(1L),
             "the unresolvable send DID persist (seq 1) — it is a normal, deliverable message");
 

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -72,6 +72,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
@@ -124,6 +125,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _presenceInterestRegistry = new PresenceInterestRegistry();
         _userDirectory = new UserDirectoryRepository(MongoClient);
@@ -214,6 +216,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
+++ b/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
@@ -310,6 +310,38 @@ public class MessageRateLimiterTests
     }
 
     [Test]
+    public void QuiescentPrune_IsSelective_DoesNotEvictARecentlyTouchedEntry()
+    {
+        // Many quiescent users seeded once at t0 — idle past the decay horizon by the time of the sweep.
+        for (var i = 0; i < 50; i++)
+        {
+            Assert.IsTrue(_limiter.TryAcquire($"stale{i}#1", Channel, _t0).Allowed);
+        }
+
+        // One user keeps sending right up to (just under) the decay horizon — this entry must NOT be
+        // swept away even though the map-wide sweep timer (anchored on the very first t0 call) fires.
+        const string ActiveUser = "active#1";
+        var justUnderDecay = _t0 + ChatLimits.AutoThrottleTierDecay - TimeSpan.FromSeconds(1);
+        Assert.IsTrue(_limiter.TryAcquire(ActiveUser, Channel, justUnderDecay).Allowed);
+
+        // A distinct caller just past the decay horizon (relative to t0) triggers the time-gated sweep.
+        var sweepTime = _t0 + ChatLimits.AutoThrottleTierDecay + TimeSpan.FromSeconds(1);
+        Assert.IsTrue(_limiter.TryAcquire(User, Channel, sweepTime).Allowed);
+
+        // The 50 stale users (idle since t0, well past decay) are gone. ActiveUser (touched only 2s
+        // before the sweep) and the sweeping caller (User) survive — proving the sweep evaluates each
+        // entry's OWN idle time rather than clearing everything whenever the map-wide timer fires.
+        Assert.LessOrEqual(_limiter.TrackedUserCount, 2,
+            "a recently-touched entry must survive a sweep that evicts other, genuinely-quiescent entries");
+
+        // A count assertion alone can't distinguish "selective pruning" from a buggy "clear everyone
+        // once the gate opens" sweep (both would leave <=2 entries here) — directly confirm ActiveUser
+        // specifically is still tracked, not merely that the total count is small.
+        Assert.AreEqual(1, _limiter.TrackedChannelCount(ActiveUser),
+            "ActiveUser's own per-channel bucket state must have survived the sweep, not been evicted");
+    }
+
+    [Test]
     public void ViolationsOutsideRollingWindow_DoNotEscalate()
     {
         // One violation per epoch, epochs spaced beyond the auto-throttle window: each old violation

--- a/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
+++ b/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
@@ -214,6 +214,10 @@ public class MessageRateLimiterTests
     [Test]
     public void AutoThrottle_EmitsOneModerationLogLine()
     {
+        // Deliberately MIXED-CASE: User ("peter#123") is already all-lowercase, so it can never
+        // discriminate "logged the caller's original casing" from "logged the internal lowercased
+        // dictionary key" — both would render identically. MixedCaseUser pins the real defect.
+        const string MixedCaseUser = "Peter#123";
         var capturedWarnings = new List<string>();
         var sink = new DelegatingLogSink(evt =>
         {
@@ -231,20 +235,22 @@ public class MessageRateLimiterTests
         {
             for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
             {
-                _limiter.TryAcquire(User, Channel, _t0);
+                _limiter.TryAcquire(MixedCaseUser, Channel, _t0);
             }
             for (var v = 0; v < ChatLimits.AutoThrottleViolationThreshold; v++)
             {
-                _limiter.TryAcquire(User, Channel, _t0);
+                _limiter.TryAcquire(MixedCaseUser, Channel, _t0);
             }
             // Further denied sends inside the hard-throttle window must NOT emit more log lines.
-            _limiter.TryAcquire(User, Channel, _t0.AddSeconds(1));
-            _limiter.TryAcquire(User, Channel, _t0.AddSeconds(2));
+            _limiter.TryAcquire(MixedCaseUser, Channel, _t0.AddSeconds(1));
+            _limiter.TryAcquire(MixedCaseUser, Channel, _t0.AddSeconds(2));
 
             Assert.AreEqual(1, capturedWarnings.Count, "auto-throttle must log exactly one moderation line");
-            // The line logs the LOWERCASED battleTag key, not the raw arg — User is already all-lowercase,
-            // but assert against the normalized form so this stays correct if User ever gains mixed casing.
-            StringAssert.Contains(User.ToLowerInvariant(), capturedWarnings[0], "the moderation line must identify the battleTag");
+            // The line must carry the caller's ORIGINAL casing — matching the hub's companion log line
+            // (ChatHub.Messaging.cs) so a case-sensitive log search finds both — NOT the internal
+            // lowercased dictionary key used for state lookups.
+            StringAssert.Contains(MixedCaseUser, capturedWarnings[0],
+                "the moderation line must identify the battleTag in the caller's original casing, not the lowercased key");
         }
         finally
         {
@@ -305,8 +311,12 @@ public class MessageRateLimiterTests
         var later = _t0 + ChatLimits.AutoThrottleTierDecay + TimeSpan.FromSeconds(1);
         Assert.IsTrue(_limiter.TryAcquire(User, Channel, later).Allowed);
 
-        Assert.LessOrEqual(_limiter.TrackedUserCount, 2,
-            "entries idle past AutoThrottleTierDecay must be pruned (only the sweeping caller may remain)");
+        // The sweep (PruneQuiescentNoLock) runs BEFORE the sweeping call's own entry is created, so all
+        // 200 prior entries — idle since _t0, past the decay horizon — are evicted and exactly ONE entry
+        // (User, just created) remains. Exact, not an upper bound: verified against the implementation's
+        // prune-before-create ordering in TryAcquire.
+        Assert.AreEqual(1, _limiter.TrackedUserCount,
+            "entries idle past AutoThrottleTierDecay must be pruned (only the sweeping caller remains)");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
+++ b/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
@@ -111,37 +111,67 @@ public class MessageRateLimiterTests
             "retry-after for a per-channel throttle must not exceed the sustained interval");
     }
 
-    [Test]
-    public void RepeatedViolations_EscalateTo60sAutoThrottle()
+    // Drives one full auto-throttle trigger for Conn on Channel at `at`: spends the burst, then lands
+    // AutoThrottleViolationThreshold violations — returns the escalation decision (JustAutoThrottled true).
+    private RateLimitDecision TriggerAutoThrottle(DateTime at)
     {
         for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
         {
-            Assert.IsTrue(_limiter.TryAcquire(Conn, Channel, _t0).Allowed);
+            Assert.IsTrue(_limiter.TryAcquire(Conn, Channel, at).Allowed, "burst send must be allowed");
         }
-
         RateLimitDecision escalation = default;
         for (var v = 0; v < ChatLimits.AutoThrottleViolationThreshold; v++)
         {
-            escalation = _limiter.TryAcquire(Conn, Channel, _t0);
-            Assert.IsFalse(escalation.Allowed, "each over-burst send is throttled");
+            escalation = _limiter.TryAcquire(Conn, Channel, at);
         }
+        Assert.IsTrue(escalation.JustAutoThrottled, "the threshold-th violation must escalate");
+        return escalation;
+    }
 
-        // The threshold-th violation flips the connection into a hard auto-throttle and signals once.
-        Assert.IsTrue(escalation.JustAutoThrottled, "reaching the violation threshold signals auto-throttle");
-        Assert.IsNotNull(escalation.RetryAfterSeconds);
-        Assert.AreEqual(ChatLimits.AutoThrottleDuration.TotalSeconds, escalation.RetryAfterSeconds.Value, 0.001);
+    [Test]
+    public void FirstAutoThrottle_Lasts10Seconds()
+    {
+        var first = TriggerAutoThrottle(_t0);
+        Assert.AreEqual(ChatLimits.AutoThrottleTierDurations[0].TotalSeconds, first.RetryAfterSeconds.Value, 0.001);
+        Assert.AreEqual(10, first.RetryAfterSeconds.Value, 0.001, "spec pin: the FIRST tier is exactly 10s");
 
-        // While hard-throttled, ALL sends are denied — even on a brand-new channel — and the notice
-        // is not re-signalled.
-        var during = _limiter.TryAcquire(Conn, "another-channel", _t0.AddSeconds(1));
-        Assert.IsFalse(during.Allowed);
-        Assert.IsFalse(during.JustAutoThrottled, "the auto-throttle notice fires exactly once");
-        Assert.IsNotNull(during.RetryAfterSeconds);
-        Assert.Greater(during.RetryAfterSeconds.Value, 0);
+        // Still denied 9s in; recovered right after the 10s tier elapses (fresh burst).
+        Assert.IsFalse(_limiter.TryAcquire(Conn, Channel, _t0.AddSeconds(9)).Allowed);
+        Assert.IsTrue(_limiter.TryAcquire(Conn, Channel, _t0 + ChatLimits.AutoThrottleTierDurations[0] + TimeSpan.FromSeconds(11)).Allowed,
+            "after serving 10s (plus bucket refill time) the connection recovers");
+    }
 
-        // After serving the full duration, the connection recovers with a fresh burst.
-        var recovered = _limiter.TryAcquire(Conn, Channel, _t0 + ChatLimits.AutoThrottleDuration + TimeSpan.FromSeconds(1));
-        Assert.IsTrue(recovered.Allowed, "the connection recovers after serving the auto-throttle duration");
+    [Test]
+    public void SecondAutoThrottle_Escalates_To30Seconds()
+    {
+        TriggerAutoThrottle(_t0);
+        // Well after the first penalty (buckets refilled), still inside the 10-minute decay window.
+        var second = TriggerAutoThrottle(_t0.AddSeconds(60));
+        Assert.AreEqual(30, second.RetryAfterSeconds.Value, 0.001, "spec pin: the SECOND tier is exactly 30s");
+    }
+
+    [Test]
+    public void ThirdAndLaterAutoThrottles_CapAt60Seconds()
+    {
+        TriggerAutoThrottle(_t0);
+        TriggerAutoThrottle(_t0.AddSeconds(60));
+        var third = TriggerAutoThrottle(_t0.AddSeconds(150));
+        Assert.AreEqual(60, third.RetryAfterSeconds.Value, 0.001, "spec pin: the THIRD tier caps at 60s");
+        var fourth = TriggerAutoThrottle(_t0.AddSeconds(300));
+        Assert.AreEqual(60, fourth.RetryAfterSeconds.Value, 0.001, "the cap holds for every later trigger");
+    }
+
+    [Test]
+    public void TierLadder_ResetsAfterTenCleanMinutes()
+    {
+        TriggerAutoThrottle(_t0);
+        TriggerAutoThrottle(_t0.AddSeconds(60)); // now at tier 2 (30s served)
+
+        // 10 clean minutes (no trigger) after the SECOND trigger → the ladder resets to the first tier.
+        var afterDecay = _t0.AddSeconds(60) + ChatLimits.AutoThrottleTierDecay + TimeSpan.FromSeconds(1);
+        var reset = TriggerAutoThrottle(afterDecay);
+        Assert.AreEqual(10, reset.RetryAfterSeconds.Value, 0.001,
+            "10 clean minutes without a trigger must reset the ladder to the 10s first tier");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
+++ b/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
@@ -123,6 +123,7 @@ public class MessageRateLimiterTests
         for (var v = 0; v < ChatLimits.AutoThrottleViolationThreshold; v++)
         {
             escalation = _limiter.TryAcquire(Conn, Channel, at);
+            Assert.IsFalse(escalation.Allowed, "every violation-loop send must be denied, including the escalating one");
         }
         Assert.IsTrue(escalation.JustAutoThrottled, "the threshold-th violation must escalate");
         return escalation;
@@ -137,6 +138,13 @@ public class MessageRateLimiterTests
 
         // Still denied 9s in; recovered right after the 10s tier elapses (fresh burst).
         Assert.IsFalse(_limiter.TryAcquire(Conn, Channel, _t0.AddSeconds(9)).Allowed);
+
+        // The hard throttle is connection-wide, not per-channel: a SECOND, different channel on the
+        // same connection is denied too while the penalty is active, and it's not a fresh escalation.
+        var otherChannelDenial = _limiter.TryAcquire(Conn, "channel-b", _t0.AddSeconds(9));
+        Assert.IsFalse(otherChannelDenial.Allowed, "hard auto-throttle blocks every channel on the connection");
+        Assert.IsFalse(otherChannelDenial.JustAutoThrottled, "a denial during an active penalty is not a new escalation");
+
         Assert.IsTrue(_limiter.TryAcquire(Conn, Channel, _t0 + ChatLimits.AutoThrottleTierDurations[0] + TimeSpan.FromSeconds(11)).Allowed,
             "after serving 10s (plus bucket refill time) the connection recovers");
     }
@@ -172,6 +180,34 @@ public class MessageRateLimiterTests
         var reset = TriggerAutoThrottle(afterDecay);
         Assert.AreEqual(10, reset.RetryAfterSeconds.Value, 0.001,
             "10 clean minutes without a trigger must reset the ladder to the 10s first tier");
+    }
+
+    [Test]
+    public void TierLadder_ResetsAtExactlyTheDecayBoundary()
+    {
+        // Pins the `>=` comparison at MessageRateLimiter.cs:194: at EXACTLY AutoThrottleTierDecay
+        // since the last trigger, the ladder MUST already have reset (the boundary is inclusive).
+        TriggerAutoThrottle(_t0);
+        TriggerAutoThrottle(_t0.AddSeconds(60)); // tier 2 (30s served); LastAutoThrottleAt = t0+60s
+
+        var atBoundary = _t0.AddSeconds(60) + ChatLimits.AutoThrottleTierDecay;
+        var reset = TriggerAutoThrottle(atBoundary);
+        Assert.AreEqual(10, reset.RetryAfterSeconds.Value, 0.001,
+            "exactly AutoThrottleTierDecay since the last trigger must reset the ladder");
+    }
+
+    [Test]
+    public void TierLadder_DoesNotReset_JustUnderTheDecayBoundary()
+    {
+        // One second short of AutoThrottleTierDecay: the ladder must NOT reset — the trigger
+        // continues the ladder from tier 2 (index 2, the 60s cap), not back down to 10s.
+        TriggerAutoThrottle(_t0);
+        TriggerAutoThrottle(_t0.AddSeconds(60)); // tier 2 (30s served); LastAutoThrottleAt = t0+60s
+
+        var justUnder = _t0.AddSeconds(60) + ChatLimits.AutoThrottleTierDecay - TimeSpan.FromSeconds(1);
+        var notReset = TriggerAutoThrottle(justUnder);
+        Assert.AreEqual(60, notReset.RetryAfterSeconds.Value, 0.001,
+            "just under AutoThrottleTierDecay since the last trigger must NOT reset the ladder");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
+++ b/W3ChampionsChatService.Tests/MessageRateLimiterTests.cs
@@ -8,16 +8,16 @@ namespace W3ChampionsChatService.Tests;
 
 /// <summary>
 /// Unit tests for <see cref="MessageRateLimiter"/> — the pure, deterministic send-path abuse control
-/// (C3 Task 6). Every decision takes an explicit <c>DateTime now</c>; refills are derived from
-/// elapsed time, so these tests never sleep and never read the wall clock. Two token buckets
-/// (per-(connection, channel) burst-then-sustained, and a per-connection global window) plus an
-/// escalation to a 60s hard auto-throttle after repeated violations.
+/// (C3 Task 6; re-keyed to battleTag by the 2026-08-04 follow-up spec §1). Every decision takes an
+/// explicit <c>DateTime now</c>; refills are derived from elapsed time, so these tests never sleep and
+/// never read the wall clock. Two token buckets (per-(user, channel) burst-then-sustained, and a
+/// per-user global window) plus an escalation to a 60s hard auto-throttle after repeated violations.
 /// </summary>
 public class MessageRateLimiterTests
 {
     private MessageRateLimiter _limiter;
     private DateTime _t0;
-    private const string Conn = "conn-1";
+    private const string User = "peter#123";
     private const string Channel = "channel-a";
 
     [SetUp]
@@ -32,13 +32,13 @@ public class MessageRateLimiterTests
     {
         for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
         {
-            var allowed = _limiter.TryAcquire(Conn, Channel, _t0);
+            var allowed = _limiter.TryAcquire(User, Channel, _t0);
             Assert.IsTrue(allowed.Allowed, $"burst message {i + 1} within capacity must be allowed");
             Assert.IsNull(allowed.RetryAfterSeconds, "allowed sends carry no retry-after");
         }
 
         // 6th message well inside the sustained interval — burst is spent, no full token yet.
-        var sixth = _limiter.TryAcquire(Conn, Channel, _t0.AddMilliseconds(500));
+        var sixth = _limiter.TryAcquire(User, Channel, _t0.AddMilliseconds(500));
 
         Assert.IsFalse(sixth.Allowed, "the 6th message inside 1s exceeds the per-channel burst");
         Assert.IsNotNull(sixth.RetryAfterSeconds);
@@ -51,21 +51,21 @@ public class MessageRateLimiterTests
     {
         for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
         {
-            _limiter.TryAcquire(Conn, Channel, _t0);
+            _limiter.TryAcquire(User, Channel, _t0);
         }
         // Burst spent; an immediate retry is throttled.
-        Assert.IsFalse(_limiter.TryAcquire(Conn, Channel, _t0).Allowed);
+        Assert.IsFalse(_limiter.TryAcquire(User, Channel, _t0).Allowed);
 
         // One sustained interval later, exactly one token has regenerated.
-        var afterOne = _limiter.TryAcquire(Conn, Channel, _t0 + ChatLimits.PerChannelSustainedInterval);
+        var afterOne = _limiter.TryAcquire(User, Channel, _t0 + ChatLimits.PerChannelSustainedInterval);
         Assert.IsTrue(afterOne.Allowed, "one token regenerates per sustained interval");
 
         // That single token is spent again — another immediate send is throttled.
-        Assert.IsFalse(_limiter.TryAcquire(Conn, Channel, _t0 + ChatLimits.PerChannelSustainedInterval).Allowed);
+        Assert.IsFalse(_limiter.TryAcquire(User, Channel, _t0 + ChatLimits.PerChannelSustainedInterval).Allowed);
 
         // Two intervals in, the next token is available — steady state of 1 per interval.
         var afterTwo = _limiter.TryAcquire(
-            Conn,
+            User,
             Channel,
             _t0 + ChatLimits.PerChannelSustainedInterval + ChatLimits.PerChannelSustainedInterval);
         Assert.IsTrue(afterTwo.Allowed, "sustained rate holds at 1 per interval");
@@ -75,16 +75,16 @@ public class MessageRateLimiterTests
     public void GlobalBucket_10Per5s_EnforcedAcrossChannels()
     {
         // One message across 10 DISTINCT channels: no per-channel bucket is ever the binding
-        // constraint (each has capacity 5), so only the per-connection global bucket can throttle.
+        // constraint (each has capacity 5), so only the per-user global bucket can throttle.
         for (var i = 0; i < ChatLimits.GlobalMessageBurst; i++)
         {
-            var d = _limiter.TryAcquire(Conn, $"channel-{i}", _t0);
+            var d = _limiter.TryAcquire(User, $"channel-{i}", _t0);
             Assert.IsTrue(d.Allowed, $"global send {i + 1} within the global burst must be allowed");
         }
 
         // 11th send on yet another fresh channel: its per-channel bucket is full, but the global
         // bucket is exhausted → throttled by the global limit, not the per-channel one.
-        var overflow = _limiter.TryAcquire(Conn, "channel-overflow", _t0);
+        var overflow = _limiter.TryAcquire(User, "channel-overflow", _t0);
 
         Assert.IsFalse(overflow.Allowed, "the global 10/5s cap is enforced across all channels");
         Assert.IsNotNull(overflow.RetryAfterSeconds);
@@ -97,10 +97,10 @@ public class MessageRateLimiterTests
     {
         for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
         {
-            _limiter.TryAcquire(Conn, Channel, _t0);
+            _limiter.TryAcquire(User, Channel, _t0);
         }
 
-        var throttled = _limiter.TryAcquire(Conn, Channel, _t0);
+        var throttled = _limiter.TryAcquire(User, Channel, _t0);
 
         Assert.IsFalse(throttled.Allowed);
         Assert.IsNotNull(throttled.RetryAfterSeconds);
@@ -111,18 +111,18 @@ public class MessageRateLimiterTests
             "retry-after for a per-channel throttle must not exceed the sustained interval");
     }
 
-    // Drives one full auto-throttle trigger for Conn on Channel at `at`: spends the burst, then lands
+    // Drives one full auto-throttle trigger for User on Channel at `at`: spends the burst, then lands
     // AutoThrottleViolationThreshold violations — returns the escalation decision (JustAutoThrottled true).
     private RateLimitDecision TriggerAutoThrottle(DateTime at)
     {
         for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
         {
-            Assert.IsTrue(_limiter.TryAcquire(Conn, Channel, at).Allowed, "burst send must be allowed");
+            Assert.IsTrue(_limiter.TryAcquire(User, Channel, at).Allowed, "burst send must be allowed");
         }
         RateLimitDecision escalation = default;
         for (var v = 0; v < ChatLimits.AutoThrottleViolationThreshold; v++)
         {
-            escalation = _limiter.TryAcquire(Conn, Channel, at);
+            escalation = _limiter.TryAcquire(User, Channel, at);
             Assert.IsFalse(escalation.Allowed, "every violation-loop send must be denied, including the escalating one");
         }
         Assert.IsTrue(escalation.JustAutoThrottled, "the threshold-th violation must escalate");
@@ -137,16 +137,16 @@ public class MessageRateLimiterTests
         Assert.AreEqual(10, first.RetryAfterSeconds.Value, 0.001, "spec pin: the FIRST tier is exactly 10s");
 
         // Still denied 9s in; recovered right after the 10s tier elapses (fresh burst).
-        Assert.IsFalse(_limiter.TryAcquire(Conn, Channel, _t0.AddSeconds(9)).Allowed);
+        Assert.IsFalse(_limiter.TryAcquire(User, Channel, _t0.AddSeconds(9)).Allowed);
 
-        // The hard throttle is connection-wide, not per-channel: a SECOND, different channel on the
-        // same connection is denied too while the penalty is active, and it's not a fresh escalation.
-        var otherChannelDenial = _limiter.TryAcquire(Conn, "channel-b", _t0.AddSeconds(9));
-        Assert.IsFalse(otherChannelDenial.Allowed, "hard auto-throttle blocks every channel on the connection");
+        // The hard throttle is user-wide, not per-channel: a SECOND, different channel for the
+        // same user is denied too while the penalty is active, and it's not a fresh escalation.
+        var otherChannelDenial = _limiter.TryAcquire(User, "channel-b", _t0.AddSeconds(9));
+        Assert.IsFalse(otherChannelDenial.Allowed, "hard auto-throttle blocks every channel for the user");
         Assert.IsFalse(otherChannelDenial.JustAutoThrottled, "a denial during an active penalty is not a new escalation");
 
-        Assert.IsTrue(_limiter.TryAcquire(Conn, Channel, _t0 + ChatLimits.AutoThrottleTierDurations[0] + TimeSpan.FromSeconds(11)).Allowed,
-            "after serving 10s (plus bucket refill time) the connection recovers");
+        Assert.IsTrue(_limiter.TryAcquire(User, Channel, _t0 + ChatLimits.AutoThrottleTierDurations[0] + TimeSpan.FromSeconds(11)).Allowed,
+            "after serving 10s (plus bucket refill time) the user recovers");
     }
 
     [Test]
@@ -185,8 +185,9 @@ public class MessageRateLimiterTests
     [Test]
     public void TierLadder_ResetsAtExactlyTheDecayBoundary()
     {
-        // Pins the `>=` comparison at MessageRateLimiter.cs:194: at EXACTLY AutoThrottleTierDecay
-        // since the last trigger, the ladder MUST already have reset (the boundary is inclusive).
+        // Pins the `>=` comparison in RecordViolationAndCheckEscalation's tier-decay check: at EXACTLY
+        // AutoThrottleTierDecay since the last trigger, the ladder MUST already have reset (the
+        // boundary is inclusive).
         TriggerAutoThrottle(_t0);
         TriggerAutoThrottle(_t0.AddSeconds(60)); // tier 2 (30s served); LastAutoThrottleAt = t0+60s
 
@@ -230,18 +231,20 @@ public class MessageRateLimiterTests
         {
             for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
             {
-                _limiter.TryAcquire(Conn, Channel, _t0);
+                _limiter.TryAcquire(User, Channel, _t0);
             }
             for (var v = 0; v < ChatLimits.AutoThrottleViolationThreshold; v++)
             {
-                _limiter.TryAcquire(Conn, Channel, _t0);
+                _limiter.TryAcquire(User, Channel, _t0);
             }
             // Further denied sends inside the hard-throttle window must NOT emit more log lines.
-            _limiter.TryAcquire(Conn, Channel, _t0.AddSeconds(1));
-            _limiter.TryAcquire(Conn, Channel, _t0.AddSeconds(2));
+            _limiter.TryAcquire(User, Channel, _t0.AddSeconds(1));
+            _limiter.TryAcquire(User, Channel, _t0.AddSeconds(2));
 
             Assert.AreEqual(1, capturedWarnings.Count, "auto-throttle must log exactly one moderation line");
-            StringAssert.Contains(Conn, capturedWarnings[0], "the moderation line must identify the connection");
+            // The line logs the LOWERCASED battleTag key, not the raw arg — User is already all-lowercase,
+            // but assert against the normalized form so this stays correct if User ever gains mixed casing.
+            StringAssert.Contains(User.ToLowerInvariant(), capturedWarnings[0], "the moderation line must identify the battleTag");
         }
         finally
         {
@@ -251,62 +254,59 @@ public class MessageRateLimiterTests
     }
 
     [Test]
-    public void Buckets_AreIndependent_PerConnection()
+    public void Buckets_AreIndependent_PerUser()
     {
-        // Connection A exhausts its per-channel burst on a shared channel.
+        // User A exhausts their per-channel burst on a shared channel.
         for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
         {
-            Assert.IsTrue(_limiter.TryAcquire("conn-A", Channel, _t0).Allowed);
+            Assert.IsTrue(_limiter.TryAcquire("userA#1", Channel, _t0).Allowed);
         }
-        Assert.IsFalse(_limiter.TryAcquire("conn-A", Channel, _t0).Allowed, "conn-A's own burst is spent");
+        Assert.IsFalse(_limiter.TryAcquire("userA#1", Channel, _t0).Allowed, "userA's own burst is spent");
 
-        // Connection B on the SAME channel is unaffected — buckets are per (connection, channel).
+        // User B on the SAME channel is unaffected — buckets are per (user, channel).
         for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
         {
             Assert.IsTrue(
-                _limiter.TryAcquire("conn-B", Channel, _t0).Allowed,
-                $"conn-B message {i + 1} must have its own independent burst");
+                _limiter.TryAcquire("userB#2", Channel, _t0).Allowed,
+                $"userB message {i + 1} must have its own independent burst");
         }
     }
 
     [Test]
-    public void RemoveConnection_DropsState()
+    public void HardThrottle_SurvivesReconnect_BecauseStateIsKeyedByBattleTag()
     {
-        for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
-        {
-            _limiter.TryAcquire(Conn, Channel, _t0);
-        }
-        Assert.IsFalse(_limiter.TryAcquire(Conn, Channel, _t0).Allowed, "burst is spent before removal");
+        TriggerAutoThrottle(_t0);
 
-        _limiter.RemoveConnection(Conn);
-
-        // After removal the connection is brand-new: full burst available at the SAME instant.
-        var afterRemoval = _limiter.TryAcquire(Conn, Channel, _t0);
-        Assert.IsTrue(afterRemoval.Allowed, "RemoveConnection drops all bucket/violation state");
-        Assert.IsNull(afterRemoval.RetryAfterSeconds);
+        // A relaunch/reconnect produces a NEW connectionId but the SAME battleTag — there is no
+        // RemoveConnection any more, and TryAcquire keys on the tag, so the penalty holds.
+        var afterReconnect = _limiter.TryAcquire(User, Channel, _t0.AddSeconds(2));
+        Assert.IsFalse(afterReconnect.Allowed, "the hard throttle must survive reconnect (battleTag-keyed)");
+        Assert.IsFalse(afterReconnect.JustAutoThrottled, "no re-signal while serving the penalty");
     }
 
     [Test]
-    public void RemoveConnection_ClearsActiveHardThrottle()
+    public void BattleTagKey_IsCaseInsensitive()
     {
-        for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
-        {
-            _limiter.TryAcquire(Conn, Channel, _t0);
-        }
-        RateLimitDecision escalation = default;
-        for (var v = 0; v < ChatLimits.AutoThrottleViolationThreshold; v++)
-        {
-            escalation = _limiter.TryAcquire(Conn, Channel, _t0);
-        }
-        Assert.IsTrue(escalation.JustAutoThrottled, "precondition: the connection is now hard-throttled");
-        Assert.IsFalse(_limiter.TryAcquire(Conn, Channel, _t0.AddSeconds(1)).Allowed, "still inside the penalty");
+        TriggerAutoThrottle(_t0);
+        var differentCasing = _limiter.TryAcquire("PETER#123", Channel, _t0.AddSeconds(2));
+        Assert.IsFalse(differentCasing.Allowed, "casing variants of one battleTag share one throttle state");
+    }
 
-        _limiter.RemoveConnection(Conn);
+    [Test]
+    public void QuiescentEntries_ArePruned_BoundingMemory()
+    {
+        // 200 distinct users each send once at t0 — 200 live entries.
+        for (var i = 0; i < 200; i++)
+        {
+            Assert.IsTrue(_limiter.TryAcquire($"user{i}#1", Channel, _t0).Allowed);
+        }
 
-        // The same connectionId is a clean slate even mid-penalty (e.g. reconnect reusing the id).
-        var afterRemoval = _limiter.TryAcquire(Conn, Channel, _t0.AddSeconds(1));
-        Assert.IsTrue(afterRemoval.Allowed, "RemoveConnection clears an active hard-throttle");
-        Assert.IsFalse(afterRemoval.JustAutoThrottled);
+        // One send far past the decay/prune horizon sweeps every quiescent entry.
+        var later = _t0 + ChatLimits.AutoThrottleTierDecay + TimeSpan.FromSeconds(1);
+        Assert.IsTrue(_limiter.TryAcquire(User, Channel, later).Allowed);
+
+        Assert.LessOrEqual(_limiter.TrackedUserCount, 2,
+            "entries idle past AutoThrottleTierDecay must be pruned (only the sweeping caller may remain)");
     }
 
     [Test]
@@ -321,9 +321,9 @@ public class MessageRateLimiterTests
             // The bucket has fully refilled across the >window gap → a fresh burst each epoch.
             for (var i = 0; i < ChatLimits.PerChannelBurst; i++)
             {
-                Assert.IsTrue(_limiter.TryAcquire(Conn, Channel, epoch).Allowed);
+                Assert.IsTrue(_limiter.TryAcquire(User, Channel, epoch).Allowed);
             }
-            var throttled = _limiter.TryAcquire(Conn, Channel, epoch);
+            var throttled = _limiter.TryAcquire(User, Channel, epoch);
             Assert.IsFalse(throttled.Allowed, "the over-burst send is throttled");
             Assert.IsFalse(
                 throttled.JustAutoThrottled,
@@ -342,12 +342,12 @@ public class MessageRateLimiterTests
         var now = _t0;
         for (var i = 0; i < 1000; i++)
         {
-            Assert.IsTrue(_limiter.TryAcquire(Conn, $"channel-{i}", now).Allowed);
+            Assert.IsTrue(_limiter.TryAcquire(User, $"channel-{i}", now).Allowed);
             now = now.AddSeconds(1);
         }
 
         Assert.LessOrEqual(
-            _limiter.TrackedChannelCount(Conn),
+            _limiter.TrackedChannelCount(User),
             ChatLimits.PerChannelBurst + 1,
             "idle per-channel buckets must be purged so the map cannot grow unboundedly");
     }

--- a/W3ChampionsChatService.Tests/MessageRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/MessageRepositoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -530,6 +531,75 @@ public class MessageRepositoryTests : IntegrationTestBase
         var count = await repo.CountUserVisibleAfter("chan1", "Peter#123", 5);
 
         Assert.AreEqual(0, count);
+    }
+
+    // ── 2026-08-05 PR36 feedback (Part 1) — CountUserVisibleAfterMany, one aggregation round-trip ────
+
+    [Test]
+    public async Task CountUserVisibleAfterMany_MatchesSingleVersion_AcrossMultipleChannels()
+    {
+        var repo = new MessageRepository(MongoClient);
+
+        // chan1: same mix as CountUserVisibleAfter_ExcludesForeignShadowAndDeleted_IncludesOwnShadow —
+        // exercises the SAME visibility predicates (deleted + foreign-shadow exclusion, own-shadow
+        // inclusion) inside the batched $match.
+        var normal = NewMessage("chan1", 1, "Peter#123");
+        var deleted = NewMessage("chan1", 2, "Peter#123");
+        var foreignShadow = NewMessage("chan1", 3, "Wolf#456");
+        foreignShadow.Shadow = true;
+        var ownShadow = NewMessage("chan1", 4, "Peter#123");
+        ownShadow.Shadow = true;
+        var trailing = NewMessage("chan1", 5, "Peter#123");
+        await repo.Insert(normal);
+        await repo.Insert(deleted);
+        await repo.Insert(foreignShadow);
+        await repo.Insert(ownShadow);
+        await repo.Insert(trailing);
+        await repo.MarkDeleted(deleted.Id, "Mod#1", DateTime.UtcNow);
+
+        // chan2: caught up (a real zero-count channel with the cursor at the tip) — must be ABSENT from
+        // the batched result, never a spurious zero entry.
+        for (var seq = 1; seq <= 3; seq++)
+        {
+            await repo.Insert(NewMessage("chan2", seq));
+        }
+
+        // chan3: no messages at all — the "genuinely no rows ever" zero-count case.
+        var cursors = new[]
+        {
+            new ChannelUnreadCursor("chan1", 0),
+            new ChannelUnreadCursor("chan2", 3),
+            new ChannelUnreadCursor("chan3", 0),
+        };
+
+        var batched = await repo.CountUserVisibleAfterMany(cursors, "Peter#123");
+
+        var singleChan1 = await repo.CountUserVisibleAfter("chan1", "Peter#123", 0);
+        var singleChan2 = await repo.CountUserVisibleAfter("chan2", "Peter#123", 3);
+        var singleChan3 = await repo.CountUserVisibleAfter("chan3", "Peter#123", 0);
+
+        Assert.AreEqual(singleChan1, batched.GetValueOrDefault("chan1", 0), "chan1 (mixed visible/deleted/shadow) must match the single-version count");
+        Assert.AreEqual(0, singleChan2, "sanity: chan2 is caught up under the single version too");
+        Assert.AreEqual(singleChan2, batched.GetValueOrDefault("chan2", 0), "chan2 (caught up) must match the single-version count");
+        Assert.AreEqual(0, singleChan3, "sanity: chan3 has no rows under the single version too");
+        Assert.AreEqual(singleChan3, batched.GetValueOrDefault("chan3", 0), "chan3 (no rows) must match the single-version count");
+
+        CollectionAssert.AreEqual(new[] { "chan1" }, batched.Keys.ToList(),
+            "a zero-count channel (caught up OR no rows) must be ABSENT from the dictionary, not present with value 0");
+    }
+
+    [Test]
+    public async Task CountUserVisibleAfterMany_EmptyInput_ReturnsEmptyWithoutQuerying()
+    {
+        var repo = new MessageRepository(MongoClient);
+        // Present so an unguarded `$or: []` (which Mongo treats as match-everything) would wrongly
+        // surface this channel — proving the empty-input guard short-circuits before any query.
+        await repo.Insert(NewMessage("chan1", 1, "Peter#123"));
+
+        var result = await repo.CountUserVisibleAfterMany(Array.Empty<ChannelUnreadCursor>(), "Peter#123");
+
+        Assert.AreEqual(0, result.Count,
+            "empty input must short-circuit to an empty result, never match-all via an unguarded $or: []");
     }
 
     // ── C4 Task 1 (D6) — purge query building blocks (consumed by a later C4 task) ───────────

--- a/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
@@ -117,7 +117,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
         _mentionInboxRepository = new MentionInboxRepository(MongoClient);
         // The REAL C6 T5 writer (D3/D4), shared with the hubs' own membership/session state, so tests
         // can seed genuine mention-inbox entries the same way the send pipeline would (C6 Task 7).
-        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository);
+        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory);
         // Wraps the REAL C6 Task 7 cleaner (MentionInboxCleaner) so DeleteMessage/PurgeMessagesFromUser
         // physically remove mention-inbox rows in this suite too, while still recording each call's exact
         // id batch for the pre-existing spy assertions below.

--- a/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
@@ -117,7 +117,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
         _mentionInboxRepository = new MentionInboxRepository(MongoClient);
         // The REAL C6 T5 writer (D3/D4), shared with the hubs' own membership/session state, so tests
         // can seed genuine mention-inbox entries the same way the send pipeline would (C6 Task 7).
-        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory);
+        _mentionFanOut = new MentionFanOut(_harness.HubContext, _sessionRegistry, _membershipRepository, _mentionInboxRepository, _userDirectory, RelationshipProviderTestFactory.CreateIgnored(), new NotificationPreferenceRepository(MongoClient));
         // Wraps the REAL C6 Task 7 cleaner (MentionInboxCleaner) so DeleteMessage/PurgeMessagesFromUser
         // physically remove mention-inbox rows in this suite too, while still recording each call's exact
         // id batch for the pre-existing spy assertions below.
@@ -192,7 +192,8 @@ public class ModerationIntegrationTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
@@ -66,6 +66,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
@@ -105,6 +106,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _userDirectory = new UserDirectoryRepository(MongoClient);
         _muteRepository = new MuteRepository(MongoClient);
@@ -178,6 +180,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/MutePortTests.cs
+++ b/W3ChampionsChatService.Tests/MutePortTests.cs
@@ -69,6 +69,7 @@ public class MutePortTests : IntegrationTestBase
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ChannelCreationRateLimiter _channelCreationRateLimiter;
     private SessionStateAssembler _assembler;
 
@@ -107,6 +108,7 @@ public class MutePortTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _channelCreationRateLimiter = new ChannelCreationRateLimiter();
         _assembler = NewAssembler(_muteRepository);
 
@@ -132,6 +134,7 @@ public class MutePortTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/MutePortTests.cs
+++ b/W3ChampionsChatService.Tests/MutePortTests.cs
@@ -146,7 +146,8 @@ public class MutePortTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient))
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient))
         {
             Clients = clients,
             Context = context,

--- a/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
@@ -93,7 +93,8 @@ public class MuteReconciliationTests : IntegrationTestBase
             chatAuthService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         _clients = new Mock<IHubCallerClients>();
         _callerProxy = new Mock<ISingleClientProxy>();

--- a/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
@@ -79,6 +79,7 @@ public class MuteReconciliationTests : IntegrationTestBase
             new FocusRegistry(),
             _onlineMemberRegistry,
             new MessageRateLimiter(),
+            new ReadRateLimiter(),
             TimeProvider.System,
             _channelRepository,
             new MembershipRepository(MongoClient, _channelRepository),

--- a/W3ChampionsChatService.Tests/NotificationPreferenceRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/NotificationPreferenceRepositoryTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using NUnit.Framework;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Memberships;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// PR36 follow-up (D2), fix round 1 (F4): direct repository-level coverage for
+/// <see cref="NotificationPreferenceRepository"/> — previously exercised only indirectly through the hub
+/// and fan-out test suites (which is how the ctor's original <c>_id</c>/ObjectId deserialization bug was
+/// actually caught, see task-1-report.md). Mirrors <see cref="MembershipRepositoryTests"/>' index-assertion
+/// style: <see cref="ChatDomainIndexes.EnsureAllAsync"/> is never called by <c>IntegrationTestBase</c>
+/// itself (it only drops the DB), so every index-dependent test here calls it explicitly first.
+/// </summary>
+public class NotificationPreferenceRepositoryTests : IntegrationTestBase
+{
+    [Test]
+    public async Task Upsert_Then_Load_RoundTrips()
+    {
+        var repo = new NotificationPreferenceRepository(MongoClient);
+        var now = DateTime.UtcNow;
+
+        await repo.Upsert("Peter#123", "chan1", NotificationLevel.None, now);
+        var loaded = await repo.Load("Peter#123", "chan1");
+
+        Assert.IsNotNull(loaded);
+        Assert.AreEqual(NotificationLevel.None, loaded.NotificationLevel);
+        Assert.That((loaded.UpdatedAt - now).Duration(), Is.LessThan(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public async Task Load_NoPreferenceEverSet_ReturnsNull()
+    {
+        var repo = new NotificationPreferenceRepository(MongoClient);
+
+        Assert.IsNull(await repo.Load("nobody#1", "chan1"),
+            "null means 'no opinion' — callers must never treat it as an implicit None");
+    }
+
+    [Test]
+    public async Task Upsert_RepeatedSets_LastWriteWins_NeverAccumulatesDuplicateRows()
+    {
+        var repo = new NotificationPreferenceRepository(MongoClient);
+        var now = DateTime.UtcNow;
+
+        await repo.Upsert("Peter#123", "chan1", NotificationLevel.None, now);
+        await repo.Upsert("Peter#123", "chan1", NotificationLevel.Mentions, now.AddMinutes(1));
+
+        var loaded = await repo.Load("Peter#123", "chan1");
+        Assert.AreEqual(NotificationLevel.Mentions, loaded.NotificationLevel, "the LAST set must win");
+
+        var collection = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName)
+            .GetCollection<NotificationPreference>(ChatCollections.NotificationPreferences);
+        var count = await collection.CountDocumentsAsync(p => p.BattleTag == "peter#123" && p.ChannelId == "chan1");
+        Assert.AreEqual(1, count, "a repeated set must upsert the SAME row, never accumulate duplicates");
+    }
+
+    // Fix round 1 (F3): a mutation that removed NormalizeTag's ToLowerInvariant() would pass every OTHER
+    // test in this suite unnoticed (they always write and read under the SAME casing). Writing under one
+    // casing and reading under another asymmetric casing pins the normalization at both the Upsert AND
+    // Load call sites.
+    [Test]
+    public async Task Upsert_MixedCase_IsReadableByDifferentCasing_PinsNormalizeTag()
+    {
+        var repo = new NotificationPreferenceRepository(MongoClient);
+        var now = DateTime.UtcNow;
+
+        await repo.Upsert("Wolf#456", "chan1", NotificationLevel.None, now);
+
+        Assert.IsNotNull(await repo.Load("wolf#456", "chan1"), "a lowercase read must resolve an upper/mixed-case write");
+        Assert.IsNotNull(await repo.Load("WOLF#456", "chan1"), "an uppercase read must resolve it too");
+
+        var collection = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName)
+            .GetCollection<NotificationPreference>(ChatCollections.NotificationPreferences);
+        var stored = await collection.Find(p => p.ChannelId == "chan1").FirstOrDefaultAsync();
+        Assert.AreEqual("wolf#456", stored.BattleTag, "the durable row is stored lowercased regardless of the write-time casing");
+    }
+
+    [Test]
+    public async Task NotificationPreferenceIndexes_AreCreated()
+    {
+        await ChatDomainIndexes.EnsureAllAsync(MongoClient);
+        var db = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName);
+        var indexes = await (await db.GetCollection<NotificationPreference>(ChatCollections.NotificationPreferences).Indexes.ListAsync()).ToListAsync();
+
+        var unique = indexes.Single(i => i["name"] == "ux_battleTag_channelId");
+        Assert.IsTrue(unique["unique"].AsBoolean);
+        Assert.AreEqual(1, unique["key"]["BattleTag"].ToInt32());
+        Assert.AreEqual(1, unique["key"]["ChannelId"].ToInt32());
+    }
+
+    [Test]
+    public async Task DuplicateNotificationPreference_RawInsert_IsRejectedByUniqueIndex()
+    {
+        // A RAW insert (bypassing Upsert's findAndModify) proves the unique index itself is what makes
+        // Upsert's last-write-wins semantics well-defined — mirrors MembershipRepositoryTests'
+        // DuplicateMembership_IsRejectedByUniqueIndex.
+        await ChatDomainIndexes.EnsureAllAsync(MongoClient);
+        var collection = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName)
+            .GetCollection<NotificationPreference>(ChatCollections.NotificationPreferences);
+        await collection.InsertOneAsync(new NotificationPreference
+        {
+            BattleTag = "peter#123",
+            ChannelId = "chan1",
+            NotificationLevel = NotificationLevel.None,
+            UpdatedAt = DateTime.UtcNow,
+        });
+
+        Assert.ThrowsAsync<MongoWriteException>(() => collection.InsertOneAsync(new NotificationPreference
+        {
+            BattleTag = "peter#123",
+            ChannelId = "chan1",
+            NotificationLevel = NotificationLevel.Mentions,
+            UpdatedAt = DateTime.UtcNow,
+        }));
+    }
+}

--- a/W3ChampionsChatService.Tests/OldProtocolRemovedTests.cs
+++ b/W3ChampionsChatService.Tests/OldProtocolRemovedTests.cs
@@ -126,6 +126,10 @@ public class OldProtocolRemovedTests
             // precedent as every C5/C6 growth above.
             "GetPresence",
             "GetPresenceDetails",
+            // 2026-08-04 follow-up spec §6 (CS Task 8): the cursor-paginated read of the caller's
+            // older 1:1 Dm shells — GetConversations (ChatHub.Dm.cs). Widens the pinned set, never
+            // weakens it — same precedent as every C5/C6 growth above.
+            "GetConversations",
             // Legacy moderation trio (kept, ChatHub.cs)
             "DeleteMessage",
             "PurgeMessagesFromUser",

--- a/W3ChampionsChatService.Tests/ProtocolContractTests.cs
+++ b/W3ChampionsChatService.Tests/ProtocolContractTests.cs
@@ -62,9 +62,10 @@ public class ProtocolContractTests
     [Test]
     public void ChatLimits_AutoThrottle_Constants()
     {
-        // Plan decision (C3-plan.md Task 1 / Open question 3) — spec §13 pins only "60s automatic
-        // throttle"; the escalation trigger threshold/window are NOT spec-pinned, XML-doc'd as such
-        // at the declaration. Tier durations/decay are pinned by the 2026-08-04 follow-up spec §1.
+        // Plan decision (C3-plan.md Task 1 / Open question 3): the escalation trigger
+        // threshold/window are NOT spec-pinned, XML-doc'd as such at the declaration. The escalating
+        // tier durations (10s/30s/60s cap) and the 10-minute decay are pinned by the 2026-08-04
+        // follow-up spec §1.
         Assert.AreEqual(5, ChatLimits.AutoThrottleViolationThreshold);
         Assert.AreEqual(TimeSpan.FromSeconds(60), ChatLimits.AutoThrottleWindow);
         CollectionAssert.AreEqual(

--- a/W3ChampionsChatService.Tests/ProtocolContractTests.cs
+++ b/W3ChampionsChatService.Tests/ProtocolContractTests.cs
@@ -64,10 +64,13 @@ public class ProtocolContractTests
     {
         // Plan decision (C3-plan.md Task 1 / Open question 3) — spec §13 pins only "60s automatic
         // throttle"; the escalation trigger threshold/window are NOT spec-pinned, XML-doc'd as such
-        // at the declaration.
+        // at the declaration. Tier durations/decay are pinned by the 2026-08-04 follow-up spec §1.
         Assert.AreEqual(5, ChatLimits.AutoThrottleViolationThreshold);
         Assert.AreEqual(TimeSpan.FromSeconds(60), ChatLimits.AutoThrottleWindow);
-        Assert.AreEqual(TimeSpan.FromSeconds(60), ChatLimits.AutoThrottleDuration);
+        CollectionAssert.AreEqual(
+            new[] { TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60) },
+            ChatLimits.AutoThrottleTierDurations);
+        Assert.AreEqual(TimeSpan.FromMinutes(10), ChatLimits.AutoThrottleTierDecay);
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ReadRateLimiterTests.cs
+++ b/W3ChampionsChatService.Tests/ReadRateLimiterTests.cs
@@ -26,6 +26,18 @@ public class ReadRateLimiterTests
         _t0 = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
     }
 
+    // Drains User's bucket back to zero tokens AS OF `at` (refilling first, same as a real TryAcquire
+    // would) — used by the F3 logging tests below to force a genuine denial at an arbitrary later time,
+    // since the bucket's full-refill time (12s) is far shorter than ReadRateLimiterDenyLogInterval (60s)
+    // and would otherwise have long since refilled by the time a suppression probe runs.
+    private void ExhaustBurstAt(DateTime at)
+    {
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            _limiter.TryAcquire(User, at);
+        }
+    }
+
     [Test]
     public void Burst_AllowsReadBurstImmediateCalls_NextIsDenied_WithRetryAfter()
     {
@@ -133,6 +145,49 @@ public class ReadRateLimiterTests
             Assert.IsTrue(_limiter.TryAcquire(User, _t0).Allowed, $"call {i + 1} within the shared budget must be allowed");
         }
         Assert.IsFalse(_limiter.TryAcquire(User, _t0).Allowed, "the shared per-battleTag budget is exhausted regardless of which guarded method spent it");
+    }
+
+    [Test]
+    public void Deny_LogsAtMostOncePerDenyLogInterval_PerUser()
+    {
+        // Fix round 1, finding F3: denials were previously invisible to operators. There is no
+        // log-capture harness in this test suite (see FanOut/ReadRateLimiter.cs's class doc for why —
+        // the log call is deliberately outside the lock), so this pins the once-per-
+        // ChatLimits.ReadRateLimiterDenyLogInterval logging decision directly via the internal test seam
+        // (LastDenyLoggedAtFor) rather than captured log output.
+        ExhaustBurstAt(_t0);
+        Assert.IsNull(_limiter.LastDenyLoggedAtFor(User), "no denial has happened yet — nothing logged");
+
+        // First denial at t0: stamps LastDenyLoggedAt.
+        var firstDenial = _limiter.TryAcquire(User, _t0);
+        Assert.IsFalse(firstDenial.Allowed, "the bucket is already fully drained by ExhaustBurstAt");
+        Assert.AreEqual(_t0, _limiter.LastDenyLoggedAtFor(User), "the first denial stamps the log time");
+
+        // A denial well within ReadRateLimiterDenyLogInterval must NOT refresh the stamp (suppressed).
+        // Re-exhaust first: by 30s later the bucket has long since fully refilled (full-refill time is
+        // only 12s), so the probe call needs a fresh drain to be a genuine denial rather than a hit.
+        var withinWindow = _t0 + TimeSpan.FromSeconds(30);
+        ExhaustBurstAt(withinWindow);
+        var secondDenial = _limiter.TryAcquire(User, withinWindow);
+        Assert.IsFalse(secondDenial.Allowed);
+        Assert.AreEqual(_t0, _limiter.LastDenyLoggedAtFor(User),
+            "a denial within the log interval must not refresh the stamp — logging stays suppressed");
+
+        // A denial once the interval has fully elapsed refreshes the stamp.
+        var afterWindow = _t0 + ChatLimits.ReadRateLimiterDenyLogInterval + TimeSpan.FromSeconds(1);
+        ExhaustBurstAt(afterWindow);
+        var thirdDenial = _limiter.TryAcquire(User, afterWindow);
+        Assert.IsFalse(thirdDenial.Allowed);
+        Assert.AreEqual(afterWindow, _limiter.LastDenyLoggedAtFor(User),
+            "a denial once the log interval has elapsed must refresh the stamp — logging resumes");
+    }
+
+    [Test]
+    public void Allow_NeverStampsLastDenyLoggedAt()
+    {
+        // The stamp must only ever move on a DENIAL, never on an allowed read.
+        Assert.IsTrue(_limiter.TryAcquire(User, _t0).Allowed);
+        Assert.IsNull(_limiter.LastDenyLoggedAtFor(User), "an allowed read must never stamp LastDenyLoggedAt");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ReadRateLimiterTests.cs
+++ b/W3ChampionsChatService.Tests/ReadRateLimiterTests.cs
@@ -1,0 +1,187 @@
+using System;
+using NUnit.Framework;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="ReadRateLimiter"/> — the pure, deterministic abuse guard for read-shaped
+/// hub methods (2026-08-05 PR36 feedback, Part 3). Every decision takes an explicit <c>DateTime now</c>;
+/// refills are derived from elapsed time, so these tests never sleep and never read the wall clock.
+/// Deliberately simpler than <see cref="MessageRateLimiter"/>: ONE token bucket per battleTag, no
+/// per-channel dimension, no violation ladder — mirrors <see cref="MessageRateLimiterTests"/>'s
+/// clock-injection and prune-invariant patterns without the escalation-ladder tests that don't apply here.
+/// </summary>
+public class ReadRateLimiterTests
+{
+    private ReadRateLimiter _limiter;
+    private DateTime _t0;
+    private const string User = "peter#123";
+
+    [SetUp]
+    public void SetUp()
+    {
+        _limiter = new ReadRateLimiter();
+        _t0 = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
+    }
+
+    [Test]
+    public void Burst_AllowsReadBurstImmediateCalls_NextIsDenied_WithRetryAfter()
+    {
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            var allowed = _limiter.TryAcquire(User, _t0);
+            Assert.IsTrue(allowed.Allowed, $"burst read {i + 1} within capacity must be allowed");
+            Assert.IsNull(allowed.RetryAfterSeconds, "allowed reads carry no retry-after");
+        }
+
+        var overflow = _limiter.TryAcquire(User, _t0);
+
+        Assert.IsFalse(overflow.Allowed, $"the read past ReadBurst ({ChatLimits.ReadBurst}) must be denied");
+        Assert.IsNotNull(overflow.RetryAfterSeconds);
+        Assert.Greater(overflow.RetryAfterSeconds.Value, 0, "retry-after must be strictly positive when throttled");
+    }
+
+    [Test]
+    public void Refill_AfterEnoughElapsedTime_ReadsAreAllowedAgain()
+    {
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            _limiter.TryAcquire(User, _t0);
+        }
+        // Burst spent; an immediate retry is throttled.
+        Assert.IsFalse(_limiter.TryAcquire(User, _t0).Allowed);
+
+        // One sustained interval later (1 / ReadRefillPerSecond), exactly one token has regenerated.
+        var interval = TimeSpan.FromSeconds(1.0 / ChatLimits.ReadRefillPerSecond);
+        var afterOne = _limiter.TryAcquire(User, _t0 + interval);
+        Assert.IsTrue(afterOne.Allowed, "one token regenerates per 1/ReadRefillPerSecond interval");
+
+        // That single token is spent again — another immediate read is throttled.
+        Assert.IsFalse(_limiter.TryAcquire(User, _t0 + interval).Allowed);
+
+        // A full burst worth of elapsed time fully refills the bucket back to capacity.
+        var fullyRefilled = _t0 + TimeSpan.FromSeconds((double)ChatLimits.ReadBurst / ChatLimits.ReadRefillPerSecond) + interval;
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_limiter.TryAcquire(User, fullyRefilled).Allowed,
+                $"read {i + 1} after a full refill window must be allowed — the bucket is back at capacity");
+        }
+    }
+
+    [Test]
+    public void RetryAfter_IsPositive_AndBoundedByFullRefillWindow()
+    {
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            _limiter.TryAcquire(User, _t0);
+        }
+
+        var throttled = _limiter.TryAcquire(User, _t0);
+
+        Assert.IsFalse(throttled.Allowed);
+        Assert.IsNotNull(throttled.RetryAfterSeconds);
+        Assert.Greater(throttled.RetryAfterSeconds.Value, 0, "retry-after must be strictly positive when throttled");
+        Assert.LessOrEqual(
+            throttled.RetryAfterSeconds.Value,
+            1.0 / ChatLimits.ReadRefillPerSecond,
+            "retry-after for an empty bucket must not exceed one refill interval (a single missing token)");
+    }
+
+    [Test]
+    public void Buckets_AreIndependent_PerBattleTag()
+    {
+        // User A exhausts their own burst.
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_limiter.TryAcquire("userA#1", _t0).Allowed);
+        }
+        Assert.IsFalse(_limiter.TryAcquire("userA#1", _t0).Allowed, "userA's own burst is spent");
+
+        // User B is completely unaffected — independent per-battleTag buckets.
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(
+                _limiter.TryAcquire("userB#2", _t0).Allowed,
+                $"userB read {i + 1} must have its own independent burst");
+        }
+    }
+
+    [Test]
+    public void BattleTagKey_IsCaseInsensitive()
+    {
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_limiter.TryAcquire(User, _t0).Allowed);
+        }
+        var differentCasing = _limiter.TryAcquire("PETER#123", _t0);
+        Assert.IsFalse(differentCasing.Allowed, "casing variants of one battleTag share one bucket");
+    }
+
+    [Test]
+    public void SharedBudget_AcrossGuardedMethods_OneBattleTagBucket()
+    {
+        // Deliverable 4: "all acquisitions share one bucket per battleTag" — simulated here by simply
+        // calling TryAcquire repeatedly for the same battleTag (the hub wires the SAME limiter instance
+        // into both GetConversations and GetMessages, so from the limiter's own perspective there is no
+        // way to distinguish "method A's call" from "method B's call" — it is the same call shape either
+        // way). Spending the WHOLE burst must deny the very next call regardless of which "method" it
+        // represents.
+        for (var i = 0; i < ChatLimits.ReadBurst; i++)
+        {
+            Assert.IsTrue(_limiter.TryAcquire(User, _t0).Allowed, $"call {i + 1} within the shared budget must be allowed");
+        }
+        Assert.IsFalse(_limiter.TryAcquire(User, _t0).Allowed, "the shared per-battleTag budget is exhausted regardless of which guarded method spent it");
+    }
+
+    [Test]
+    public void QuiescentEntries_ArePruned_BoundingMemory()
+    {
+        // 200 distinct users each read once at t0 — 200 live entries.
+        for (var i = 0; i < 200; i++)
+        {
+            Assert.IsTrue(_limiter.TryAcquire($"user{i}#1", _t0).Allowed);
+        }
+
+        // One read far past the prune horizon sweeps every quiescent entry.
+        var later = _t0 + ChatLimits.ReadRateLimiterPruneHorizon + TimeSpan.FromSeconds(1);
+        Assert.IsTrue(_limiter.TryAcquire(User, later).Allowed);
+
+        // The sweep (PruneQuiescentNoLock) runs BEFORE the sweeping call's own entry is created, so all
+        // 200 prior entries — idle since _t0, past the prune horizon — are evicted and exactly ONE entry
+        // (User, just created) remains.
+        Assert.AreEqual(1, _limiter.TrackedUserCount,
+            "entries idle past ReadRateLimiterPruneHorizon must be pruned (only the sweeping caller remains)");
+    }
+
+    [Test]
+    public void QuiescentPrune_IsSelective_DoesNotEvictARecentlyTouchedEntry()
+    {
+        // Many quiescent users seeded once at t0 — idle past the prune horizon by the time of the sweep.
+        for (var i = 0; i < 50; i++)
+        {
+            Assert.IsTrue(_limiter.TryAcquire($"stale{i}#1", _t0).Allowed);
+        }
+
+        // One user keeps reading right up to (just under) the prune horizon — this entry must NOT be
+        // swept away even though the map-wide sweep timer (anchored on the very first t0 call) fires.
+        const string ActiveUser = "active#1";
+        var justUnderHorizon = _t0 + ChatLimits.ReadRateLimiterPruneHorizon - TimeSpan.FromSeconds(1);
+        Assert.IsTrue(_limiter.TryAcquire(ActiveUser, justUnderHorizon).Allowed);
+
+        // A distinct caller just past the prune horizon (relative to t0) triggers the time-gated sweep.
+        var sweepTime = _t0 + ChatLimits.ReadRateLimiterPruneHorizon + TimeSpan.FromSeconds(1);
+        Assert.IsTrue(_limiter.TryAcquire(User, sweepTime).Allowed);
+
+        // The 50 stale users (idle since t0, well past the horizon) are gone. ActiveUser (touched only 2s
+        // before the sweep) and the sweeping caller (User) survive. Unlike MessageRateLimiterTests' analog
+        // (which needs a separate TrackedChannelCount probe to rule out a "clear everyone" bug landing on
+        // the same bound), an EXACT count of 2 here already distinguishes all three failure modes given
+        // this scenario's fixed shape (52 total, 1 active, 1 sweeper): "no prune" would leave 52, a
+        // "clear-everyone" bug would leave 1 (only the sweeping caller), and correct selective pruning
+        // leaves exactly 2 — there is no per-key auxiliary state left for a 4th, more specific probe.
+        Assert.AreEqual(2, _limiter.TrackedUserCount,
+            "a recently-touched entry must survive a sweep that evicts other, genuinely-quiescent entries");
+    }
+}

--- a/W3ChampionsChatService.Tests/ReadRateLimiterTests.cs
+++ b/W3ChampionsChatService.Tests/ReadRateLimiterTests.cs
@@ -131,21 +131,13 @@ public class ReadRateLimiterTests
         Assert.IsFalse(differentCasing.Allowed, "casing variants of one battleTag share one bucket");
     }
 
-    [Test]
-    public void SharedBudget_AcrossGuardedMethods_OneBattleTagBucket()
-    {
-        // Deliverable 4: "all acquisitions share one bucket per battleTag" — simulated here by simply
-        // calling TryAcquire repeatedly for the same battleTag (the hub wires the SAME limiter instance
-        // into both GetConversations and GetMessages, so from the limiter's own perspective there is no
-        // way to distinguish "method A's call" from "method B's call" — it is the same call shape either
-        // way). Spending the WHOLE burst must deny the very next call regardless of which "method" it
-        // represents.
-        for (var i = 0; i < ChatLimits.ReadBurst; i++)
-        {
-            Assert.IsTrue(_limiter.TryAcquire(User, _t0).Allowed, $"call {i + 1} within the shared budget must be allowed");
-        }
-        Assert.IsFalse(_limiter.TryAcquire(User, _t0).Allowed, "the shared per-battleTag budget is exhausted regardless of which guarded method spent it");
-    }
+    // Fix round 1, finding F4: SharedBudget_AcrossGuardedMethods_OneBattleTagBucket was deleted from
+    // here — it only proved "spending the budget via repeated TryAcquire denies the next TryAcquire,"
+    // which is untestable-by-construction as a cross-method claim at the LIMITER level (the limiter
+    // itself has no notion of "method"; a second-instance mis-wiring in Startup.cs would still pass it).
+    // The real cross-method-sharing property — a real GetConversations call and a real GetMessages call
+    // drawing from the SAME limiter INSTANCE — is now pinned at the hub level instead:
+    // ChatHubGetConversationsTests.GetConversations_ReadLimit_SharedBudget_RealCallDrainsGetMessagesBudget.
 
     [Test]
     public void Deny_LogsAtMostOncePerDenyLogInterval_PerUser()

--- a/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
+++ b/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
@@ -13,6 +13,7 @@ using W3ChampionsChatService.Mentions;
 using W3ChampionsChatService.Messages;
 using W3ChampionsChatService.Mutes;
 using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Relationships;
 
 namespace W3ChampionsChatService.Tests;
 
@@ -680,5 +681,160 @@ public class SessionStateAssemblerTests : IntegrationTestBase
 
         Assert.AreEqual(1, dto.MentionUnreadCount,
             "CountUnread must normalize the identity's casing to match the lowercased stored key");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Follow-up spec §6 — bounded SessionState 1:1-DM snapshot. Keeps ALL non-DM channels, ALL pending
+    // 1:1 requests, ALL blocked 1:1 shells (any age), the DmSnapshotRecentConversations most-recent
+    // ACCEPTED-non-blocked 1:1 shells, and any OLDER such shell with a possible unread. The
+    // OnlineMemberRegistry seed is bounded TOGETHER with the DTO (registry == DTO invariant).
+    // ---------------------------------------------------------------------------------------------
+
+    // Inserts an ACCEPTED 1:1 shell between viewer and counterpart at the given recency, with the
+    // viewer's own membership row (LastReadSeq = lastReadSeq), returning the shell. LastSeq controls the
+    // raw-seq unread candidate test (LastSeq > LastReadSeq).
+    private async Task<ChatChannel> InsertAcceptedDmWithMembership(
+        string viewer, string counterpart, DateTime lastMessageAt, long lastSeq = 0, long lastReadSeq = 0)
+    {
+        var channel = new ChatChannel
+        {
+            Type = ChannelType.Dm,
+            PairKey = DmPairKey.For(viewer, counterpart),
+            RequestState = DmRequestState.Accepted,
+            RequestInitiatedBy = viewer,
+            LastSeq = lastSeq,
+            LastMessageAt = lastMessageAt,
+        };
+        await _channelRepository.Insert(channel);
+        await InsertMembership(channel.Id, viewer, lastReadSeq);
+        return channel;
+    }
+
+    [Test]
+    public async Task Snapshot_Keeps30MostRecentAcceptedDms_AndDropsOlderReadOnes()
+    {
+        var viewer = "peter#123";
+        var t0 = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+        var shells = new List<ChatChannel>();
+        for (var i = 0; i < 35; i++) // 35 accepted, fully-read shells, newest = i=34
+        {
+            shells.Add(await InsertAcceptedDmWithMembership(viewer, $"friend{i}#1", t0.AddMinutes(i)));
+        }
+
+        var identity = Identity(viewer);
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", t0.AddHours(1), ChatUserFor(identity));
+
+        var dmIds = dto.Channels.Where(c => c.Channel.Type == ChannelType.Dm).Select(c => c.Channel.Id).ToHashSet();
+        Assert.AreEqual(ChatLimits.DmSnapshotRecentConversations, dmIds.Count, "exactly the 30 most-recent ride");
+        for (var i = 5; i < 35; i++) Assert.IsTrue(dmIds.Contains(shells[i].Id), $"recent shell {i} must be kept");
+        for (var i = 0; i < 5; i++) Assert.IsFalse(dmIds.Contains(shells[i].Id), $"old read shell {i} must be dropped");
+
+        // The registry seed matches the DTO exactly — the excluded shells are NOT fan-out members.
+        Assert.IsTrue(_onlineMemberRegistry.IsMember("conn-1", shells[34].Id));
+        Assert.IsFalse(_onlineMemberRegistry.IsMember("conn-1", shells[0].Id),
+            "registry channel set must equal the DTO channel set (bounded together)");
+    }
+
+    [Test]
+    public async Task Snapshot_KeepsOlderDm_WhenItHasUnread()
+    {
+        var viewer = "peter#123";
+        var t0 = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+        // The unread old one, OLDEST of all — LastSeq 3 > LastReadSeq 1.
+        var unreadOld = await InsertAcceptedDmWithMembership(viewer, "olduna#1", t0.AddMinutes(-60), lastSeq: 3, lastReadSeq: 1);
+        for (var i = 0; i < ChatLimits.DmSnapshotRecentConversations; i++)
+        {
+            await InsertAcceptedDmWithMembership(viewer, $"friend{i}#1", t0.AddMinutes(i));
+        }
+
+        var identity = Identity(viewer);
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", t0.AddHours(1), ChatUserFor(identity));
+
+        Assert.IsTrue(dto.Channels.Any(c => c.Channel.Id == unreadOld.Id),
+            "an older 1:1 shell with unread > 0 must ride the snapshot (truthful Messages badge)");
+    }
+
+    [Test]
+    public async Task Snapshot_KeepsPendingAndBlockedDms_RegardlessOfRecency_AndAllGroupDms()
+    {
+        var viewer = "peter#123";
+        var t0 = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+        // Ancient pending request TO the viewer; ancient fully-read shell with a BLOCKED counterpart.
+        var pending = await InsertDmChannel("stranger#7", viewer, DmRequestState.Pending, t0.AddDays(-20));
+        await InsertMembership(pending.Id, viewer, 0);
+        var blocked = await InsertAcceptedDmWithMembership(viewer, "creep#666", t0.AddDays(-300));
+        var group = new ChatChannel { Type = ChannelType.GroupDm, Name = "the gang", LastMessageAt = t0.AddDays(-200) };
+        await _channelRepository.Insert(group);
+        await InsertMembership(group.Id, viewer, 0);
+        for (var i = 0; i < ChatLimits.DmSnapshotRecentConversations; i++)
+        {
+            await InsertAcceptedDmWithMembership(viewer, $"friend{i}#1", t0.AddMinutes(i));
+        }
+
+        var snapshot = new RelationshipSnapshot(
+            viewer,
+            friends: new HashSet<string>(),
+            blocked: new HashSet<string> { "creep#666" },
+            fetchedAt: t0.AddHours(1));
+        var identity = Identity(viewer);
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", t0.AddHours(1), ChatUserFor(identity), snapshot);
+
+        var ids = dto.Channels.Select(c => c.Channel.Id).ToHashSet();
+        Assert.IsTrue(ids.Contains(pending.Id), "every pending request rides, regardless of recency");
+        Assert.IsTrue(ids.Contains(blocked.Id), "every blocked 1:1 shell rides, regardless of recency");
+        Assert.IsTrue(ids.Contains(group.Id), "every GroupDm shell rides — bounding is 1:1-only");
+        Assert.IsTrue(dto.PendingDmRequests.Any(r => r.ChannelId == pending.Id), "the tray still sees it");
+    }
+
+    [Test]
+    public async Task Snapshot_WithoutRelationshipSnapshot_DegradesBlockedKeeps_ButBoundsStillApply()
+    {
+        var viewer = "peter#123";
+        var t0 = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+        var blockedOld = await InsertAcceptedDmWithMembership(viewer, "creep#666", t0.AddDays(-300));
+        for (var i = 0; i < ChatLimits.DmSnapshotRecentConversations; i++)
+        {
+            await InsertAcceptedDmWithMembership(viewer, $"friend{i}#1", t0.AddMinutes(i));
+        }
+
+        var identity = Identity(viewer);
+        // relationshipSnapshot omitted (null) — the wb-unavailable degradation.
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", t0.AddHours(1), ChatUserFor(identity));
+
+        Assert.IsFalse(dto.Channels.Any(c => c.Channel.Id == blockedOld.Id),
+            "no snapshot ⇒ no blocked-keeps (degradation; self-heals next connect) — the recency bound still applies");
+        Assert.AreEqual(ChatLimits.DmSnapshotRecentConversations,
+            dto.Channels.Count(c => c.Channel.Type == ChannelType.Dm));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Carried launcher-review item (2026-08-04 follow-up): MembershipRepository.LoadForUser had NO
+    // explicit sort, so SessionStateDto.Channels order was Mongo-arbitrary — the launcher relies on
+    // server order to preserve "join order" for name-joinable (SemiPublic) channels across a reconnect.
+    // Fixed at the repository (MembershipRepository.LoadForUser sorts JoinedAt ascending); pinned here
+    // end-to-end through the assembler so a regression in either layer fails this test.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Assemble_Channels_PreserveMembershipJoinedAtOrder_ForNonDmChannels_RegardlessOfInsertionOrder()
+    {
+        var identity = Identity("peter#123");
+        var chanA = await InsertChannel(ChannelType.SemiPublic, "ClanAlpha", lastSeq: 0);
+        var chanB = await InsertChannel(ChannelType.SemiPublic, "ClanBravo", lastSeq: 0);
+        var chanC = await InsertChannel(ChannelType.SemiPublic, "ClanCharlie", lastSeq: 0);
+        var t0 = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // Inserted (and JoinedAt-stamped) in SCRAMBLED order: C joined first, then A, then B — but the
+        // channel rows themselves were created A, B, C above (insertion order != join order).
+        await _membershipRepository.Insert(new ChannelMembership { ChannelId = chanC.Id, BattleTag = identity.BattleTag, JoinedAt = t0 });
+        await _membershipRepository.Insert(new ChannelMembership { ChannelId = chanA.Id, BattleTag = identity.BattleTag, JoinedAt = t0.AddMinutes(5) });
+        await _membershipRepository.Insert(new ChannelMembership { ChannelId = chanB.Id, BattleTag = identity.BattleTag, JoinedAt = t0.AddMinutes(10) });
+
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", t0.AddHours(1), ChatUserFor(identity));
+
+        CollectionAssert.AreEqual(
+            new[] { chanC.Id, chanA.Id, chanB.Id },
+            dto.Channels.Select(c => c.Channel.Id).ToList(),
+            "Channels must come back in membership JoinedAt-ascending order, not Mongo insertion/natural order");
     }
 }

--- a/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
+++ b/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
@@ -308,6 +308,45 @@ public class SessionStateAssemblerTests : IntegrationTestBase
         Assert.IsTrue(dto.PublicCatalog.Any(c => c.Id == pub.Id));
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // Follow-up spec §3 — the public catalog must come back in DefaultChatRooms seed order (deploy's
+    // hardcoded room list, "W3C Lounge" first), NOT Mongo's natural/insertion order. A legacy public
+    // channel not present in the seed list sorts after all seeded rooms, alphabetically.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task PublicCatalog_ComesBackInDefaultChatRoomsSeedOrder_RegardlessOfInsertionOrder()
+    {
+        // A subset of the hardcoded catalog, inserted in DELIBERATELY scrambled order.
+        await InsertChannel(ChannelType.Public, "FFA", 0);
+        await InsertChannel(ChannelType.Public, "1 vs 1", 0);
+        await InsertChannel(ChannelType.Public, "W3C Lounge", 0);
+        await InsertChannel(ChannelType.Public, "Legion TD", 0);
+
+        var identity = Identity("peter#123");
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", DateTime.UtcNow, ChatUserFor(identity));
+
+        CollectionAssert.AreEqual(
+            new[] { "W3C Lounge", "1 vs 1", "FFA", "Legion TD" },
+            dto.PublicCatalog.Select(c => c.Name).ToList(),
+            "catalog order must equal DefaultChatRooms seed order (W3C Lounge first), not Mongo output order");
+    }
+
+    [Test]
+    public async Task PublicCatalog_UnknownPublicChannel_SortsAfterAllSeededRooms()
+    {
+        await InsertChannel(ChannelType.Public, "Zombie Legacy Room", 0);
+        await InsertChannel(ChannelType.Public, "W3C Lounge", 0);
+
+        var identity = Identity("peter#123");
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", DateTime.UtcNow, ChatUserFor(identity));
+
+        CollectionAssert.AreEqual(
+            new[] { "W3C Lounge", "Zombie Legacy Room" },
+            dto.PublicCatalog.Select(c => c.Name).ToList(),
+            "a legacy public channel not in the seed list sorts last, alphabetically — still deterministic");
+    }
+
     [Test]
     public async Task Assemble_Stubs_PendingDmRequestsEmpty_MentionUnreadZero()
     {

--- a/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
+++ b/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
@@ -754,6 +754,84 @@ public class SessionStateAssemblerTests : IntegrationTestBase
             "an older 1:1 shell with unread > 0 must ride the snapshot (truthful Messages badge)");
     }
 
+    // 2026-08-05 PR36 feedback (Part 1) — unread hydration across the kept set now runs through ONE
+    // batched CountUserVisibleAfterMany aggregation instead of one query per shell; this pins that the
+    // per-channel $or branches never cross-contaminate each other's counts.
+    [Test]
+    public async Task Snapshot_UnreadCounts_AreCorrectPerChannel_AcrossMultipleDmShells_ViaBatchedQuery()
+    {
+        var viewer = "peter#123";
+        var t0 = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        var shellA = await InsertAcceptedDmWithMembership(viewer, "alpha#1", t0.AddMinutes(1), lastSeq: 3, lastReadSeq: 0);
+        for (var seq = 1L; seq <= 3; seq++) await InsertMessage(shellA.Id, "alpha#1", seq);
+
+        var shellB = await InsertAcceptedDmWithMembership(viewer, "bravo#1", t0.AddMinutes(2), lastSeq: 5, lastReadSeq: 2);
+        for (var seq = 1L; seq <= 5; seq++) await InsertMessage(shellB.Id, "bravo#1", seq);
+
+        // No messages at all for shellC — a genuine zero that must not pick up A's or B's $or-branch match.
+        var shellC = await InsertAcceptedDmWithMembership(viewer, "charlie#1", t0.AddMinutes(3), lastSeq: 0, lastReadSeq: 0);
+
+        var identity = Identity(viewer);
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", t0.AddHours(1), ChatUserFor(identity));
+
+        Assert.AreEqual(3L, dto.Channels.Single(c => c.Channel.Id == shellA.Id).UnreadCount, "shellA: 3 visible rows after cursor 0");
+        Assert.AreEqual(3L, dto.Channels.Single(c => c.Channel.Id == shellB.Id).UnreadCount, "shellB: rows 3,4,5 after cursor 2");
+        Assert.AreEqual(0L, dto.Channels.Single(c => c.Channel.Id == shellC.Id).UnreadCount, "shellC: no messages — must not leak another channel's count");
+    }
+
+    // 2026-08-05 PR36 feedback (Part 2) — the rule-(e) older-unread tail is capped at
+    // ChatLimits.DmSnapshotMaxOlderUnread so a pathological account can never force an unbounded scan.
+    [Test]
+    public async Task Snapshot_CapsOlderUnreadTail_AtDmSnapshotMaxOlderUnread_KeepingTheMostRecentOfTheTail()
+    {
+        var viewer = "peter#123";
+        var t0 = new DateTime(2026, 8, 1, 12, 0, 0, DateTimeKind.Utc);
+
+        // 30 recent, fully-read shells — rule (d), entirely unaffected by the rule-(e) cap below.
+        for (var i = 0; i < ChatLimits.DmSnapshotRecentConversations; i++)
+        {
+            await InsertAcceptedDmWithMembership(viewer, $"friend{i}#1", t0.AddMinutes(i));
+        }
+
+        // 101 OLDER shells, each with a possible unread (LastSeq 3 > LastReadSeq 1). older[0] is the
+        // MOST RECENT of this tail (closest to t0); older[100] is the OLDEST. Every one of them is older
+        // than every "recent" shell above (t0.AddDays(-1)-ish vs t0.AddMinutes(0..29)).
+        const int olderCount = ChatLimits.DmSnapshotMaxOlderUnread + 1;
+        var older = new List<ChatChannel>();
+        for (var k = 0; k < olderCount; k++)
+        {
+            older.Add(await InsertAcceptedDmWithMembership(
+                viewer, $"olduna{k}#1", t0.AddDays(-1).AddMinutes(-k), lastSeq: 3, lastReadSeq: 1));
+        }
+
+        // Realism extras: a pending request and a non-Dm channel — neither ever enters the ordered/capped
+        // rule-(d)/(e) scan, so both must ride the snapshot regardless of the cap above.
+        var pending = await InsertDmChannel("stranger#7", viewer, DmRequestState.Pending, t0.AddDays(-500));
+        await InsertMembership(pending.Id, viewer, 0);
+        var nonDm = await InsertChannel(ChannelType.SemiPublic, "MyClan", lastSeq: 0);
+        await InsertMembership(nonDm.Id, viewer, 0);
+
+        var identity = Identity(viewer);
+        var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", t0.AddHours(1), ChatUserFor(identity));
+
+        var keptIds = dto.Channels.Select(c => c.Channel.Id).ToHashSet();
+        var olderIdsKept = older.Select(c => c.Id).Where(keptIds.Contains).ToHashSet();
+
+        Assert.AreEqual(ChatLimits.DmSnapshotMaxOlderUnread, olderIdsKept.Count,
+            "exactly the cap's worth of older-unread shells ride the snapshot, not all 101");
+        for (var k = 0; k < ChatLimits.DmSnapshotMaxOlderUnread; k++)
+        {
+            Assert.IsTrue(olderIdsKept.Contains(older[k].Id),
+                $"older[{k}] is within the {ChatLimits.DmSnapshotMaxOlderUnread}-most-recent slice of the tail and must be kept");
+        }
+        Assert.IsFalse(olderIdsKept.Contains(older[olderCount - 1].Id),
+            "the 101st (oldest) older-unread shell must be excluded once the cap is reached");
+
+        Assert.IsTrue(keptIds.Contains(pending.Id), "pending requests are unaffected by the rule-(e) cap");
+        Assert.IsTrue(keptIds.Contains(nonDm.Id), "non-Dm channels are unaffected by the rule-(e) cap");
+    }
+
     [Test]
     public async Task Snapshot_KeepsPendingAndBlockedDms_RegardlessOfRecency_AndAllGroupDms()
     {

--- a/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
+++ b/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
@@ -771,10 +771,13 @@ public class SessionStateAssemblerTests : IntegrationTestBase
             await InsertAcceptedDmWithMembership(viewer, $"friend{i}#1", t0.AddMinutes(i));
         }
 
+        // Mixed casing vs. the lowercased pair-key half CounterpartOf returns ("creep#666") — exercises
+        // the OrdinalIgnoreCase contract RelationshipSnapshot.HasBlocked documents, instead of a
+        // same-casing comparison that would pass even with an ordinal-exact (bugged) comparer.
         var snapshot = new RelationshipSnapshot(
             viewer,
             friends: new HashSet<string>(),
-            blocked: new HashSet<string> { "creep#666" },
+            blocked: new HashSet<string> { "Creep#666" },
             fetchedAt: t0.AddHours(1));
         var identity = Identity(viewer);
         var (dto, _) = await _assembler.AssembleAndSeed(identity, "conn-1", t0.AddHours(1), ChatUserFor(identity), snapshot);

--- a/W3ChampionsChatService.Tests/StartupDependencyInjectionTests.cs
+++ b/W3ChampionsChatService.Tests/StartupDependencyInjectionTests.cs
@@ -208,6 +208,18 @@ public class StartupDependencyInjectionTests
     }
 
     [Test]
+    public void ReadRateLimiter_IsSingleton_SharedAcrossResolutions()
+    {
+        using var provider = BuildProvider();
+
+        var first = provider.GetRequiredService<ReadRateLimiter>();
+        var second = provider.GetRequiredService<ReadRateLimiter>();
+
+        Assert.AreSame(first, second,
+            "ReadRateLimiter MUST be a singleton — a transient registration would silently fragment the in-memory fan-out state each connection seeds and tears down");
+    }
+
+    [Test]
     public void ActivityCoalescer_IsSingleton_SharedAcrossResolutions()
     {
         using var provider = BuildProvider();
@@ -306,6 +318,7 @@ public class StartupDependencyInjectionTests
         Assert.IsNotNull(provider.GetRequiredService<UserDirectoryRepository>());
         Assert.IsNotNull(provider.GetRequiredService<UserSettingsRepository>());
         Assert.IsNotNull(provider.GetRequiredService<MentionInboxRepository>());
+        Assert.IsNotNull(provider.GetRequiredService<NotificationPreferenceRepository>());
         Assert.IsNotNull(provider.GetRequiredService<PublicChannelSeeder>());
         Assert.IsNotNull(provider.GetRequiredService<CleanupJobs>());
 

--- a/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
+++ b/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
@@ -245,6 +245,7 @@ public class ViewersAccumulatorTests : IntegrationTestBase
     private OnlineMemberRegistry _onlineMemberRegistry;
     private SessionRegistry _sessionRegistry;
     private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
     private ConnectionMapping _connectionMapping;
     private UserDirectoryRepository _userDirectory;
     private MuteRepository _muteRepository;
@@ -269,6 +270,7 @@ public class ViewersAccumulatorTests : IntegrationTestBase
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _sessionRegistry = new SessionRegistry();
         _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
         _connectionMapping = new ConnectionMapping();
         _userDirectory = new UserDirectoryRepository(MongoClient);
         _muteRepository = new MuteRepository(MongoClient);
@@ -305,6 +307,7 @@ public class ViewersAccumulatorTests : IntegrationTestBase
             _focusRegistry,
             _onlineMemberRegistry,
             _messageRateLimiter,
+            _readRateLimiter,
             _time,
             _channelRepository,
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
+++ b/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
@@ -319,7 +319,8 @@ public class ViewersAccumulatorTests : IntegrationTestBase
             _authService.Object,
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
-            new MentionInboxRepository(MongoClient));
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
         var context = new Mock<HubCallerContext>();

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -19,6 +19,32 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
     public Task<List<ChatChannel>> LoadByIds(IEnumerable<string> ids) =>
         Channels.Find(Builders<ChatChannel>.Filter.In(c => c.Id, ids.ToList())).ToListAsync();
 
+    /// <summary>
+    /// Server-side count of the subset of <paramref name="ids"/> that are name-joinable
+    /// (<see cref="ChannelType.Public"/> or <see cref="ChannelType.SemiPublic"/>) — 2026-08-05 PR36
+    /// feedback, Part 3: backs <see cref="Memberships.MembershipRepository.CountNameJoinableMembershipsForUser"/>'s
+    /// minimal-payload rewrite, so the join-cap gate counts via <c>CountDocumentsAsync</c> instead of
+    /// pulling every channel document behind a user's memberships just to count a type-filtered subset.
+    /// A channel id with no matching document (deleted channel behind an orphan membership) simply
+    /// doesn't count — same as <see cref="LoadByIds"/> silently omitting it.
+    /// </summary>
+    public Task<long> CountNameJoinableAmongIds(IReadOnlyCollection<string> ids)
+    {
+        if (ids.Count == 0)
+        {
+            return Task.FromResult(0L);
+        }
+
+        var filterBuilder = Builders<ChatChannel>.Filter;
+        var filter = filterBuilder.And(
+            filterBuilder.In(c => c.Id, ids),
+            filterBuilder.Or(
+                filterBuilder.Eq(c => c.Type, ChannelType.Public),
+                filterBuilder.Eq(c => c.Type, ChannelType.SemiPublic)));
+
+        return Channels.CountDocumentsAsync(filter);
+    }
+
     public Task<ChatChannel> LoadByNormalizedName(ChannelType type, string normalizedName) =>
         Channels.Find(c => c.Type == type && c.NormalizedName == normalizedName).FirstOrDefaultAsync();
 

--- a/W3ChampionsChatService/Channels/DmPairKey.cs
+++ b/W3ChampionsChatService/Channels/DmPairKey.cs
@@ -12,4 +12,17 @@ public static class DmPairKey
         var b = battleTagB.Trim().ToLowerInvariant();
         return string.CompareOrdinal(a, b) <= 0 ? $"{a}|{b}" : $"{b}|{a}";
     }
+
+    /// <summary>
+    /// The OTHER half of a pair-key (lowercased/normalized, matching how <see cref="For"/> built it) —
+    /// the counterpart of <paramref name="battleTag"/> in a 1:1 Dm. Mirrors the split logic
+    /// ChatHub.ResolveDmCounterpart has always used; hoisted here so the SessionStateAssembler's
+    /// blocked-shell keep (follow-up spec §6) and the hub share ONE implementation.
+    /// </summary>
+    public static string CounterpartOf(string pairKey, string battleTag)
+    {
+        var parts = pairKey.Split('|');
+        var normalized = battleTag.Trim().ToLowerInvariant();
+        return parts[0] == normalized ? parts[1] : parts[0];
+    }
 }

--- a/W3ChampionsChatService/Channels/DmPairKey.cs
+++ b/W3ChampionsChatService/Channels/DmPairKey.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace W3ChampionsChatService.Channels;
 
 public static class DmPairKey
@@ -17,12 +19,17 @@ public static class DmPairKey
     /// The OTHER half of a pair-key (lowercased/normalized, matching how <see cref="For"/> built it) —
     /// the counterpart of <paramref name="battleTag"/> in a 1:1 Dm. Mirrors the split logic
     /// ChatHub.ResolveDmCounterpart has always used; hoisted here so the SessionStateAssembler's
-    /// blocked-shell keep (follow-up spec §6) and the hub share ONE implementation.
+    /// blocked-shell keep (follow-up spec §6) and the hub share ONE implementation. The comparison is
+    /// <see cref="StringComparison.OrdinalIgnoreCase"/> (the pre-hoist ResolveDmCounterpart behavior) —
+    /// not a plain ordinal <c>==</c> — because <see cref="string.ToLowerInvariant"/> is not guaranteed
+    /// to fold every code point identically on both sides (e.g. locale-sensitive casing edge cases), so
+    /// an ordinal-only match could spuriously fall through to <c>parts[0]</c> and hand back the CALLER's
+    /// own tag as its "counterpart".
     /// </summary>
     public static string CounterpartOf(string pairKey, string battleTag)
     {
         var parts = pairKey.Split('|');
         var normalized = battleTag.Trim().ToLowerInvariant();
-        return parts[0] == normalized ? parts[1] : parts[0];
+        return string.Equals(parts[0], normalized, StringComparison.OrdinalIgnoreCase) ? parts[1] : parts[0];
     }
 }

--- a/W3ChampionsChatService/Chats/ChatHub.Channels.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Channels.cs
@@ -259,7 +259,10 @@ public partial class ChatHub
     /// touches the throttle.</item>
     /// <item>Create the membership with <see cref="NotificationLevel.Mentions"/> — an EXPLICIT override
     /// of <see cref="ChannelMembership.NotificationLevel"/>'s model default (<c>All</c>) — insert it,
-    /// seed <see cref="FanOut.OnlineMemberRegistry"/> for this connection, and return Ok.</item>
+    /// seed <see cref="FanOut.OnlineMemberRegistry"/> for this connection, and return Ok. PR36 follow-up
+    /// (D2): the Mentions default is used ONLY when the caller has no persisted preference for this
+    /// channel (<see cref="Memberships.NotificationPreferenceRepository.Load"/>); otherwise the (re)join
+    /// seeds from that persisted level instead — see the seeding code just above the insert.</item>
     /// </list>
     /// </summary>
     public async Task<JoinChannelResult> JoinChannel(string name)
@@ -324,18 +327,26 @@ public partial class ChatHub
             channel = await _channelRepository.FindOrCreateSemiPublic(name, now);
         }
 
+        // PR36 follow-up (D2): a (re)join seeds from the caller's own PERSISTED preference for this
+        // channel if one exists (the last level they EXPLICITLY set via SetNotificationLevel, surviving
+        // a prior leave's hard membership delete) — otherwise falls back to the fresh-join Mentions
+        // default. This is what lets "join → set None → leave → rejoin" keep the room silenced.
+        var pref = await _notificationPreferenceRepository.Load(battleTag, channel.Id);
+        var seedLevel = pref?.NotificationLevel ?? NotificationLevel.Mentions;
+
         var membership = new ChannelMembership
         {
             ChannelId = channel.Id,
             BattleTag = battleTag,
-            // Override the model default (All) — a freshly joined channel starts at Mentions.
-            NotificationLevel = NotificationLevel.Mentions,
+            // Override the model default (All) — a freshly joined channel starts at Mentions, unless a
+            // persisted preference says otherwise (see above).
+            NotificationLevel = seedLevel,
             JoinedAt = now,
         };
         await _membershipRepository.Insert(membership);
 
         _onlineMemberRegistry.Join(channel.Id, Context.ConnectionId,
-            new MemberState(battleTag, NotificationLevel.Mentions, membership.LastReadSeq, channel.Type));
+            new MemberState(battleTag, seedLevel, membership.LastReadSeq, channel.Type));
 
         return new JoinChannelResult(ChatResultCode.Ok, Channel: channel, Membership: membership);
     }
@@ -475,6 +486,15 @@ public partial class ChatHub
     /// SemiPublic (and every other type) supports all three levels. On success, persists via
     /// <see cref="Memberships.MembershipRepository.SetNotificationLevel"/> and mirrors the change into
     /// <see cref="FanOut.OnlineMemberRegistry"/> so the hot fan-out path sees it immediately.
+    /// <para>
+    /// PR36 follow-up (D2): AFTER that membership update succeeds, ALSO upserts a
+    /// <see cref="Memberships.NotificationPreference"/> row for (battleTag, channelId) — but ONLY when
+    /// the channel is name-joinable (<see cref="ChannelType.Public"/>/<see cref="ChannelType.SemiPublic"/>).
+    /// Dm/GroupDm/System memberships are ACL-governed, not user-leavable in the room-catalog sense, so the
+    /// pref collection stays bounded to the room catalog — this write is what lets the level SURVIVE a
+    /// later hard-delete leave (<see cref="LeaveChannel"/>) and get re-seeded on rejoin (<see cref="JoinChannel"/>)
+    /// or consulted for a non-member Public mention (<see cref="Mentions.MentionFanOut"/>).
+    /// </para>
     /// </summary>
     public async Task<ChannelOperationResult> SetNotificationLevel(string channelId, NotificationLevel level)
     {
@@ -491,17 +511,27 @@ public partial class ChatHub
             return new ChannelOperationResult(ChatResultCode.NotMember);
         }
 
-        if (level == NotificationLevel.All)
+        // PR36 follow-up (D2): the channel is now loaded UNCONDITIONALLY (previously only for the All-
+        // on-Public rejection check below) — the pref write further down needs its Type regardless of
+        // which level was requested.
+        var channel = await _channelRepository.Load(channelId);
+
+        if (level == NotificationLevel.All && channel != null && channel.Type == ChannelType.Public)
         {
-            var channel = await _channelRepository.Load(channelId);
-            if (channel != null && channel.Type == ChannelType.Public)
-            {
-                return new ChannelOperationResult(ChatResultCode.PermissionDenied);
-            }
+            return new ChannelOperationResult(ChatResultCode.PermissionDenied);
         }
 
         await _membershipRepository.SetNotificationLevel(channelId, battleTag, level);
         _onlineMemberRegistry.SetNotificationLevel(channelId, Context.ConnectionId, level);
+
+        // PR36 follow-up (D2): persist the just-applied level for name-joinable rooms only, so it
+        // survives a later leave/rejoin cycle. A vanished channel (null) is treated as non-name-joinable
+        // — no pref write, nothing to seed back into on a rejoin that can never happen.
+        if (channel != null && (channel.Type == ChannelType.Public || channel.Type == ChannelType.SemiPublic))
+        {
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
+            await _notificationPreferenceRepository.Upsert(battleTag, channelId, level, now);
+        }
 
         return new ChannelOperationResult(ChatResultCode.Ok);
     }

--- a/W3ChampionsChatService/Chats/ChatHub.Channels.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Channels.cs
@@ -495,6 +495,14 @@ public partial class ChatHub
     /// later hard-delete leave (<see cref="LeaveChannel"/>) and get re-seeded on rejoin (<see cref="JoinChannel"/>)
     /// or consulted for a non-member Public mention (<see cref="Mentions.MentionFanOut"/>).
     /// </para>
+    /// <para>
+    /// Fix round 1 (F5): the pref upsert is a SECONDARY, best-effort write — by the time it runs, the
+    /// primary membership update has already succeeded and the caller's request is already satisfied. A
+    /// failure there (e.g. a Mongo hiccup) must NEVER surface as an error for an already-applied level
+    /// change — this matches the "secondary write never breaks the primary ack" posture elsewhere in the
+    /// codebase (<see cref="Mentions.MentionFanOut"/>'s per-target fault isolation, <see cref="FanOut.FanOutEngine"/>'s
+    /// per-recipient fault isolation). Failures are caught and logged; the method still returns Ok.
+    /// </para>
     /// </summary>
     public async Task<ChannelOperationResult> SetNotificationLevel(string channelId, NotificationLevel level)
     {
@@ -527,10 +535,24 @@ public partial class ChatHub
         // PR36 follow-up (D2): persist the just-applied level for name-joinable rooms only, so it
         // survives a later leave/rejoin cycle. A vanished channel (null) is treated as non-name-joinable
         // — no pref write, nothing to seed back into on a rejoin that can never happen.
+        // Fix round 1 (F5): best-effort — the membership update above already succeeded and the caller's
+        // request is already satisfied, so a failure persisting this SECONDARY carrier must not turn an
+        // already-applied level change into an error response.
         if (channel != null && (channel.Type == ChannelType.Public || channel.Type == ChannelType.SemiPublic))
         {
             var now = _timeProvider.GetUtcNow().UtcDateTime;
-            await _notificationPreferenceRepository.Upsert(battleTag, channelId, level, now);
+            try
+            {
+                await _notificationPreferenceRepository.Upsert(battleTag, channelId, level, now);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(
+                    ex,
+                    "NotificationPreference upsert failed for {BattleTag} on channel {ChannelId} — the membership level was already applied; the persisted preference may lag until the next successful set",
+                    battleTag,
+                    channelId);
+            }
         }
 
         return new ChannelOperationResult(ChatResultCode.Ok);

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -373,12 +373,8 @@ public partial class ChatHub
     /// snapshot/registry lookups; the materialized membership + settings reads). Never called for GroupDm
     /// (no pair-key).
     /// </summary>
-    private static string ResolveDmCounterpart(ChatChannel channel, string senderBattleTag)
-    {
-        var parts = channel.PairKey.Split('|');
-        var senderNormalized = senderBattleTag.Trim().ToLowerInvariant();
-        return string.Equals(parts[0], senderNormalized, StringComparison.OrdinalIgnoreCase) ? parts[1] : parts[0];
-    }
+    private static string ResolveDmCounterpart(ChatChannel channel, string senderBattleTag) =>
+        DmPairKey.CounterpartOf(channel.PairKey, senderBattleTag);
 
     /// <summary>
     /// The shared consent-accept transition used by BOTH reply-accept (a recipient's first reply) and

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -540,7 +540,20 @@ public partial class ChatHub
         var recipientMembership = await _membershipRepository.InsertIfAbsent(candidate);
         var newlyMaterialized = recipientMembership.Id == candidate.Id;
 
-        if (newlyMaterialized)
+        // Follow-up spec §6 (bounded-snapshot repair): the recipient's connect snapshot may have
+        // EXCLUDED this older 1:1 shell — and with it their OnlineMemberRegistry seed (registry set ==
+        // DTO set). If they are online but this connection's registry lacks the channel, RE-ANNOUNCE
+        // exactly like a first materialization: PushChannelAdded(focus:false) re-seeds the registry AND
+        // hands the client the shell — and because this hook runs BEFORE the step-8 fan-out, the
+        // activity for THIS very message reaches them. An already-seeded recipient is untouched (no
+        // ChannelAdded on ordinary messages); ChannelAdded is an upsert client-side, so a client that
+        // somehow still knows the shell just refreshes it.
+        var recipientSession = _sessionRegistry.GetByBattleTag(counterpart);
+        var needsReAnnounce = !newlyMaterialized
+            && recipientSession != null
+            && !_onlineMemberRegistry.IsMember(recipientSession.ConnectionId, channel.Id);
+
+        if (newlyMaterialized || needsReAnnounce)
         {
             // Seeds the recipient's OnlineMemberRegistry + pushes ChannelAdded(focus:false) if they are
             // online; a no-op for an offline recipient (their SessionState picks the channel up on connect).
@@ -568,7 +581,6 @@ public partial class ChatHub
             await _membershipRepository.ClearDeclinedUntil(channel.Id, counterpart);
         }
 
-        var recipientSession = _sessionRegistry.GetByBattleTag(counterpart);
         if (recipientSession != null)
         {
             var dto = new PendingDmRequestDto(channel.Id, channel.RequestInitiatedBy, channel.LastMessageAt ?? now);

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -753,7 +753,7 @@ public partial class ChatHub
                 item.Channel, MembershipDto.From(item.Membership), unreadCount, unreadCount > 0));
 
             // JoinPreservingReadCursor (not the plain Join): membership.LastReadSeq was captured back at
-            // step 5 (LoadForUser), and this method awaits the channel LoadByIds AND the batched
+            // step 6 (LoadForUser), and this method awaits the channel LoadByIds AND the batched
             // unread-count aggregation before reaching this seed loop — a concurrent MarkRead landing on an
             // already-seeded (channel, connection) entry during that window must never be regressed back
             // down by the DB-loaded LastReadSeq captured earlier.

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -9,6 +9,7 @@ using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Memberships;
+using W3ChampionsChatService.Messages;
 using W3ChampionsChatService.Protocol;
 using W3ChampionsChatService.Relationships;
 using W3ChampionsChatService.Users;
@@ -630,17 +631,22 @@ public partial class ChatHub
     /// non-null <see cref="ChatChannel.LastMessageAt"/> (a null-stamped doc is data-impossible in
     /// production but would otherwise dead-end the client's wire cursor); order, cursor-filter, take the
     /// page.</item>
-    /// <item>Per shell: D7 unread count → <see cref="ChannelDto"/>; seed the registry via
-    /// <see cref="OnlineMemberRegistry.JoinPreservingReadCursor"/> (never regresses a newer in-flight
-    /// <c>MarkRead</c>); return Ok.</item>
+    /// <item>ONE batched <see cref="Messages.MessageRepository.CountUserVisibleAfterMany"/> aggregation
+    /// covers D7 unread for the WHOLE page (2026-08-05 PR36 feedback, Part 1 — previously one
+    /// <c>CountUserVisibleAfter</c> round-trip PER shell, up to <see cref="ChatLimits.ConversationsPageSize"/>
+    /// round-trips per call); per shell: build the <see cref="ChannelDto"/> from the batched result, seed
+    /// the registry via <see cref="OnlineMemberRegistry.JoinPreservingReadCursor"/> (never regresses a
+    /// newer in-flight <c>MarkRead</c>); return Ok.</item>
     /// </list>
     /// Per-page cost scales with the caller's TOTAL membership count (one <c>LoadForUser</c> + one
     /// <c>LoadByIds</c> per call, independent of the requested page size) — an explicit brief decision,
-    /// acceptable because a client is expected to need only 1-3 pages before reaching the end. Paging
-    /// deliberately relaxes Task 6's "registry set == connect-snapshot DTO set" invariant: the registry
-    /// can now hold MORE than what any single SessionState carried. The broader property still holds —
-    /// registry membership implies the client actually knows about the channel — because every shell
-    /// seeded here is returned in this SAME response.
+    /// acceptable because a client is expected to need only 1-3 pages before reaching the end. The unread
+    /// hydration step above, by contrast, is now O(1) round-trips regardless of page size (was O(page
+    /// size) before the 2026-08-05 batching fix). Paging deliberately relaxes Task 6's "registry set ==
+    /// connect-snapshot DTO set" invariant: the registry can now hold MORE than what any single
+    /// SessionState carried. The broader property still holds — registry membership implies the client
+    /// actually knows about the channel — because every shell seeded here is returned in this SAME
+    /// response.
     /// </summary>
     public async Task<GetConversationsResult> GetConversations(DateTime? cursorLastMessageAt, string cursorChannelId, int limit)
     {
@@ -679,8 +685,9 @@ public partial class ChatHub
         }
 
         // 5. Membership-first (user→channels — the only supported direction), then the channel docs in
-        // ONE LoadByIds. In-memory ordering over the caller's own bounded conversation count mirrors
-        // the CountNameJoinableMembershipsForUser precedent — no new aggregation pipeline.
+        // ONE LoadByIds. In-memory ordering over the caller's own bounded conversation count — no new
+        // aggregation pipeline needed here (unlike the batched unread counts in step 6 below, this step
+        // needs the full membership/channel docs, not just a count).
         var memberships = await _membershipRepository.LoadForUser(battleTag);
         var channelsById = (await _channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
             .ToDictionary(c => c.Id);
@@ -713,18 +720,26 @@ public partial class ChatHub
             .Take(effectiveLimit)
             .ToList();
 
-        // 6. Project (same D7 unread as the connect snapshot) + seed the registry per returned shell.
+        // 6. Project (same D7 unread as the connect snapshot) — ONE batched CountUserVisibleAfterMany
+        // aggregation for the whole page (2026-08-05 PR36 feedback, Part 1: this used to be one
+        // CountUserVisibleAfter round-trip PER shell, up to ConversationsPageSize == 50 round-trips per
+        // call) — then seed the registry per returned shell.
+        var unreadCounts = await _messageRepository.CountUserVisibleAfterMany(
+            page.Select(item => new ChannelUnreadCursor(item.Channel.Id, item.Membership.LastReadSeq)).ToList(),
+            battleTag);
+
         var conversations = new List<ChannelDto>(page.Count);
         foreach (var item in page)
         {
-            var unreadCount = await _messageRepository.CountUserVisibleAfter(
-                item.Channel.Id, battleTag, item.Membership.LastReadSeq);
+            var unreadCount = unreadCounts.GetValueOrDefault(item.Channel.Id, 0L);
             conversations.Add(new ChannelDto(
                 item.Channel, MembershipDto.From(item.Membership), unreadCount, unreadCount > 0));
 
-            // JoinPreservingReadCursor (not the plain Join): this loop awaits Mongo per shell, so a
-            // concurrent MarkRead landing on an already-seeded (channel, connection) entry during that
-            // window must never be regressed back down by the DB-loaded LastReadSeq captured before it.
+            // JoinPreservingReadCursor (not the plain Join): membership.LastReadSeq was captured back at
+            // step 5 (LoadForUser), and this method awaits the relationship snapshot fetch AND the batched
+            // unread-count aggregation before reaching this seed loop — a concurrent MarkRead landing on an
+            // already-seeded (channel, connection) entry during that window must never be regressed back
+            // down by the DB-loaded LastReadSeq captured earlier.
             _onlineMemberRegistry.JoinPreservingReadCursor(
                 item.Channel.Id,
                 Context.ConnectionId,

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -736,7 +736,7 @@ public partial class ChatHub
                 item.Channel, MembershipDto.From(item.Membership), unreadCount, unreadCount > 0));
 
             // JoinPreservingReadCursor (not the plain Join): membership.LastReadSeq was captured back at
-            // step 5 (LoadForUser), and this method awaits the relationship snapshot fetch AND the batched
+            // step 5 (LoadForUser), and this method awaits the channel LoadByIds AND the batched
             // unread-count aggregation before reaching this seed loop — a concurrent MarkRead landing on an
             // already-seeded (channel, connection) entry during that window must never be regressed back
             // down by the DB-loaded LastReadSeq captured earlier.

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using MongoDB.Bson;
@@ -598,5 +600,89 @@ public partial class ChatHub
                 Log.Warning(ex, "RequestReceived push failed for {ConnectionId} on channel {ChannelId} — best-effort, tray resurfaces it via SessionState", recipientSession.ConnectionId, channel.Id);
             }
         }
+    }
+
+    /// <summary>
+    /// 2026-08-04 follow-up spec §6: pages the caller's OLDER 1:1 Dm shells (the ones the bounded
+    /// connect snapshot excluded), newest-first by (LastMessageAt, ChannelId), cursor =
+    /// (cursorLastMessageAt, cursorChannelId) — both null for the first page; strictly-older-than
+    /// filtering keyed on the PAIR makes the pagination stable under concurrent recency changes (a
+    /// conversation that moves forward jumps to the FRONT and can never be double-served in a later
+    /// page). Reuses ChannelDto (the SessionState.Channels shape) and computes the SAME D7
+    /// user-visible unread per returned shell. Every returned shell is ALSO seeded into the caller's
+    /// OnlineMemberRegistry — the follow-up §6 companion rule to the bounded connect seed — so a paged
+    /// conversation is immediately usable (SendMessage/FocusChannel/GetMessages/MarkRead) without an
+    /// extra OpenDm round-trip. Resolution order:
+    /// <list type="number">
+    /// <item>Fail-closed identity → <see cref="ChatResultCode.PermissionDenied"/>.</item>
+    /// <item>Malformed cursor (exactly one half supplied) → <see cref="HubException"/> (the
+    /// <c>GetMessages</c> client-bug mapping).</item>
+    /// <item>Clamp <paramref name="limit"/> to [1, <see cref="ChatLimits.ConversationsPageSize"/>].</item>
+    /// <item>Load ALL memberships + their channels (the same two indexed queries the connect snapshot
+    /// runs), keep <see cref="ChannelType.Dm"/> only, order, cursor-filter, take the page.</item>
+    /// <item>Per shell: D7 unread count → <see cref="ChannelDto"/>; seed the registry; return Ok.</item>
+    /// </list>
+    /// </summary>
+    public async Task<GetConversationsResult> GetConversations(DateTime? cursorLastMessageAt, string cursorChannelId, int limit)
+    {
+        // 1. Fail-closed identity.
+        if (!_sessionRegistry.TryGetByConnectionId(Context.ConnectionId, out var session))
+        {
+            return new GetConversationsResult(ChatResultCode.PermissionDenied);
+        }
+
+        // 2. The cursor is a PAIR — both halves or neither (first page).
+        var hasCursorTime = cursorLastMessageAt.HasValue;
+        var hasCursorId = !string.IsNullOrEmpty(cursorChannelId);
+        if (hasCursorTime != hasCursorId)
+        {
+            throw new HubException("GetConversations: cursorLastMessageAt and cursorChannelId form one cursor — supply both or neither.");
+        }
+
+        // 3. Clamp — never Limit(0)/unbounded, never rejected.
+        var effectiveLimit = Math.Clamp(limit, 1, ChatLimits.ConversationsPageSize);
+
+        var battleTag = session.Identity.BattleTag;
+
+        // 4. Membership-first (user→channels — the only supported direction), then the channel docs in
+        // ONE LoadByIds. In-memory ordering over the caller's own bounded conversation count mirrors
+        // the CountNameJoinableMembershipsForUser precedent — no new aggregation pipeline.
+        var memberships = await _membershipRepository.LoadForUser(battleTag);
+        var channelsById = (await _channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
+            .ToDictionary(c => c.Id);
+
+        var ordered = memberships
+            .Where(m => channelsById.TryGetValue(m.ChannelId, out var c) && c.Type == ChannelType.Dm)
+            .Select(m =>
+            {
+                var channel = channelsById[m.ChannelId];
+                return (Membership: m, Channel: channel, SortTime: channel.LastMessageAt ?? m.JoinedAt);
+            })
+            .OrderByDescending(x => x.SortTime)
+            .ThenByDescending(x => x.Channel.Id, StringComparer.Ordinal);
+
+        var page = (hasCursorTime
+                ? ordered.Where(x => x.SortTime < cursorLastMessageAt.Value
+                    || (x.SortTime == cursorLastMessageAt.Value && string.CompareOrdinal(x.Channel.Id, cursorChannelId) < 0))
+                : ordered)
+            .Take(effectiveLimit)
+            .ToList();
+
+        // 5. Project (same D7 unread as the connect snapshot) + seed the registry per returned shell.
+        var conversations = new List<ChannelDto>(page.Count);
+        foreach (var item in page)
+        {
+            var unreadCount = await _messageRepository.CountUserVisibleAfter(
+                item.Channel.Id, battleTag, item.Membership.LastReadSeq);
+            conversations.Add(new ChannelDto(
+                item.Channel, MembershipDto.From(item.Membership), unreadCount, unreadCount > 0));
+
+            _onlineMemberRegistry.Join(
+                item.Channel.Id,
+                Context.ConnectionId,
+                new MemberState(battleTag, item.Membership.NotificationLevel, item.Membership.LastReadSeq, ChannelType.Dm));
+        }
+
+        return new GetConversationsResult(ChatResultCode.Ok, conversations);
     }
 }

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -618,10 +618,29 @@ public partial class ChatHub
     /// <item>Malformed cursor (exactly one half supplied) → <see cref="HubException"/> (the
     /// <c>GetMessages</c> client-bug mapping).</item>
     /// <item>Clamp <paramref name="limit"/> to [1, <see cref="ChatLimits.ConversationsPageSize"/>].</item>
+    /// <item>Resolve the CALLER's <see cref="RelationshipSnapshot"/> ONCE (mirrors <see cref="OpenDm"/>
+    /// step 3): no usable snapshot at all (<see cref="RelationshipUnavailableException"/>) fails closed to
+    /// <see cref="ChatResultCode.Throttled"/> rather than risk serving an unfiltered page — a blocked
+    /// counterpart's shell must NEVER page in here as an ordinary conversation (it stays in the connect
+    /// snapshot unconditionally, Task 6, for the client's Blocked section ONLY).</item>
     /// <item>Load ALL memberships + their channels (the same two indexed queries the connect snapshot
-    /// runs), keep <see cref="ChannelType.Dm"/> only, order, cursor-filter, take the page.</item>
-    /// <item>Per shell: D7 unread count → <see cref="ChannelDto"/>; seed the registry; return Ok.</item>
+    /// runs), keep <see cref="ChannelType.Dm"/> shells that are NOT <see cref="DmRequestState.Pending"/>
+    /// (pending requests ride the connect snapshot + request tray ONLY — see
+    /// <see cref="Protocol.SessionStateAssembler.SelectSnapshotMemberships"/>), NOT blocked, and carry a
+    /// non-null <see cref="ChatChannel.LastMessageAt"/> (a null-stamped doc is data-impossible in
+    /// production but would otherwise dead-end the client's wire cursor); order, cursor-filter, take the
+    /// page.</item>
+    /// <item>Per shell: D7 unread count → <see cref="ChannelDto"/>; seed the registry via
+    /// <see cref="OnlineMemberRegistry.JoinPreservingReadCursor"/> (never regresses a newer in-flight
+    /// <c>MarkRead</c>); return Ok.</item>
     /// </list>
+    /// Per-page cost scales with the caller's TOTAL membership count (one <c>LoadForUser</c> + one
+    /// <c>LoadByIds</c> per call, independent of the requested page size) — an explicit brief decision,
+    /// acceptable because a client is expected to need only 1-3 pages before reaching the end. Paging
+    /// deliberately relaxes Task 6's "registry set == connect-snapshot DTO set" invariant: the registry
+    /// can now hold MORE than what any single SessionState carried. The broader property still holds —
+    /// registry membership implies the client actually knows about the channel — because every shell
+    /// seeded here is returned in this SAME response.
     /// </summary>
     public async Task<GetConversationsResult> GetConversations(DateTime? cursorLastMessageAt, string cursorChannelId, int limit)
     {
@@ -644,7 +663,22 @@ public partial class ChatHub
 
         var battleTag = session.Identity.BattleTag;
 
-        // 4. Membership-first (user→channels — the only supported direction), then the channel docs in
+        // 4. Resolve the CALLER's relationship snapshot ONCE (mirrors OpenDm step 3): blocked shells stay
+        // in the connect snapshot unconditionally (Task 6's Blocked tray) but must NEVER page in here as
+        // an ordinary, live conversation — e.g. a 2-year-old blocked shell must not re-surface and get
+        // registry-Joined as a live fan-out target. No usable snapshot at all is an outage: fail closed
+        // retriable rather than risk serving an unfiltered page.
+        RelationshipSnapshot snapshot;
+        try
+        {
+            snapshot = await _relationshipProvider.GetSnapshotAsync(battleTag);
+        }
+        catch (RelationshipUnavailableException)
+        {
+            return new GetConversationsResult(ChatResultCode.Throttled, ChatLimits.RelationshipRetryAfterSeconds);
+        }
+
+        // 5. Membership-first (user→channels — the only supported direction), then the channel docs in
         // ONE LoadByIds. In-memory ordering over the caller's own bounded conversation count mirrors
         // the CountNameJoinableMembershipsForUser precedent — no new aggregation pipeline.
         var memberships = await _membershipRepository.LoadForUser(battleTag);
@@ -652,7 +686,18 @@ public partial class ChatHub
             .ToDictionary(c => c.Id);
 
         var ordered = memberships
-            .Where(m => channelsById.TryGetValue(m.ChannelId, out var c) && c.Type == ChannelType.Dm)
+            .Where(m => channelsById.TryGetValue(m.ChannelId, out var c)
+                && c.Type == ChannelType.Dm
+                // Pending requests ride the connect snapshot + request tray ONLY — never a paged
+                // "conversation", from either direction (incoming or caller-initiated outgoing).
+                && c.RequestState != DmRequestState.Pending
+                // A null-stamped LastMessageAt is data-impossible in production (FindOrCreateDm always
+                // stamps it at insert) but would otherwise produce an inexpressible client cursor for
+                // that shell — exclude it from the page rather than dead-end pagination. The `?? JoinedAt`
+                // SortTime fallback below is retained regardless, for ordering determinism.
+                && c.LastMessageAt != null
+                // Blocked-counterpart shells stay Blocked-tray-only (Task 6) — never page in here.
+                && !(c.PairKey != null && snapshot.HasBlocked(DmPairKey.CounterpartOf(c.PairKey, battleTag))))
             .Select(m =>
             {
                 var channel = channelsById[m.ChannelId];
@@ -668,7 +713,7 @@ public partial class ChatHub
             .Take(effectiveLimit)
             .ToList();
 
-        // 5. Project (same D7 unread as the connect snapshot) + seed the registry per returned shell.
+        // 6. Project (same D7 unread as the connect snapshot) + seed the registry per returned shell.
         var conversations = new List<ChannelDto>(page.Count);
         foreach (var item in page)
         {
@@ -677,12 +722,15 @@ public partial class ChatHub
             conversations.Add(new ChannelDto(
                 item.Channel, MembershipDto.From(item.Membership), unreadCount, unreadCount > 0));
 
-            _onlineMemberRegistry.Join(
+            // JoinPreservingReadCursor (not the plain Join): this loop awaits Mongo per shell, so a
+            // concurrent MarkRead landing on an already-seeded (channel, connection) entry during that
+            // window must never be regressed back down by the DB-loaded LastReadSeq captured before it.
+            _onlineMemberRegistry.JoinPreservingReadCursor(
                 item.Channel.Id,
                 Context.ConnectionId,
                 new MemberState(battleTag, item.Membership.NotificationLevel, item.Membership.LastReadSeq, ChannelType.Dm));
         }
 
-        return new GetConversationsResult(ChatResultCode.Ok, conversations);
+        return new GetConversationsResult(ChatResultCode.Ok, Conversations: conversations);
     }
 }

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -622,7 +622,8 @@ public partial class ChatHub
     /// (<see cref="FanOut.ReadRateLimiter"/>) shared with <see cref="GetMessages"/> (per the task
     /// report's scope determination). Not allowed → <see cref="ChatResultCode.Throttled"/> with the
     /// retry-after — the SAME reject shape the relationship-outage path below already uses. Limits are
-    /// generous (burst 30, sustained 5/s) — server protection only, not UX pacing (Marco) — so no
+    /// generous (burst 60, sustained 5/s — sized for connect fan-out, see
+    /// <see cref="ChatLimits.ReadBurst"/>'s doc) — server protection only, not UX pacing (Marco) — so no
     /// legitimate client should ever observe this in normal operation.</item>
     /// <item>Malformed cursor (exactly one half supplied) → <see cref="HubException"/> (the
     /// <c>GetMessages</c> client-bug mapping).</item>

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -616,6 +616,14 @@ public partial class ChatHub
     /// extra OpenDm round-trip. Resolution order:
     /// <list type="number">
     /// <item>Fail-closed identity → <see cref="ChatResultCode.PermissionDenied"/>.</item>
+    /// <item>Read-abuse rate limit (2026-08-05 PR36 feedback, Part 3): invoked FIRST THING after identity
+    /// resolution — before the cursor validation, the clamp, and the relationship-snapshot fetch below —
+    /// so a denied caller never reaches ANY further work. ONE per-battleTag token bucket
+    /// (<see cref="FanOut.ReadRateLimiter"/>) shared with <see cref="GetMessages"/> (per the task
+    /// report's scope determination). Not allowed → <see cref="ChatResultCode.Throttled"/> with the
+    /// retry-after — the SAME reject shape the relationship-outage path below already uses. Limits are
+    /// generous (burst 30, sustained 5/s) — server protection only, not UX pacing (Marco) — so no
+    /// legitimate client should ever observe this in normal operation.</item>
     /// <item>Malformed cursor (exactly one half supplied) → <see cref="HubException"/> (the
     /// <c>GetMessages</c> client-bug mapping).</item>
     /// <item>Clamp <paramref name="limit"/> to [1, <see cref="ChatLimits.ConversationsPageSize"/>].</item>
@@ -655,8 +663,18 @@ public partial class ChatHub
         {
             return new GetConversationsResult(ChatResultCode.PermissionDenied);
         }
+        var battleTag = session.Identity.BattleTag;
 
-        // 2. The cursor is a PAIR — both halves or neither (first page).
+        // 2. Read-abuse rate limit (2026-08-05 PR36 feedback, Part 3) — FIRST THING, before any further
+        // work (cursor validation, clamp, relationship-snapshot fetch, Mongo). Shares ONE per-battleTag
+        // bucket with GetMessages — see FanOut/ReadRateLimiter.cs and the task report's scope determination.
+        var readDecision = _readRateLimiter.TryAcquire(battleTag, _timeProvider.GetUtcNow().UtcDateTime);
+        if (!readDecision.Allowed)
+        {
+            return new GetConversationsResult(ChatResultCode.Throttled, readDecision.RetryAfterSeconds);
+        }
+
+        // 3. The cursor is a PAIR — both halves or neither (first page).
         var hasCursorTime = cursorLastMessageAt.HasValue;
         var hasCursorId = !string.IsNullOrEmpty(cursorChannelId);
         if (hasCursorTime != hasCursorId)
@@ -664,12 +682,10 @@ public partial class ChatHub
             throw new HubException("GetConversations: cursorLastMessageAt and cursorChannelId form one cursor — supply both or neither.");
         }
 
-        // 3. Clamp — never Limit(0)/unbounded, never rejected.
+        // 4. Clamp — never Limit(0)/unbounded, never rejected.
         var effectiveLimit = Math.Clamp(limit, 1, ChatLimits.ConversationsPageSize);
 
-        var battleTag = session.Identity.BattleTag;
-
-        // 4. Resolve the CALLER's relationship snapshot ONCE (mirrors OpenDm step 3): blocked shells stay
+        // 5. Resolve the CALLER's relationship snapshot ONCE (mirrors OpenDm step 3): blocked shells stay
         // in the connect snapshot unconditionally (Task 6's Blocked tray) but must NEVER page in here as
         // an ordinary, live conversation — e.g. a 2-year-old blocked shell must not re-surface and get
         // registry-Joined as a live fan-out target. No usable snapshot at all is an outage: fail closed
@@ -684,9 +700,9 @@ public partial class ChatHub
             return new GetConversationsResult(ChatResultCode.Throttled, ChatLimits.RelationshipRetryAfterSeconds);
         }
 
-        // 5. Membership-first (user→channels — the only supported direction), then the channel docs in
+        // 6. Membership-first (user→channels — the only supported direction), then the channel docs in
         // ONE LoadByIds. In-memory ordering over the caller's own bounded conversation count — no new
-        // aggregation pipeline needed here (unlike the batched unread counts in step 6 below, this step
+        // aggregation pipeline needed here (unlike the batched unread counts in step 7 below, this step
         // needs the full membership/channel docs, not just a count).
         var memberships = await _membershipRepository.LoadForUser(battleTag);
         var channelsById = (await _channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
@@ -720,7 +736,7 @@ public partial class ChatHub
             .Take(effectiveLimit)
             .ToList();
 
-        // 6. Project (same D7 unread as the connect snapshot) — ONE batched CountUserVisibleAfterMany
+        // 7. Project (same D7 unread as the connect snapshot) — ONE batched CountUserVisibleAfterMany
         // aggregation for the whole page (2026-08-05 PR36 feedback, Part 1: this used to be one
         // CountUserVisibleAfter round-trip PER shell, up to ConversationsPageSize == 50 round-trips per
         // call) — then seed the registry per returned shell.

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -270,8 +270,12 @@ public partial class ChatHub
         // routes a shadow message to its author only) — or when there are no mention tags (the common case:
         // `mentionTags` came from the step-5.25 gate, empty for a message with no `<@…>` markup, so the hot
         // path pays nothing). MentionFanOut is the SOLE authority on who gets an inbox entry + notification:
-        // for each ELIGIBLE target (D3: not the sender; an actual member of THIS channel — the uniform
-        // membership wall, a.k.a. the Dm/GroupDm excerpt PRIVACY WALL; NotificationLevel != None)
+        // for each ELIGIBLE target (D3: not the sender). Dm/GroupDm/SemiPublic/System keep the membership
+        // PRIVACY WALL — a real channel_memberships row is required (a.k.a. the Dm/GroupDm excerpt wall).
+        // Public rooms are the one exception (2026-08-04 follow-up §4): a target with no membership row is
+        // still eligible there provided the tag resolves to a UserDirectoryRepository row, since a public
+        // room's excerpt is public content and the membership wall protects nothing there. For a JOINED
+        // target of any channel type, NotificationLevel != None remains the opt-out.
         // NotifyAsync writes a mention-inbox entry (expiry via ExpiryCalculator.ForMentionInboxEntry — the
         // C1-amendment-1 wiring, 30d and always <= the message TTL) and pushes a targeted MentionNotified.
         // Per-target fault isolation lives inside NotifyAsync (mirrors FanOutEngine's idiom), so a dead

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -60,7 +60,7 @@ public partial class ChatHub
     /// <c>&lt;@…&gt;</c> as plain text) and simply produces no mention-inbox entry and no notification. So
     /// there is NO directory read and NO membership check here — resolvability ≠ selectability (that is
     /// <c>SearchMentionCandidates</c>' job), and who is actually notified is decided SOLELY by the uniform
-    /// membership wall in <see cref="Mentions.MentionFanOut"/> (step 7.75 below). The count cap is
+    /// membership wall in <see cref="Mentions.MentionFanOut"/> (step 8 below). The count cap is
     /// content-intrinsic and deterministic, so it runs BEFORE the private-lane gates and the mute gate
     /// below BY DESIGN: a blocked sender and an unblocked sender must see an IDENTICAL outcome for the same
     /// over-cap content (running it after the private-lane gate's silent short-circuit would let a fake-Ok
@@ -171,10 +171,12 @@ public partial class ChatHub
         // invalid `<@…>` as plain text) and that target simply gets no inbox entry and no notification. So
         // the send path performs NO directory read and NO membership check: resolvability ≠ selectability
         // (that's SearchMentionCandidates' job), and who is actually notified is decided SOLELY by the
-        // uniform membership wall in MentionFanOut (step 7.75). The cap reject maps to TooLong (the pinned
+        // uniform membership wall in MentionFanOut (step 8). The cap reject maps to TooLong (the pinned
         // 7-member enum has no InvalidContent — same C3 precedent as empty-after-trim).
         // mentionTags (all extracted, deduped, post-cap) threads forward to the (Task 5) mention fan-out
-        // call site that lands after DM materialization (7.5) and before FanOutEngine.OnMessagePersisted (8).
+        // call site that lands after DM materialization (7.5) and AFTER FanOutEngine.OnMessagePersisted
+        // (7.75, fix round 1 F2b — moved earlier so channel delivery never waits on the mention fan-out's
+        // relationship reads).
         var mentionTags = MentionMarkup.ExtractTags(content);
         if (mentionTags.Count > ChatLimits.MaxMentionsPerMessage)
         {
@@ -263,19 +265,34 @@ public partial class ChatHub
             await MaterializeDmRecipientAndNotify(channel, session.Identity.BattleTag, now);
         }
 
-        // 7.75 Mention fan-out (C6 Task 5, D3/D4). Runs AFTER the Dm recipient is materialized (7.5) — so
-        // a first-message Dm mention of the counterpart finds their just-created membership row — and
-        // BEFORE the C3 fan-out seam (8). SKIPPED ENTIRELY (zero cost) when the message is shadow — a
-        // shadow sender's mentions must notify NOBODY, the shadow illusion (the C3 fan-out below already
-        // routes a shadow message to its author only) — or when there are no mention tags (the common case:
-        // `mentionTags` came from the step-5.25 gate, empty for a message with no `<@…>` markup, so the hot
-        // path pays nothing). MentionFanOut is the SOLE authority on who gets an inbox entry + notification:
-        // for each ELIGIBLE target (D3: not the sender). Dm/GroupDm/SemiPublic/System keep the membership
-        // PRIVACY WALL — a real channel_memberships row is required (a.k.a. the Dm/GroupDm excerpt wall).
-        // Public rooms are the one exception (2026-08-04 follow-up §4): a target with no membership row is
-        // still eligible there provided the tag resolves to a UserDirectoryRepository row, since a public
-        // room's excerpt is public content and the membership wall protects nothing there. For a JOINED
-        // target of any channel type, NotificationLevel != None remains the opt-out.
+        // 7.75 Fan-out seam (Task 12 focused delivery + Task 13 activity routing): focused MessageReceived
+        // delivery + shadow-author-only routing, then unfocused level-All members are routed to the
+        // ActivityCoalescer. `now` is threaded in (not re-read) so the whole send — rate limit, persist,
+        // expiry, and fan-out coalescing — decides against the SAME server instant. Per-recipient sends
+        // are fault-isolated inside FanOutEngine, so a fan-out hiccup never turns this already-persisted
+        // message's ack into an error below.
+        // Fix round 1 (F2b): this now runs BEFORE the mention fan-out (step 8, below) — previously it ran
+        // after, so a degraded relationship service (mention fan-out's D1 block check, up to
+        // MaxMentionsPerMessage wb round-trips) could delay MessageReceived for every OTHER viewer of the
+        // channel. OnMessagePersisted consumes nothing the mention fan-out produces (no shared write, no
+        // read-after-write dependency), so swapping the order is behavior-preserving for channel delivery;
+        // it only changes which of the two a mention target's client observes first.
+        await _fanOutEngine.OnMessagePersisted(channel, message, senderConnectionId: connectionId, isShadow, now);
+
+        // 8. Mention fan-out (C6 Task 5, D3/D4). Runs AFTER the Dm recipient is materialized (7.5) — so a
+        // first-message Dm mention of the counterpart finds their just-created membership row — and AFTER
+        // the C3 fan-out seam (7.75, fix round 1 F2b — see that step's comment for why). SKIPPED ENTIRELY
+        // (zero cost) when the message is shadow — a shadow sender's mentions must notify NOBODY, the
+        // shadow illusion (the C3 fan-out above already routes a shadow message to its author only) — or
+        // when there are no mention tags (the common case: `mentionTags` came from the step-5.25 gate,
+        // empty for a message with no `<@…>` markup, so the hot path pays nothing). MentionFanOut is the
+        // SOLE authority on who gets an inbox entry + notification: for each ELIGIBLE target (D3: not the
+        // sender). Dm/GroupDm/SemiPublic/System keep the membership PRIVACY WALL — a real
+        // channel_memberships row is required (a.k.a. the Dm/GroupDm excerpt wall). Public rooms are the
+        // one exception (2026-08-04 follow-up §4): a target with no membership row is still eligible there
+        // provided the tag resolves to a UserDirectoryRepository row, since a public room's excerpt is
+        // public content and the membership wall protects nothing there. For a JOINED target of any
+        // channel type, NotificationLevel != None remains the opt-out.
         // NotifyAsync writes a mention-inbox entry (expiry via ExpiryCalculator.ForMentionInboxEntry — the
         // C1-amendment-1 wiring, 30d and always <= the message TTL) and pushes a targeted MentionNotified.
         // Per-target fault isolation lives inside NotifyAsync (mirrors FanOutEngine's idiom), so a dead
@@ -285,14 +302,6 @@ public partial class ChatHub
         {
             await _mentionFanOut.NotifyAsync(channel, message, mentionTags, now);
         }
-
-        // 8. Fan-out seam (Task 12 focused delivery + Task 13 activity routing): focused MessageReceived
-        // delivery + shadow-author-only routing, then unfocused level-All members are routed to the
-        // ActivityCoalescer. `now` is threaded in (not re-read) so the whole send — rate limit, persist,
-        // expiry, and fan-out coalescing — decides against the SAME server instant. Per-recipient sends
-        // are fault-isolated inside FanOutEngine, so a fan-out hiccup never turns this already-persisted
-        // message's ack into an error below.
-        await _fanOutEngine.OnMessagePersisted(channel, message, senderConnectionId: connectionId, isShadow, now);
 
         // 9. Typed ack.
         return new SendMessageResult(ChatResultCode.Ok, MessageId: message.Id, Seq: seq);

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -317,14 +317,11 @@ public partial class ChatHub
     /// <item>Fail-closed identity: an unregistered connection (never authenticated, or its session was
     /// displaced/torn down) → <see cref="ChatResultCode.PermissionDenied"/> — there is no identity to
     /// page history under.</item>
-    /// <item>Malformed-arg guard, BEFORE any DB work: <paramref name="beforeSeq"/> and
-    /// <paramref name="aroundSeq"/> are mutually exclusive paging modes. A caller supplying BOTH is a
-    /// client programming error, not a user-facing rejection, so it throws <see cref="HubException"/>
-    /// (decision 5's client-error mapping — the same graceful-throw style as
-    /// <see cref="Authentication.ChatHubPermissionFilter"/>) rather than a typed result code.</item>
-    /// <item>Read-abuse rate limit (2026-08-05 PR36 feedback, Part 3), BEFORE any DB work — mirrors
-    /// <see cref="SendMessage(string, string)"/>'s "rate limit before the first DB read" ordering. ONE
-    /// per-battleTag token bucket (<see cref="FanOut.ReadRateLimiter"/>) shared with
+    /// <item>Read-abuse rate limit (2026-08-05 PR36 feedback, Part 3) — FIRST THING after identity
+    /// resolution, strictly before the malformed-arg guard below AND any DB work (fix round 1, finding
+    /// F5: this now structurally mirrors <see cref="GetConversations"/>'s "limiter absolutely first"
+    /// ordering exactly, rather than the narrower "before the first DB read" ordering this method used
+    /// before). ONE per-battleTag token bucket (<see cref="FanOut.ReadRateLimiter"/>) shared with
     /// <see cref="GetConversations"/> — the task report records the launcher-e investigation establishing
     /// that a <see cref="ChatResultCode.Throttled"/> GetMessages reject already degrades gracefully on
     /// both old and current shipped clients (silent no-op, no retry storm, no error modal), which is why
@@ -332,6 +329,11 @@ public partial class ChatHub
     /// retry-after. Limits are generous (burst 60, sustained 5/s — sized for connect fan-out, see
     /// <see cref="ChatLimits.ReadBurst"/>'s doc) — server protection only, not UX pacing (Marco) — so no
     /// legitimate client should ever observe this in normal operation.</item>
+    /// <item>Malformed-arg guard, BEFORE any DB work: <paramref name="beforeSeq"/> and
+    /// <paramref name="aroundSeq"/> are mutually exclusive paging modes. A caller supplying BOTH is a
+    /// client programming error, not a user-facing rejection, so it throws <see cref="HubException"/>
+    /// (decision 5's client-error mapping — the same graceful-throw style as
+    /// <see cref="Authentication.ChatHubPermissionFilter"/>) rather than a typed result code.</item>
     /// <item>Membership: the hot path reads <see cref="FanOut.OnlineMemberRegistry.IsMember"/> (zero
     /// DB) and, if the caller is a member, pages directly — no channel load. A non-member falls to the
     /// cold path: a single <see cref="Channels.ChannelRepository.Load"/> distinguishes "no such
@@ -363,8 +365,21 @@ public partial class ChatHub
         {
             return new GetMessagesResult(ChatResultCode.PermissionDenied);
         }
+        var battleTag = session.Identity.BattleTag;
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
 
-        // 2. Malformed-arg guard, before any DB work: beforeSeq/aroundSeq are mutually exclusive
+        // 2. Read-abuse rate limit (2026-08-05 PR36 feedback, Part 3) — FIRST THING, before the
+        // malformed-arg guard below and before any DB work (fix round 1, finding F5: structurally
+        // mirrors GetConversations' "limiter absolutely first" ordering exactly). Shares ONE
+        // per-battleTag bucket with GetConversations — see FanOut/ReadRateLimiter.cs and the task
+        // report's scope determination.
+        var readDecision = _readRateLimiter.TryAcquire(battleTag, now);
+        if (!readDecision.Allowed)
+        {
+            return new GetMessagesResult(ChatResultCode.Throttled, readDecision.RetryAfterSeconds);
+        }
+
+        // 3. Malformed-arg guard, before any DB work: beforeSeq/aroundSeq are mutually exclusive
         // paging modes. Supplying both is a client bug — a graceful HubException, not a typed result.
         if (beforeSeq.HasValue && aroundSeq.HasValue)
         {
@@ -372,17 +387,6 @@ public partial class ChatHub
         }
 
         var connectionId = Context.ConnectionId;
-        var battleTag = session.Identity.BattleTag;
-        var now = _timeProvider.GetUtcNow().UtcDateTime;
-
-        // 3. Read-abuse rate limit (2026-08-05 PR36 feedback, Part 3), BEFORE any DB work — mirrors
-        // SendMessage's "rate limit before the first DB read" ordering. Shares ONE per-battleTag bucket
-        // with GetConversations — see FanOut/ReadRateLimiter.cs and the task report's scope determination.
-        var readDecision = _readRateLimiter.TryAcquire(battleTag, now);
-        if (!readDecision.Allowed)
-        {
-            return new GetMessagesResult(ChatResultCode.Throttled, readDecision.RetryAfterSeconds);
-        }
 
         // 4. Membership (hot path, zero DB). A non-member falls to the cold path: a single Load
         // distinguishes NotFound from NotMember — EXCEPT for PUBLIC channels (follow-up spec §4's

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -212,10 +212,10 @@ public partial class ChatHub
 
         // 7. Persist (C1 amendment): allocate the per-channel seq (atomic $inc LastSeq + $set
         // LastMessageAt on the channel doc), then insert the durable message.
-        // TOCTOU guard: the channel existed at step 4, but a TTL-backed shell (System/Dm/GroupDm) could
+        // TOCTOU guard: the channel existed at step 5, but a TTL-backed shell (System/Dm/GroupDm) could
         // be reaped in the gap before AllocateSeq. AllocateSeq then throws (its $inc matched no doc, so
         // NO seq/LastMessageAt was burned) — map that vanished-channel race to the SAME typed NotFound
-        // as step 4 rather than letting an untyped exception escape as a generic SignalR error (the
+        // as step 5 rather than letting an untyped exception escape as a generic SignalR error (the
         // pipeline's "every rejection is a typed result" guardrail). A genuine Insert failure below is a
         // real infrastructure error and is deliberately left to propagate.
         // C5 D10 (shell-expiry maintenance, the C1-amendment gap): for Dm/GroupDm the SAME atomic

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -319,7 +319,11 @@ public partial class ChatHub
     /// channel" (<see cref="ChatResultCode.NotFound"/>) from "channel exists, caller just isn't in it"
     /// (<see cref="ChatResultCode.NotMember"/>) — EXCEPT for a <see cref="ChannelType.Public"/> channel
     /// (follow-up spec §4, the mention-inbox jump into an unjoined public room), where a non-member falls
-    /// through to the same paging step 4 uses for a member instead of being rejected.</item>
+    /// through to the same paging step 4 uses for a member instead of being rejected. That exception
+    /// itself excludes a full-banned non-member (<see cref="ConnectionMapping.GetEffectiveMuteStatus"/>
+    /// == <see cref="MuteStatus.Full"/>, mirroring <see cref="JoinChannel"/>'s gate), which still gets
+    /// <see cref="ChatResultCode.NotMember"/> — the same result a non-member got before this fallthrough
+    /// existed, so the ban is not disclosed.</item>
     /// <item>Page: <paramref name="aroundSeq"/> set → <see cref="Messages.MessageRepository.LoadPageAround"/>;
     /// otherwise → <see cref="Messages.MessageRepository.LoadPageBefore"/> (a null
     /// <paramref name="beforeSeq"/> means the latest page). Both repo methods already apply
@@ -357,6 +361,16 @@ public partial class ChatHub
         // privileged and a non-member may READ it. Pull-only and UserVisible-filtered exactly like a
         // member's read; joining stays explicit, and FocusChannel/MarkRead keep their membership
         // gates — this is a read-only context allowance, never implicit membership.
+        // A full-banned caller is excluded from that allowance: the codebase's full-ban room-scope rule
+        // already blocks a full-banned user from JOINING a Public room (ChatHub.Channels.cs's JoinChannel
+        // full-ban gate) and hides the catalog entirely (SessionStateAssembler's full-ban catalog-hiding
+        // rule) — letting the SAME user read Public history for free via this fallthrough would bypass
+        // that rule. Mirrors JoinChannel's gate style exactly (GetEffectiveMuteStatus == Full), but
+        // returns the SAME NotMember a non-member got before this task's fallthrough existed, so the ban
+        // is indistinguishable from ordinary non-membership — no new information disclosure. Shadow does
+        // NOT block reads (only Full does) — a shadow-muted caller keeps the illusion. This check is
+        // scoped strictly to the non-member Public fallthrough: a MEMBER's read (including a full-banned
+        // member's) is completely unaffected — this is a read-only gate, not a general mute check.
         if (!_onlineMemberRegistry.IsMember(connectionId, channelId))
         {
             var channel = await _channelRepository.Load(channelId);
@@ -368,15 +382,22 @@ public partial class ChatHub
             {
                 return new GetMessagesResult(ChatResultCode.NotMember);
             }
-            // Public: fall through to step 4's normal paging below.
+            var now = _timeProvider.GetUtcNow().UtcDateTime;
+            if (_connections.GetEffectiveMuteStatus(connectionId, now) == MuteStatus.Full)
+            {
+                return new GetMessagesResult(ChatResultCode.NotMember);
+            }
+            // Public, not full-banned: fall through to step 4's normal paging below.
         }
 
         // 4. Page + project. A MODERATOR (C4 D9) reads through the moderator repo variants — no
         // UserVisible filter, so deleted rows and EVERY author's shadow rows come back — and projects
         // with the REAL flags (ForModerator). This is the moderator's own in-channel focused view, so
         // their OWN shadow/deleted rows are flagged too, not illusion-forced (they are a moderator). The
-        // membership gate above is UNCHANGED — a non-member is already rejected regardless of permission;
-        // the privileged any-channel read is the REST endpoint (Task 7), not this focused-view read.
+        // membership gate above is UNCHANGED for non-Public channels — a non-member is still rejected
+        // regardless of permission there. On a Public channel a non-member instead passes step 3's
+        // fallthrough (full-ban excluded) and reaches this branch same as a member would — the privileged
+        // any-channel read is still the REST endpoint (Task 7), not this focused-view read.
         //
         // This branch does NOT re-apply the {Public, SemiPublic, System+Match} scope wall that
         // single-delete/purge/the REST endpoint enforce — it is safe only emergently, by construction

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -395,9 +395,14 @@ public partial class ChatHub
         // with the REAL flags (ForModerator). This is the moderator's own in-channel focused view, so
         // their OWN shadow/deleted rows are flagged too, not illusion-forced (they are a moderator). The
         // membership gate above is UNCHANGED for non-Public channels — a non-member is still rejected
-        // regardless of permission there. On a Public channel a non-member instead passes step 3's
-        // fallthrough (full-ban excluded) and reaches this branch same as a member would — the privileged
-        // any-channel read is still the REST endpoint (Task 7), not this focused-view read.
+        // regardless of permission there. On a Public channel, though, a NON-MEMBER moderator DOES reach
+        // this branch (step 3's fallthrough, full-ban excluded) and gets the SAME privileged ForModerator
+        // projection a member-moderator would — a deliberate, narrow consequence of §4's non-member read
+        // allowance for Public channels, chosen rather than accidental (pinned by
+        // GetMessages_NonMemberModerator_PublicChannel_ReturnsForModeratorProjection). It stays bounded to
+        // ONE Public channel per call, keyed by the caller-supplied channelId; the privileged read across
+        // EVERY channel regardless of type/membership is still the REST endpoint (Task 7) — this method
+        // does not replace or widen that.
         //
         // This branch does NOT re-apply the {Public, SemiPublic, System+Match} scope wall that
         // single-delete/purge/the REST endpoint enforce — it is safe only emergently, by construction

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -329,8 +329,9 @@ public partial class ChatHub
     /// that a <see cref="ChatResultCode.Throttled"/> GetMessages reject already degrades gracefully on
     /// both old and current shipped clients (silent no-op, no retry storm, no error modal), which is why
     /// this method is guarded at all. Not allowed → <see cref="ChatResultCode.Throttled"/> with the
-    /// retry-after. Limits are generous (burst 30, sustained 5/s) — server protection only, not UX pacing
-    /// (Marco) — so no legitimate client should ever observe this in normal operation.</item>
+    /// retry-after. Limits are generous (burst 60, sustained 5/s — sized for connect fan-out, see
+    /// <see cref="ChatLimits.ReadBurst"/>'s doc) — server protection only, not UX pacing (Marco) — so no
+    /// legitimate client should ever observe this in normal operation.</item>
     /// <item>Membership: the hot path reads <see cref="FanOut.OnlineMemberRegistry.IsMember"/> (zero
     /// DB) and, if the caller is a member, pages directly — no channel load. A non-member falls to the
     /// cold path: a single <see cref="Channels.ChannelRepository.Load"/> distinguishes "no such

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -322,6 +322,15 @@ public partial class ChatHub
     /// client programming error, not a user-facing rejection, so it throws <see cref="HubException"/>
     /// (decision 5's client-error mapping — the same graceful-throw style as
     /// <see cref="Authentication.ChatHubPermissionFilter"/>) rather than a typed result code.</item>
+    /// <item>Read-abuse rate limit (2026-08-05 PR36 feedback, Part 3), BEFORE any DB work — mirrors
+    /// <see cref="SendMessage(string, string)"/>'s "rate limit before the first DB read" ordering. ONE
+    /// per-battleTag token bucket (<see cref="FanOut.ReadRateLimiter"/>) shared with
+    /// <see cref="GetConversations"/> — the task report records the launcher-e investigation establishing
+    /// that a <see cref="ChatResultCode.Throttled"/> GetMessages reject already degrades gracefully on
+    /// both old and current shipped clients (silent no-op, no retry storm, no error modal), which is why
+    /// this method is guarded at all. Not allowed → <see cref="ChatResultCode.Throttled"/> with the
+    /// retry-after. Limits are generous (burst 30, sustained 5/s) — server protection only, not UX pacing
+    /// (Marco) — so no legitimate client should ever observe this in normal operation.</item>
     /// <item>Membership: the hot path reads <see cref="FanOut.OnlineMemberRegistry.IsMember"/> (zero
     /// DB) and, if the caller is a member, pages directly — no channel load. A non-member falls to the
     /// cold path: a single <see cref="Channels.ChannelRepository.Load"/> distinguishes "no such
@@ -363,8 +372,18 @@ public partial class ChatHub
 
         var connectionId = Context.ConnectionId;
         var battleTag = session.Identity.BattleTag;
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
 
-        // 3. Membership (hot path, zero DB). A non-member falls to the cold path: a single Load
+        // 3. Read-abuse rate limit (2026-08-05 PR36 feedback, Part 3), BEFORE any DB work — mirrors
+        // SendMessage's "rate limit before the first DB read" ordering. Shares ONE per-battleTag bucket
+        // with GetConversations — see FanOut/ReadRateLimiter.cs and the task report's scope determination.
+        var readDecision = _readRateLimiter.TryAcquire(battleTag, now);
+        if (!readDecision.Allowed)
+        {
+            return new GetMessagesResult(ChatResultCode.Throttled, readDecision.RetryAfterSeconds);
+        }
+
+        // 4. Membership (hot path, zero DB). A non-member falls to the cold path: a single Load
         // distinguishes NotFound from NotMember — EXCEPT for PUBLIC channels (follow-up spec §4's
         // mention-inbox jump): a public room is name-joinable by anyone, so its history is not
         // privileged and a non-member may READ it. Pull-only and UserVisible-filtered exactly like a
@@ -391,21 +410,20 @@ public partial class ChatHub
             {
                 return new GetMessagesResult(ChatResultCode.NotMember);
             }
-            var now = _timeProvider.GetUtcNow().UtcDateTime;
             if (_connections.GetEffectiveMuteStatus(connectionId, now) == MuteStatus.Full)
             {
                 return new GetMessagesResult(ChatResultCode.NotMember);
             }
-            // Public, not full-banned: fall through to step 4's normal paging below.
+            // Public, not full-banned: fall through to step 5's normal paging below.
         }
 
-        // 4. Page + project. A MODERATOR (C4 D9) reads through the moderator repo variants — no
+        // 5. Page + project. A MODERATOR (C4 D9) reads through the moderator repo variants — no
         // UserVisible filter, so deleted rows and EVERY author's shadow rows come back — and projects
         // with the REAL flags (ForModerator). This is the moderator's own in-channel focused view, so
         // their OWN shadow/deleted rows are flagged too, not illusion-forced (they are a moderator). The
         // membership gate above is UNCHANGED for non-Public channels — a non-member is still rejected
         // regardless of permission there. On a Public channel, though, a NON-MEMBER moderator DOES reach
-        // this branch (step 3's fallthrough, full-ban excluded) and gets the SAME privileged ForModerator
+        // this branch (step 4's fallthrough, full-ban excluded) and gets the SAME privileged ForModerator
         // projection a member-moderator would — a deliberate, narrow consequence of §4's non-member read
         // allowance for Public channels, chosen rather than accidental (pinned by
         // GetMessages_NonMemberModerator_PublicChannel_ReturnsForModeratorProjection). It stays bounded to
@@ -427,7 +445,7 @@ public partial class ChatHub
                 ? await _messageRepository.LoadPageAroundForModerator(channelId, aroundSeq.Value, limit)
                 : await _messageRepository.LoadPageBeforeForModerator(channelId, beforeSeq, limit);
             var moderatorMessages = moderatorPage.Select(m => MessageDto.ForModerator(channelId, m)).ToList();
-            return new GetMessagesResult(ChatResultCode.Ok, moderatorMessages);
+            return new GetMessagesResult(ChatResultCode.Ok, Messages: moderatorMessages);
         }
 
         // Non-moderator: the repo applies UserVisible filtering and clamps the limit — passed straight
@@ -437,7 +455,7 @@ public partial class ChatHub
             ? await _messageRepository.LoadPageAround(channelId, battleTag, aroundSeq.Value, limit)
             : await _messageRepository.LoadPageBefore(channelId, battleTag, beforeSeq, limit);
         var messages = page.Select(m => MessageDto.ForUserDelivery(channelId, m)).ToList();
-        return new GetMessagesResult(ChatResultCode.Ok, messages);
+        return new GetMessagesResult(ChatResultCode.Ok, Messages: messages);
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -122,19 +122,21 @@ public partial class ChatHub
         var now = _timeProvider.GetUtcNow().UtcDateTime;
 
         // 4. Rate limit BEFORE the channel load (security-review fix): reject a throttled member before
-        // paying for a DB read. JustAutoThrottled (only ever true on a denial) → push exactly one
-        // ThrottleNotice. TryAcquire only needs connectionId + channelId, both already in hand.
-        var decision = _messageRateLimiter.TryAcquire(connectionId, channelId, now);
+        // paying for a DB read. JustAutoThrottled fires once per escalation episode (the single decision
+        // that transitions the user into hard auto-throttle) → push exactly one ThrottleNotice.
+        // TryAcquire is keyed by battleTag (follow-up spec §1: violations/tier/hard-throttle survive
+        // reconnect), so it needs the durable identity, not the ephemeral connectionId.
+        var decision = _messageRateLimiter.TryAcquire(session.Identity.BattleTag, channelId, now);
         if (decision.JustAutoThrottled)
         {
-            // Moderation-attribution log: MessageRateLimiter only has the ephemeral connectionId in
-            // scope, so a reconnect-flapping spammer can't be correlated across auto-throttle episodes
-            // from its line alone. The hub has the durable battleTag (session.Identity.BattleTag) right
-            // here, so it logs its own attributed line — mirrors the battleTag-attribution style of
-            // ChatHubPermissionFilter/BanUser's moderation logs. The limiter's own connectionId-only
-            // line (MessageRateLimiter.TryAcquire) stays as-is (MessageRateLimiterTests asserts on it),
-            // so this auto-throttle episode is intentionally logged twice — once per durable identity
-            // (this line) and once from the pure limiter (connectionId only).
+            // Moderation-attribution log: the limiter's own line (MessageRateLimiter.TryAcquire) already
+            // identifies the battleTag key now that state is re-keyed by it — but it has no visibility
+            // into WHICH connection triggered this particular episode. The hub adds that connectionId
+            // here so a moderator can correlate the episode to a specific live socket — mirrors the
+            // battleTag-attribution style of ChatHubPermissionFilter/BanUser's moderation logs. The
+            // limiter's own line stays as-is (MessageRateLimiterTests asserts on it), so this auto-throttle
+            // episode is intentionally logged twice — once from the pure limiter (battleTag only) and once
+            // from the hub (battleTag + the triggering connectionId).
             Log.Warning(
                 "Auto-throttled chat connection {ConnectionId} (battleTag {BattleTag}) after repeated rate-limit violations",
                 connectionId,

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -317,7 +317,9 @@ public partial class ChatHub
     /// DB) and, if the caller is a member, pages directly — no channel load. A non-member falls to the
     /// cold path: a single <see cref="Channels.ChannelRepository.Load"/> distinguishes "no such
     /// channel" (<see cref="ChatResultCode.NotFound"/>) from "channel exists, caller just isn't in it"
-    /// (<see cref="ChatResultCode.NotMember"/>).</item>
+    /// (<see cref="ChatResultCode.NotMember"/>) — EXCEPT for a <see cref="ChannelType.Public"/> channel
+    /// (follow-up spec §4, the mention-inbox jump into an unjoined public room), where a non-member falls
+    /// through to the same paging step 4 uses for a member instead of being rejected.</item>
     /// <item>Page: <paramref name="aroundSeq"/> set → <see cref="Messages.MessageRepository.LoadPageAround"/>;
     /// otherwise → <see cref="Messages.MessageRepository.LoadPageBefore"/> (a null
     /// <paramref name="beforeSeq"/> means the latest page). Both repo methods already apply
@@ -350,13 +352,23 @@ public partial class ChatHub
         var battleTag = session.Identity.BattleTag;
 
         // 3. Membership (hot path, zero DB). A non-member falls to the cold path: a single Load
-        // distinguishes NotFound from NotMember — mirrors FocusChannel's cold path exactly.
+        // distinguishes NotFound from NotMember — EXCEPT for PUBLIC channels (follow-up spec §4's
+        // mention-inbox jump): a public room is name-joinable by anyone, so its history is not
+        // privileged and a non-member may READ it. Pull-only and UserVisible-filtered exactly like a
+        // member's read; joining stays explicit, and FocusChannel/MarkRead keep their membership
+        // gates — this is a read-only context allowance, never implicit membership.
         if (!_onlineMemberRegistry.IsMember(connectionId, channelId))
         {
             var channel = await _channelRepository.Load(channelId);
-            return channel == null
-                ? new GetMessagesResult(ChatResultCode.NotFound)
-                : new GetMessagesResult(ChatResultCode.NotMember);
+            if (channel == null)
+            {
+                return new GetMessagesResult(ChatResultCode.NotFound);
+            }
+            if (channel.Type != ChannelType.Public)
+            {
+                return new GetMessagesResult(ChatResultCode.NotMember);
+            }
+            // Public: fall through to step 4's normal paging below.
         }
 
         // 4. Page + project. A MODERATOR (C4 D9) reads through the moderator repo variants — no

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -277,6 +277,13 @@ public partial class ChatHub
         // channel. OnMessagePersisted consumes nothing the mention fan-out produces (no shared write, no
         // read-after-write dependency), so swapping the order is behavior-preserving for channel delivery;
         // it only changes which of the two a mention target's client observes first.
+        // ACCEPTED CEILING (Marco round 2026-08-05, decision I2): the reordering above fixes OTHER
+        // viewers only. The SENDER's own ack still awaits step 8's mention fan-out below, whose stage 2
+        // resolves every otherwise-eligible target's D1 block snapshot CONCURRENTLY — so a mention-bearing
+        // send pays AT MOST ONE wb HTTP timeout (~2s, WebsiteBackendRelationshipSource's client timeout)
+        // when wb is degraded, never one per mention. This is a chosen trade, not an unaddressed artifact
+        // of the reordering — consistent with the DM-send path's existing wb coupling in
+        // ApplyPrivateLaneGates.
         await _fanOutEngine.OnMessagePersisted(channel, message, senderConnectionId: connectionId, isShadow, now);
 
         // 8. Mention fan-out (C6 Task 5, D3/D4). Runs AFTER the Dm recipient is materialized (7.5) — so a
@@ -297,7 +304,11 @@ public partial class ChatHub
         // C1-amendment-1 wiring, 30d and always <= the message TTL) and pushes a targeted MentionNotified.
         // Per-target fault isolation lives inside NotifyAsync (mirrors FanOutEngine's idiom), so a dead
         // target socket or a single failed insert never turns this already-persisted send's Ok ack into an
-        // error, nor blocks the other targets.
+        // error, nor blocks the other targets. It does NOT shield the SENDER's own ack from latency,
+        // though: this call is awaited before step 9 returns, so the ack pays NotifyAsync's stage 2 wb
+        // round-trip (block-check snapshots resolved CONCURRENTLY, so at most ONE ~2s wb HTTP timeout when
+        // wb is degraded — see the F2b comment above). That is an accepted trade (Marco round 2026-08-05),
+        // not an artifact; other viewers' delivery is unaffected because the fan-out engine above already ran.
         if (!isShadow && mentionTags.Count > 0)
         {
             await _mentionFanOut.NotifyAsync(channel, message, mentionTags, now);
@@ -340,7 +351,7 @@ public partial class ChatHub
     /// channel" (<see cref="ChatResultCode.NotFound"/>) from "channel exists, caller just isn't in it"
     /// (<see cref="ChatResultCode.NotMember"/>) — EXCEPT for a <see cref="ChannelType.Public"/> channel
     /// (follow-up spec §4, the mention-inbox jump into an unjoined public room), where a non-member falls
-    /// through to the same paging step 4 uses for a member instead of being rejected. That exception
+    /// through to the same paging step 5 uses for a member instead of being rejected. That exception
     /// itself excludes a full-banned non-member (<see cref="ConnectionMapping.GetEffectiveMuteStatus"/>
     /// == <see cref="MuteStatus.Full"/>, mirroring <see cref="JoinChannel"/>'s gate), which still gets
     /// <see cref="ChatResultCode.NotMember"/> — the same result a non-member got before this fallthrough

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -363,7 +363,12 @@ public partial class ChatHub(
 
             _focusRegistry.RemoveConnection(Context.ConnectionId);
             _onlineMemberRegistry.RemoveConnection(Context.ConnectionId);
-            _messageRateLimiter.RemoveConnection(Context.ConnectionId);
+            // MessageRateLimiter is deliberately NOT torn down here (2026-08-04 follow-up spec §1): its
+            // state is battleTag-keyed and must SURVIVE disconnect/reconnect (violations, the tier
+            // ladder, and an active hard throttle all persist across a relaunch) — the limiter prunes
+            // its own quiescent entries opportunistically instead. See
+            // MessageRateLimiterTests.HardThrottle_SurvivesReconnect_BecauseStateIsKeyedByBattleTag and
+            // ChatHubSendMessageTests.Send_AutoThrottle_SurvivesReconnect_SameBattleTag.
             // Task 13: also drop the connection's ChannelActivity coalescing state (routed through the
             // fan-out engine, which owns the coalescer) so the singleton can't leak past the socket.
             _fanOutEngine.OnConnectionClosed(Context.ConnectionId);

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -192,7 +192,7 @@ public partial class ChatHub(
         // snapshot — blocked shells outside the recency window may be omitted from THIS SessionState
         // only (self-heals on the next connect); a wb outage must never fail the connect. Catches
         // Exception (not just RelationshipUnavailableException), matching every sibling wb call on this
-        // hub's connect/disconnect paths (UpsertDirectory, PrefetchRelationshipSnapshot,
+        // hub's connect/disconnect paths (UpsertDirectory, PushFriendPresenceFromSnapshot,
         // PushFriendPresenceOnDisconnect) — no provider exception type can ever hard-fail connect.
         RelationshipSnapshot relationshipSnapshot = null;
         try
@@ -207,7 +207,7 @@ public partial class ChatHub(
         // C5 (Task 1) / C6 (Task 11, D13): unchanged role (friend-presence push), now dispatched AFTER
         // the awaited fetch above and handed that ALREADY-RESOLVED snapshot directly — a wb outage means
         // one round-trip per connect, not two. Still fire-and-forget and non-fatal.
-        _ = PrefetchRelationshipSnapshot(identity.BattleTag, wentOnline, Context.ConnectionId, relationshipSnapshot);
+        _ = PushFriendPresenceFromSnapshot(identity.BattleTag, wentOnline, Context.ConnectionId, relationshipSnapshot);
 
         // C3 (Task 8): assemble the SessionState snapshot and seed this connection's fan-out state (the
         // OnlineMemberRegistry + the legacy mute cache, both done inside AssembleAndSeed), then push the
@@ -271,7 +271,7 @@ public partial class ChatHub(
         }
     }
 
-    // C5 (Task 1): best-effort connect-time relationship prefetch. Deliberately fire-and-forget — the
+    // C5 (Task 1): best-effort connect-time friend-presence push. Deliberately fire-and-forget — the
     // caller does NOT await it, so a slow/unreachable wb read never adds latency to (or fails) a connect.
     // C6 (Task 11, D13): EXTENDED (not a second background task) so that, after a resolved snapshot, on a
     // GENUINE offline→online transition (<paramref name="wentOnline"/> — the SAME flag OnConnectedAsync
@@ -280,15 +280,16 @@ public partial class ChatHub(
     // connection. Fault-isolated per-recipient via FanOutEngine.PushFriendPresenceChanged. A displaced
     // reconnect (wentOnline == false) pushes nothing, mirroring Task 9's PresenceChanged transition guard
     // exactly.
-    // Follow-up spec §6: this method no longer fetches its own snapshot at all — <paramref
-    // name="resolvedSnapshot"/> is the connect path's ALREADY-RESOLVED pre-assembly snapshot (null when
-    // that fetch itself failed — RelationshipUnavailableException was already logged there). Calling
-    // GetSnapshotAsync again here would be a duplicate wb round-trip stacked on the one the connect path
-    // already awaited — precisely doubling load on wb during exactly the outage where it's least welcome.
-    // When null, the friend push is silently skipped: honest degradation (a later connect self-heals once
-    // wb recovers), never a retry. This makes the source call count for a whole connect exactly one, by
-    // construction — never conditional on timing or on whether the pre-assembly fetch succeeded.
-    private async Task PrefetchRelationshipSnapshot(
+    // Follow-up spec §6: this method no longer fetches its own snapshot at all (hence no longer named
+    // "Prefetch...") — <paramref name="resolvedSnapshot"/> is the connect path's ALREADY-RESOLVED
+    // pre-assembly snapshot (null when that fetch itself failed — the exception was already logged
+    // there). Calling GetSnapshotAsync again here would be a duplicate wb round-trip stacked on the one
+    // the connect path already awaited — precisely doubling load on wb during exactly the outage where
+    // it's least welcome. When null, the friend push is silently skipped: honest degradation (a later
+    // connect self-heals once wb recovers), never a retry. This makes the source call count for a whole
+    // connect exactly one, by construction — never conditional on timing or on whether the pre-assembly
+    // fetch succeeded.
+    private async Task PushFriendPresenceFromSnapshot(
         string battleTag, bool wentOnline, string connectionId, RelationshipSnapshot resolvedSnapshot)
     {
         if (resolvedSnapshot == null || !wentOnline)
@@ -433,7 +434,7 @@ public partial class ChatHub(
         }
     }
 
-    // C6 (Task 11, D13): the disconnect-side counterpart to PrefetchRelationshipSnapshot's connect-time
+    // C6 (Task 11, D13): the disconnect-side counterpart to PushFriendPresenceFromSnapshot's connect-time
     // push. A NEW fire-and-forget task (the disconnect path had no pre-existing background task to ride).
     // Fetches the disconnecting user's OWN relationship snapshot and, on success, pushes
     // FriendPresenceChanged{subject, online:false} to every currently-online friend via

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -30,6 +30,10 @@ public partial class ChatHub(
     FocusRegistry focusRegistry,
     OnlineMemberRegistry onlineMemberRegistry,
     MessageRateLimiter messageRateLimiter,
+    // 2026-08-05 PR36 feedback, Part 3: the read-shaped hub methods' abuse guard (GetConversations,
+    // GetMessages), added right beside MessageRateLimiter — same singleton-sharing rationale, deliberately
+    // NOT the same instance/type (see FanOut/ReadRateLimiter.cs class doc for why they stay separate).
+    ReadRateLimiter readRateLimiter,
     TimeProvider timeProvider,
     // C3 (Task 9): resolves a channel for the FocusChannel NotFound-vs-NotMember split (cold path,
     // only reached when the caller is NOT already a member per OnlineMemberRegistry).
@@ -111,6 +115,9 @@ public partial class ChatHub(
     private readonly FocusRegistry _focusRegistry = focusRegistry;
     private readonly OnlineMemberRegistry _onlineMemberRegistry = onlineMemberRegistry;
     private readonly MessageRateLimiter _messageRateLimiter = messageRateLimiter;
+    // 2026-08-05 PR36 feedback, Part 3: the read-shaped hub methods' abuse guard — see the ctor param
+    // doc comment above.
+    private readonly ReadRateLimiter _readRateLimiter = readRateLimiter;
     private readonly TimeProvider _timeProvider = timeProvider;
     private readonly ChannelRepository _channelRepository = channelRepository;
     // C3 (Task 10): membership self-service deps — see the constructor param doc comment above.

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -92,7 +92,11 @@ public partial class ChatHub(
     // MarkMentionsRead / MentionUnreadCount), injected now in the SAME single ctor growth. There is NO
     // T5 consumer — the write path uses MentionFanOut's OWN MentionInboxRepository, not this one; Task 6
     // is the first reader.
-    MentionInboxRepository mentionInboxRepository) : Hub
+    MentionInboxRepository mentionInboxRepository,
+    // PR36 follow-up (D2): the notification-preference carrier — JoinChannel's rejoin-seed path reads it,
+    // SetNotificationLevel's write path (Public/SemiPublic only) writes it. Both live in
+    // ChatHub.Channels.cs; this is the ONLY ctor change this task makes to ChatHub itself.
+    NotificationPreferenceRepository notificationPreferenceRepository) : Hub
 {
     private readonly ConnectionMapping _connections = connections;
     private readonly MuteReconciliationService _muteReconciliation = muteReconciliation;
@@ -134,6 +138,8 @@ public partial class ChatHub(
     // C6 (Task 6): the mention-inbox read/ack store — first CONSUMED in Task 6. No T5 reader — see the
     // ctor param doc comment (the write path uses MentionFanOut's own repository, not this field).
     private readonly MentionInboxRepository _mentionInboxRepository = mentionInboxRepository;
+    // PR36 follow-up (D2): the notification-preference carrier — see the ctor param doc comment above.
+    private readonly NotificationPreferenceRepository _notificationPreferenceRepository = notificationPreferenceRepository;
 
     public override async Task OnConnectedAsync()
     {

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -184,16 +184,26 @@ public partial class ChatHub(
         var resolution = await _chatAuthenticationService.GetUserFromIdentity(identity);
         await UpsertDirectory(identity, resolution, now);
 
-        // C5 (Task 1, spec §6): warm the relationship cache with the CONNECTING user's OWN snapshot so the
-        // block/friend gates (later C5 tasks) start hot. Fire-and-forget and NON-FATAL: it is deliberately
-        // NOT awaited (a slow/unreachable wb read must never add latency to, or fail, a connect), and any
-        // failure is swallowed + logged exactly like UpsertDirectory. The task touches only the singleton
-        // provider + the captured battleTag/connectionId, so it is safe even after this hub instance is
-        // disposed; a cache miss simply self-heals on the first gated action.
-        // C6 (Task 11, D13): this SAME task now ALSO carries the friend-presence push — see
-        // PrefetchRelationshipSnapshot's doc comment below. Riding the existing fire-and-forget work
-        // (rather than adding a second background task) is what keeps this connect-latency-free: wentOnline
-        // and Context.ConnectionId are captured NOW, synchronously, before the task is dispatched.
+        // Follow-up spec §6: resolve the caller's OWN relationship snapshot BEFORE assembly — the
+        // bounded DM snapshot needs the block list to keep every blocked 1:1 shell regardless of
+        // recency. Bounded wait: the wb source self-caps at its 2s HttpClient timeout and the provider
+        // serves fresh-cache/stale tiers first (the connect path already awaits one wb round-trip —
+        // GetUserFromIdentity above). Fail-soft: with nothing cached at all, assemble WITHOUT a
+        // snapshot — blocked shells outside the recency window may be omitted from THIS SessionState
+        // only (self-heals on the next connect); a wb outage must never fail the connect.
+        RelationshipSnapshot relationshipSnapshot = null;
+        try
+        {
+            relationshipSnapshot = await _relationshipProvider.GetSnapshotAsync(identity.BattleTag);
+        }
+        catch (RelationshipUnavailableException ex)
+        {
+            Log.Warning(ex, "No relationship snapshot for {BattleTag} at connect — blocked 1:1 shells may be omitted from this SessionState", identity.BattleTag);
+        }
+
+        // C5 (Task 1) / C6 (Task 11, D13): unchanged role (cache warm + friend-presence push), now
+        // dispatched AFTER the awaited fetch above so its own GetSnapshotAsync is a warm-cache hit
+        // instead of a duplicate wb round-trip. Still fire-and-forget and non-fatal.
         _ = PrefetchRelationshipSnapshot(identity.BattleTag, wentOnline, Context.ConnectionId);
 
         // C3 (Task 8): assemble the SessionState snapshot and seed this connection's fan-out state (the
@@ -203,7 +213,7 @@ public partial class ChatHub(
         // the connect fails — an authenticated connection with no snapshot is useless — so we do NOT
         // swallow it (unlike the non-fatal directory upsert above). The already-resolved chatUser is
         // threaded straight through — AssembleAndSeed no longer re-resolves it itself (D9).
-        var (dto, muteStatus) = await _assembler.AssembleAndSeed(identity, Context.ConnectionId, now, resolution.User);
+        var (dto, muteStatus) = await _assembler.AssembleAndSeed(identity, Context.ConnectionId, now, resolution.User, relationshipSnapshot);
         await Clients.Caller.SendAsync(ChatEvents.SessionState, dto);
 
         if (muteStatus == MuteStatus.Full)

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -190,21 +190,24 @@ public partial class ChatHub(
         // serves fresh-cache/stale tiers first (the connect path already awaits one wb round-trip —
         // GetUserFromIdentity above). Fail-soft: with nothing cached at all, assemble WITHOUT a
         // snapshot — blocked shells outside the recency window may be omitted from THIS SessionState
-        // only (self-heals on the next connect); a wb outage must never fail the connect.
+        // only (self-heals on the next connect); a wb outage must never fail the connect. Catches
+        // Exception (not just RelationshipUnavailableException), matching every sibling wb call on this
+        // hub's connect/disconnect paths (UpsertDirectory, PrefetchRelationshipSnapshot,
+        // PushFriendPresenceOnDisconnect) — no provider exception type can ever hard-fail connect.
         RelationshipSnapshot relationshipSnapshot = null;
         try
         {
             relationshipSnapshot = await _relationshipProvider.GetSnapshotAsync(identity.BattleTag);
         }
-        catch (RelationshipUnavailableException ex)
+        catch (Exception ex)
         {
             Log.Warning(ex, "No relationship snapshot for {BattleTag} at connect — blocked 1:1 shells may be omitted from this SessionState", identity.BattleTag);
         }
 
-        // C5 (Task 1) / C6 (Task 11, D13): unchanged role (cache warm + friend-presence push), now
-        // dispatched AFTER the awaited fetch above so its own GetSnapshotAsync is a warm-cache hit
-        // instead of a duplicate wb round-trip. Still fire-and-forget and non-fatal.
-        _ = PrefetchRelationshipSnapshot(identity.BattleTag, wentOnline, Context.ConnectionId);
+        // C5 (Task 1) / C6 (Task 11, D13): unchanged role (friend-presence push), now dispatched AFTER
+        // the awaited fetch above and handed that ALREADY-RESOLVED snapshot directly — a wb outage means
+        // one round-trip per connect, not two. Still fire-and-forget and non-fatal.
+        _ = PrefetchRelationshipSnapshot(identity.BattleTag, wentOnline, Context.ConnectionId, relationshipSnapshot);
 
         // C3 (Task 8): assemble the SessionState snapshot and seed this connection's fan-out state (the
         // OnlineMemberRegistry + the legacy mute cache, both done inside AssembleAndSeed), then push the
@@ -270,36 +273,30 @@ public partial class ChatHub(
 
     // C5 (Task 1): best-effort connect-time relationship prefetch. Deliberately fire-and-forget — the
     // caller does NOT await it, so a slow/unreachable wb read never adds latency to (or fails) a connect.
-    // Any failure is swallowed and logged exactly like UpsertDirectoryStub; on success the provider caches
-    // the snapshot. References only the singleton provider + the captured battleTag/connectionId, so it is
-    // safe to run to completion after this hub instance is disposed.
-    // C6 (Task 11, D13): EXTENDED (not a second background task) so that, after a successful fetch, on a
+    // C6 (Task 11, D13): EXTENDED (not a second background task) so that, after a resolved snapshot, on a
     // GENUINE offline→online transition (<paramref name="wentOnline"/> — the SAME flag OnConnectedAsync
     // already computed; never re-derived here) it also pushes FriendPresenceChanged{subject, online:true}
     // to every one of the connecting user's OWN friends (from THIS snapshot) that currently has a live
-    // connection. Fault-isolated per-recipient via FanOutEngine.PushFriendPresenceChanged. On ANY failure
-    // fetching the snapshot — including RelationshipUnavailableException (no cache at all) — the friend
-    // push is silently skipped (logged, never thrown): honest degradation, matching the same
-    // stale-usable/fail-closed policy Task 10's GetPresenceDetails already established for this provider.
-    // A displaced reconnect (wentOnline == false) pushes nothing, mirroring Task 9's PresenceChanged
-    // transition guard exactly.
-    private async Task PrefetchRelationshipSnapshot(string battleTag, bool wentOnline, string connectionId)
+    // connection. Fault-isolated per-recipient via FanOutEngine.PushFriendPresenceChanged. A displaced
+    // reconnect (wentOnline == false) pushes nothing, mirroring Task 9's PresenceChanged transition guard
+    // exactly.
+    // Follow-up spec §6: this method no longer fetches its own snapshot at all — <paramref
+    // name="resolvedSnapshot"/> is the connect path's ALREADY-RESOLVED pre-assembly snapshot (null when
+    // that fetch itself failed — RelationshipUnavailableException was already logged there). Calling
+    // GetSnapshotAsync again here would be a duplicate wb round-trip stacked on the one the connect path
+    // already awaited — precisely doubling load on wb during exactly the outage where it's least welcome.
+    // When null, the friend push is silently skipped: honest degradation (a later connect self-heals once
+    // wb recovers), never a retry. This makes the source call count for a whole connect exactly one, by
+    // construction — never conditional on timing or on whether the pre-assembly fetch succeeded.
+    private async Task PrefetchRelationshipSnapshot(
+        string battleTag, bool wentOnline, string connectionId, RelationshipSnapshot resolvedSnapshot)
     {
-        RelationshipSnapshot snapshot;
-        try
+        if (resolvedSnapshot == null || !wentOnline)
         {
-            snapshot = await _relationshipProvider.GetSnapshotAsync(battleTag);
-        }
-        catch (Exception ex)
-        {
-            Log.Warning(ex, "Failed to prefetch relationship snapshot for {BattleTag}", battleTag);
             return;
         }
 
-        if (wentOnline)
-        {
-            await _fanOutEngine.PushFriendPresenceChanged(battleTag, online: true, snapshot.Friends, connectionId);
-        }
+        await _fanOutEngine.PushFriendPresenceChanged(battleTag, online: true, resolvedSnapshot.Friends, connectionId);
     }
 
     public override async Task OnDisconnectedAsync(Exception exception)

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -79,7 +79,8 @@ public partial class ChatHub(
     // FreshFromWb to decide whether it may replace the cached Profile) — one wb round-trip serves both,
     // where the pre-D9 path resolved it twice.
     IChatAuthenticationService chatAuthenticationService,
-    // C6 (Task 5, D3/D4): the mention fan-out. SendMessage's step 7.75 (ChatHub.Messaging.cs) hands it
+    // C6 (Task 5, D3/D4): the mention fan-out. SendMessage's step 8 (ChatHub.Messaging.cs; fix round 1
+    // F2b moved it after the step-7.75 channel fan-out seam) hands it
     // the validated mention-tag list for each persisted, NON-shadow message; per eligible member it
     // writes a mention-inbox entry + a targeted MentionNotified push. Singleton (Startup).
     MentionFanOut mentionFanOut,
@@ -130,7 +131,7 @@ public partial class ChatHub(
     private readonly DmInitiationTracker _dmInitiationTracker = dmInitiationTracker;
     // D9 (C6 Task 3): the hoisted chat-flair resolution — see the constructor param doc comment above.
     private readonly IChatAuthenticationService _chatAuthenticationService = chatAuthenticationService;
-    // C6 (Task 5): the mention fan-out seam consumed by SendMessage's step 7.75 (ChatHub.Messaging.cs).
+    // C6 (Task 5): the mention fan-out seam consumed by SendMessage's step 8 (ChatHub.Messaging.cs).
     private readonly MentionFanOut _mentionFanOut = mentionFanOut;
     // C6 (Task 5, D15): injected now, first CONSUMED in Task 9 (presence-interest derivation). No T5
     // reader — see the ctor param doc comment for why it lands in this single ctor growth.

--- a/W3ChampionsChatService/Chats/DefaultChatRooms.cs
+++ b/W3ChampionsChatService/Chats/DefaultChatRooms.cs
@@ -8,7 +8,7 @@ public class DefaultChatRooms()
     /// The hardcoded public catalog — fed into <c>Channels/PublicChannelSeeder.cs</c> at startup.
     /// Catalog changes remain deploy-only by explicit product decision.
     /// </summary>
-    public static List<string> Rooms { get; } = [
+    public static readonly IReadOnlyList<string> Rooms = [
         "W3C Lounge",
         "1 vs 1",
         "2 vs 2",

--- a/W3ChampionsChatService/Domain/ChatCollections.cs
+++ b/W3ChampionsChatService/Domain/ChatCollections.cs
@@ -13,4 +13,9 @@ public static class ChatCollections
     public const string UserDirectory = "user_directory";
     public const string UserSettings = "user_settings";
     public const string MentionInbox = "mention_inbox";
+
+    // PR36 follow-up (D2): one doc per (battleTag, channelId) carrying the last EXPLICITLY-set
+    // NotificationLevel for a name-joinable room — survives a hard-delete leave/rejoin cycle
+    // independently of ChannelMembership's own lifecycle (see NotificationPreferenceRepository).
+    public const string NotificationPreferences = "notification_prefs";
 }

--- a/W3ChampionsChatService/Domain/ChatDomainIndexes.cs
+++ b/W3ChampionsChatService/Domain/ChatDomainIndexes.cs
@@ -34,6 +34,7 @@ public static class ChatDomainIndexes
         await EnsureMessageIndexes(db);
         await EnsureMentionInboxIndexes(db);
         await EnsureUserDirectoryIndexes(db);
+        await EnsureNotificationPreferenceIndexes(db);
     }
 
     private static async Task EnsureChannelIndexes(IMongoDatabase db)
@@ -187,6 +188,22 @@ public static class ChatDomainIndexes
             new CreateIndexModel<UserDirectoryEntry>(
                 Builders<UserDirectoryEntry>.IndexKeys.Ascending(e => e.NormalizedName).Descending(e => e.LastSeenAt),
                 new CreateIndexOptions { Name = "ix_normalizedName_lastSeenAt" }),
+        ]);
+    }
+
+    /// <summary>
+    /// PR36 follow-up (D2): backs <see cref="Memberships.NotificationPreferenceRepository"/>'s Load
+    /// (BattleTag, ChannelId) point-read AND enforces the one-row-per-(user, channel) invariant that
+    /// makes <c>Upsert</c>'s last-write-wins semantics well-defined.
+    /// </summary>
+    private static async Task EnsureNotificationPreferenceIndexes(IMongoDatabase db)
+    {
+        var prefs = db.GetCollection<NotificationPreference>(ChatCollections.NotificationPreferences);
+        await prefs.Indexes.CreateManyAsync(
+        [
+            new CreateIndexModel<NotificationPreference>(
+                Builders<NotificationPreference>.IndexKeys.Ascending(p => p.BattleTag).Ascending(p => p.ChannelId),
+                new CreateIndexOptions { Name = "ux_battleTag_channelId", Unique = true }),
         ]);
     }
 }

--- a/W3ChampionsChatService/Domain/ChatDomainIndexes.cs
+++ b/W3ChampionsChatService/Domain/ChatDomainIndexes.cs
@@ -83,14 +83,32 @@ public static class ChatDomainIndexes
     private static async Task EnsureMembershipIndexes(IMongoDatabase db)
     {
         var memberships = db.GetCollection<ChannelMembership>(ChatCollections.ChannelMemberships);
+
+        // 2026-08-04 follow-up: superseded by ix_battleTag_joinedAt below — MembershipRepository.LoadForUser
+        // now sorts by JoinedAt (carried launcher-review item, see that method's doc), and a compound
+        // (BattleTag, JoinedAt) index serves that sorted read directly (index-order scan) instead of an
+        // in-memory sort behind an index-only BattleTag prefix scan. Best-effort drop, same
+        // swallow-IndexNotFound idiom as the D6 ix_sender_sentAt migration above — safe on a fresh
+        // database (nothing to drop) and on an already-migrated one (same reason).
+        try
+        {
+            await memberships.Indexes.DropOneAsync("ix_battleTag");
+        }
+        catch (MongoCommandException ex) when (IsIndexNotFound(ex))
+        {
+            // no-op: nothing to drop
+        }
+
         await memberships.Indexes.CreateManyAsync(
         [
             new CreateIndexModel<ChannelMembership>(
                 Builders<ChannelMembership>.IndexKeys.Ascending(m => m.ChannelId).Ascending(m => m.BattleTag),
                 new CreateIndexOptions { Name = "ux_channelId_battleTag", Unique = true }),
+            // Replaces ix_battleTag: BattleTag stays the selective prefix (LoadForUser's filter), JoinedAt
+            // extends it so the method's SortBy(JoinedAt) is served by the index itself.
             new CreateIndexModel<ChannelMembership>(
-                Builders<ChannelMembership>.IndexKeys.Ascending(m => m.BattleTag),
-                new CreateIndexOptions { Name = "ix_battleTag" }),
+                Builders<ChannelMembership>.IndexKeys.Ascending(m => m.BattleTag).Ascending(m => m.JoinedAt),
+                new CreateIndexOptions { Name = "ix_battleTag_joinedAt" }),
         ]);
     }
 

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -208,4 +208,24 @@ public static class ChatLimits
     /// endpoint bodies pin this field; plan decision, not itself brief-pinned text; hard-coded, adjust
     /// here only.</summary>
     public const int InternalChannelNameMaxLength = 100;
+
+    /// <summary>2026-08-05 PR36 feedback, Part 3: <see cref="FanOut.ReadRateLimiter"/>'s single per-
+    /// battleTag token bucket, shared across every READ-shaped hub method it guards
+    /// (<c>GetConversations</c>, <c>GetMessages</c>). This is a server-protection abuse guard, not UX
+    /// pacing (Marco) — burst 30, sustained 5/s is far above any legitimate client's per-user-action
+    /// handful of loads, so no well-behaved client should ever observe a denial in normal operation.
+    /// Not spec §13 text; hard-coded, adjust here only.</summary>
+    public const int ReadBurst = 30;
+
+    /// <summary>Sustained refill rate (tokens/second) for the <see cref="ReadBurst"/> bucket above.</summary>
+    public const int ReadRefillPerSecond = 5;
+
+    /// <summary>Quiescent-prune horizon for <see cref="FanOut.ReadRateLimiter"/> — mirrors
+    /// <see cref="FanOut.MessageRateLimiter"/>'s <see cref="AutoThrottleTierDecay"/>-anchored sweep, but this
+    /// limiter has no violation ladder to protect, only the single bucket's fullness. INVARIANT (pinned
+    /// by <c>ChatLimitsTests</c>): this MUST stay strictly greater than the bucket's own full-refill time
+    /// (<see cref="ReadBurst"/> / <see cref="ReadRefillPerSecond"/> seconds = 6s) — otherwise an entry
+    /// pruned at this horizon and silently recreated fresh (full capacity) would NOT be behaviour-
+    /// preserving relative to a live bucket that had only refilled for that same idle duration.</summary>
+    public static readonly TimeSpan ReadRateLimiterPruneHorizon = TimeSpan.FromMinutes(2);
 }

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -96,7 +96,11 @@ public static class ChatLimits
     /// <summary>Escalating auto-throttle tiers (2026-08-04 follow-up spec §1, hard-coded — no env
     /// plumbing per the parent-spec rule): first trigger 10s, second 30s, third and beyond 60s (cap
     /// — the last element applies to every later trigger). The ladder resets to the first tier after
-    /// <see cref="AutoThrottleTierDecay"/> without a new trigger.</summary>
+    /// <see cref="AutoThrottleTierDecay"/> without a new trigger.
+    /// <para>INVARIANT (pinned by <c>ChatLimitsTests</c>): every element here must stay strictly less
+    /// than <see cref="AutoThrottleTierDecay"/> — <see cref="FanOut.MessageRateLimiter"/>'s quiescent
+    /// prune treats the decay horizon as "definitely idle, safe to evict", which only holds if no tier's
+    /// hard-throttle penalty can still be running that long after a user's last touch.</para></summary>
     public static readonly IReadOnlyList<TimeSpan> AutoThrottleTierDurations =
     [
         TimeSpan.FromSeconds(10),

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -86,13 +86,23 @@ public static class ChatLimits
     /// not messages, so a larger ceiling is appropriate.</summary>
     public const int ModerationChannelsPageSize = 500;
 
-    /// <summary>Auto-throttle escalation (C3 plan decision, Task 1). Spec §13 pins only "60s
-    /// automatic throttle"; the trigger threshold/window are NOT spec-pinned — cheap to change
-    /// (C3-plan.md Open question 3). Repeated rate-limit violations within the window escalate to
-    /// a hard per-connection throttle for the duration below, plus a moderation log entry.</summary>
+    /// <summary>Auto-throttle escalation trigger (C3 plan decision, Task 1; trigger UNCHANGED by the
+    /// 2026-08-04 follow-up spec §1): repeated rate-limit violations within the window escalate to a
+    /// hard per-user throttle, plus a moderation log entry.</summary>
     public const int AutoThrottleViolationThreshold = 5;
     public static readonly TimeSpan AutoThrottleWindow = TimeSpan.FromSeconds(60);
-    public static readonly TimeSpan AutoThrottleDuration = TimeSpan.FromSeconds(60);
+
+    /// <summary>Escalating auto-throttle tiers (2026-08-04 follow-up spec §1, hard-coded — no env
+    /// plumbing per the parent-spec rule): first trigger 10s, second 30s, third and beyond 60s (cap
+    /// — the last element applies to every later trigger). The ladder resets to the first tier after
+    /// <see cref="AutoThrottleTierDecay"/> without a new trigger.</summary>
+    public static readonly TimeSpan[] AutoThrottleTierDurations =
+    [
+        TimeSpan.FromSeconds(10),
+        TimeSpan.FromSeconds(30),
+        TimeSpan.FromSeconds(60),
+    ];
+    public static readonly TimeSpan AutoThrottleTierDecay = TimeSpan.FromMinutes(10);
 
     /// <summary>Relationship (friends/blocked) snapshot cache TTL (C5 plan decision, T1 — not spec §13).
     /// The provider serves a cached snapshot without refetching for this long; spec §6 notes the

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -233,7 +233,7 @@ public static class ChatLimits
     /// <see cref="FanOut.MessageRateLimiter"/>'s <see cref="AutoThrottleTierDecay"/>-anchored sweep, but this
     /// limiter has no violation ladder to protect, only the single bucket's fullness. INVARIANT (pinned
     /// by <c>ChatLimitsTests</c>): this MUST stay strictly greater than the bucket's own full-refill time
-    /// (<see cref="ReadBurst"/> / <see cref="ReadRefillPerSecond"/> seconds = 6s) — otherwise an entry
+    /// (<see cref="ReadBurst"/> / <see cref="ReadRefillPerSecond"/> seconds = 12s) — otherwise an entry
     /// pruned at this horizon and silently recreated fresh (full capacity) would NOT be behaviour-
     /// preserving relative to a live bucket that had only refilled for that same idle duration.</summary>
     public static readonly TimeSpan ReadRateLimiterPruneHorizon = TimeSpan.FromMinutes(2);

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -168,6 +168,15 @@ public static class ChatLimits
     /// channel are never bounded by this.</summary>
     public const int DmSnapshotRecentConversations = 30;
 
+    /// <summary>2026-08-05 PR36 feedback, Part 2 — safety ceiling against pathological accounts on the
+    /// connect-snapshot rule-(e) tail (<see cref="Protocol.SessionStateAssembler.SelectSnapshotMemberships"/>):
+    /// the ordered (recency-desc) scan keeps at most this many OLDER-with-unread 1:1 Dm shells beyond the
+    /// <see cref="DmSnapshotRecentConversations"/> most-recent window; anything beyond is still reachable
+    /// via <c>GetConversations</c> pagination. The Messages badge may undercount ONLY for an account with
+    /// MORE than this many unread older 1:1 conversations at once — an accepted trade-off (Marco,
+    /// 2026-08-05), never a silently-wrong count for anyone under the cap.</summary>
+    public const int DmSnapshotMaxOlderUnread = 100;
+
     /// <summary>GetConversations page-size cap (2026-08-04 follow-up spec §6 — not spec §13; requested
     /// limits above this are clamped down, never rejected — the <see cref="MessagePageSize"/> precedent).</summary>
     public const int ConversationsPageSize = 50;

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -237,4 +237,11 @@ public static class ChatLimits
     /// pruned at this horizon and silently recreated fresh (full capacity) would NOT be behaviour-
     /// preserving relative to a live bucket that had only refilled for that same idle duration.</summary>
     public static readonly TimeSpan ReadRateLimiterPruneHorizon = TimeSpan.FromMinutes(2);
+
+    /// <summary>Fix round 1 (finding F3): minimum interval between two <see cref="FanOut.ReadRateLimiter"/>
+    /// "read rate limit denied" log lines for the SAME user. Denials were previously invisible to
+    /// operators — combined with the silent client failure mode on a denial, "no legitimate client ever
+    /// hits it" was unfalsifiable in production. A sustained-denial user must not spam the log on every
+    /// call, so this bounds it to once per window. Not spec §13 text; hard-coded, adjust here only.</summary>
+    public static readonly TimeSpan ReadRateLimiterDenyLogInterval = TimeSpan.FromMinutes(1);
 }

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace W3ChampionsChatService.Domain;
 
@@ -96,7 +97,7 @@ public static class ChatLimits
     /// plumbing per the parent-spec rule): first trigger 10s, second 30s, third and beyond 60s (cap
     /// — the last element applies to every later trigger). The ladder resets to the first tier after
     /// <see cref="AutoThrottleTierDecay"/> without a new trigger.</summary>
-    public static readonly TimeSpan[] AutoThrottleTierDurations =
+    public static readonly IReadOnlyList<TimeSpan> AutoThrottleTierDurations =
     [
         TimeSpan.FromSeconds(10),
         TimeSpan.FromSeconds(30),

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -168,6 +168,10 @@ public static class ChatLimits
     /// channel are never bounded by this.</summary>
     public const int DmSnapshotRecentConversations = 30;
 
+    /// <summary>GetConversations page-size cap (2026-08-04 follow-up spec §6 — not spec §13; requested
+    /// limits above this are clamped down, never rejected — the <see cref="MessagePageSize"/> precedent).</summary>
+    public const int ConversationsPageSize = 50;
+
     /// <summary>C7 HMAC freshness window (brief Design decision 2): a request is rejected when
     /// |now − timestamp| exceeds this window. Pinned default — M1/W2 build against this exact 300s
     /// value as a cross-repo contract, so a test asserts it verbatim.</summary>

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -162,6 +162,12 @@ public static class ChatLimits
     /// not spec §13; requests above this are rejected with <c>HubException</c>).</summary>
     public const int PresenceQueryMaxBattleTags = 200;
 
+    /// <summary>2026-08-04 follow-up spec §6: connect-snapshot bound for ACCEPTED, non-blocked 1:1 Dm
+    /// shells — the N most-recent ride SessionState; older ones ride only with unread > 0 (or via
+    /// GetConversations pagination). Pending requests, blocked shells, GroupDm, and every non-DM
+    /// channel are never bounded by this.</summary>
+    public const int DmSnapshotRecentConversations = 30;
+
     /// <summary>C7 HMAC freshness window (brief Design decision 2): a request is rejected when
     /// |now − timestamp| exceeds this window. Pinned default — M1/W2 build against this exact 300s
     /// value as a cross-repo contract, so a test asserts it verbatim.</summary>

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -212,10 +212,19 @@ public static class ChatLimits
     /// <summary>2026-08-05 PR36 feedback, Part 3: <see cref="FanOut.ReadRateLimiter"/>'s single per-
     /// battleTag token bucket, shared across every READ-shaped hub method it guards
     /// (<c>GetConversations</c>, <c>GetMessages</c>). This is a server-protection abuse guard, not UX
-    /// pacing (Marco) — burst 30, sustained 5/s is far above any legitimate client's per-user-action
-    /// handful of loads, so no well-behaved client should ever observe a denial in normal operation.
+    /// pacing (Marco).
+    /// <para>
+    /// Fix round 1, finding F1: sized for the CONNECT FAN-OUT shape, not a per-user-action handful of
+    /// loads — the original 30 undercounted this. The connect snapshot carries no messages, so a client
+    /// re-seeds every focused surface on EVERY (re)connect: up to launcher <c>MAX_FOCUSED_CHANNELS</c>
+    /// (10) expanded DM windows in parallel, plus the active channel, plus the match embed (~12
+    /// surfaces). SignalR's default first reconnect retry is 0ms, so a single socket flap pays that
+    /// reseed TWICE within ~2s (~24 calls) before tray scroll or channel clicks push it any higher. 60 ≈
+    /// 2× that worst-case flap with slack — still far above anything a single legitimate user action
+    /// needs, so no well-behaved client should ever observe a denial in normal operation.
+    /// </para>
     /// Not spec §13 text; hard-coded, adjust here only.</summary>
-    public const int ReadBurst = 30;
+    public const int ReadBurst = 60;
 
     /// <summary>Sustained refill rate (tokens/second) for the <see cref="ReadBurst"/> bucket above.</summary>
     public const int ReadRefillPerSecond = 5;

--- a/W3ChampionsChatService/Domain/CleanupJobs.cs
+++ b/W3ChampionsChatService/Domain/CleanupJobs.cs
@@ -13,7 +13,11 @@ namespace W3ChampionsChatService.Domain;
 /// Weekly maintenance (driven by WeeklyCleanupService):
 /// (a) semi-public channel GC — a semiPublic channel with zero memberships AND zero stored
 ///     messages is dead (message TTL already removed anything older than retention);
-/// (b) membership pruning for users idle &gt; 1 year per user_directory.lastSeenAt.
+/// (b) membership pruning for users idle &gt; 1 year per user_directory.lastSeenAt — fix round 1 (F6)
+///     extends this to ALSO delete the same idle users' <see cref="Memberships.NotificationPreference"/>
+///     rows, so that carrier doesn't outlive the membership it was written to survive. The pref
+///     collection has no TTL of its own (PR36 D2 — it must persist indefinitely across an ordinary
+///     leave/rejoin), so this job is its ONLY GC path.
 /// Group/DM shells need no job — their ExpiresAt TTL handles them.
 /// </summary>
 public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient)
@@ -52,6 +56,7 @@ public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoC
         var db = CreateClient();
         var directory = db.GetCollection<UserDirectoryEntry>(ChatCollections.UserDirectory);
         var memberships = db.GetCollection<ChannelMembership>(ChatCollections.ChannelMemberships);
+        var notificationPreferences = db.GetCollection<NotificationPreference>(ChatCollections.NotificationPreferences);
 
         var cutoff = now - RetentionPeriods.IdleMembership;
         var idleBattleTags = await directory
@@ -66,10 +71,18 @@ public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoC
         // on the projected BattleTag). The projected idle tags are therefore already lowercased and this
         // .ToLowerInvariant() is a no-op on them — kept as a defensive boundary normalization so a legacy
         // pre-D8 (mixed-case) directory _id still lingering in the collection (entries are kept, never
-        // TTL'd) can't silently match no membership row and no-op the prune.
+        // TTL'd) can't silently match no membership row and no-op the prune. NotificationPreference stores
+        // its BattleTag lowercased too (see that repository's class doc), so the SAME key list serves it.
         var idleMembershipKeys = idleBattleTags.Select(t => t.ToLowerInvariant()).ToList();
         var result = await memberships.DeleteManyAsync(
             Builders<ChannelMembership>.Filter.In(m => m.BattleTag, idleMembershipKeys));
+
+        // Fix round 1 (F6): the persisted NotificationPreference carrier (PR36 D2) has no TTL of its own —
+        // it is deliberately durable across an ordinary leave/rejoin — so it must be swept here alongside
+        // the membership rows of the SAME idle users, or it would outlive every other trace of them.
+        await notificationPreferences.DeleteManyAsync(
+            Builders<NotificationPreference>.Filter.In(p => p.BattleTag, idleMembershipKeys));
+
         return result.DeletedCount;
     }
 }

--- a/W3ChampionsChatService/FanOut/ActivityCoalescer.cs
+++ b/W3ChampionsChatService/FanOut/ActivityCoalescer.cs
@@ -49,9 +49,9 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
     // The online-member index — read at EMIT time for the member's CURRENT LastReadSeq (suppression).
     private readonly OnlineMemberRegistry _onlineMemberRegistry = onlineMemberRegistry;
 
-    // connectionId -> (channelId -> coalescing window state). Nested by connection (mirroring
-    // MessageRateLimiter's per-connection map) so RemoveConnection on disconnect is O(1) — dropping a
-    // connection never scans every channel. Mutated only under _lock.
+    // connectionId -> (channelId -> coalescing window state). Nested by connection — this coalescer's
+    // own state is (and stays) connection-scoped for the connection's full lifetime, so RemoveConnection
+    // on disconnect is O(1) and dropping a connection never scans every channel. Mutated only under _lock.
     private readonly Dictionary<string, Dictionary<string, Entry>> _entriesByConnection =
         new Dictionary<string, Dictionary<string, Entry>>();
 
@@ -187,8 +187,10 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
     /// single O(1) map removal. Called from the hub's disconnect teardown (via
     /// <see cref="FanOutEngine.OnConnectionClosed"/>) so this singleton's per-connection state can never
     /// leak past the socket's lifetime — SignalR never reuses a connectionId, so an un-evicted entry
-    /// would live for the whole process. Mirrors the <c>RemoveConnection</c> the sibling registries /
-    /// <see cref="MessageRateLimiter"/> expose for the same reason. No-op for an unknown connection.
+    /// would live for the whole process. Mirrors the <c>RemoveConnection</c> the sibling registries
+    /// (<see cref="FocusRegistry"/>, <see cref="OnlineMemberRegistry"/>) expose for the same reason —
+    /// unlike those (and unlike this coalescer), <see cref="MessageRateLimiter"/> is battleTag-keyed and
+    /// deliberately SURVIVES disconnect, so it exposes no such method. No-op for an unknown connection.
     /// </summary>
     public void RemoveConnection(string connectionId)
     {
@@ -247,7 +249,8 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
 
     /// <summary>
     /// The coalescing window state for one (connection, channel). Plain mutable fields, mutated only
-    /// under the coalescer's lock (mirrors <see cref="MessageRateLimiter"/>'s per-connection state).
+    /// under the coalescer's lock; the entry lives for exactly as long as its owning connection and is
+    /// dropped in one shot by <see cref="RemoveConnection"/> on disconnect.
     /// <see cref="LastSentAt"/> defaults to <see cref="DateTime.MinValue"/> so the first offer is always
     /// "window elapsed" and fires immediately. <see cref="LastEmittedSeq"/> is the running high-water
     /// mark of every seq this (connection, channel) has emitted or pended — both <see cref="Offer"/> and

--- a/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
+++ b/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
@@ -137,12 +137,15 @@ public class MessageRateLimiter
         }
 
         // Emit the moderation line outside the lock. The transition it reports happened exactly once
-        // (inside the lock), so this fires exactly once per hard-throttle episode.
+        // (inside the lock), so this fires exactly once per hard-throttle episode. Logs the caller's
+        // ORIGINAL-CASING battleTag (not the internal lowercased `key`) so this line matches the hub's
+        // own companion Log.Warning (ChatHub.Messaging.cs) — a case-sensitive log search for a
+        // particular battleTag must find both lines.
         if (applied is TimeSpan d)
         {
             Log.Warning(
                 "Auto-throttling chat user {BattleTag} for {DurationSeconds}s after {ViolationThreshold} rate-limit violations within {WindowSeconds}s",
-                key,
+                battleTag,
                 d.TotalSeconds,
                 ChatLimits.AutoThrottleViolationThreshold,
                 ChatLimits.AutoThrottleWindow.TotalSeconds);

--- a/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
+++ b/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
@@ -42,9 +42,9 @@ public readonly record struct RateLimitDecision(
 /// token every 0.5s).</item>
 /// </list>
 /// A send consumes one token from BOTH buckets; if either is short, the send is throttled and no
-/// token is consumed. Repeated throttles escalate to a hard per-connection auto-throttle
-/// (<see cref="ChatLimits.AutoThrottleViolationThreshold"/> violations within
-/// <see cref="ChatLimits.AutoThrottleWindow"/> → denied for <see cref="ChatLimits.AutoThrottleDuration"/>).
+/// token is consumed. Repeated throttles escalate to an escalating hard auto-throttle
+/// (<see cref="ChatLimits.AutoThrottleTierDurations"/> 10s→30s→60s cap, ladder decaying after
+/// <see cref="ChatLimits.AutoThrottleTierDecay"/>).
 /// <para>
 /// NO timers and NO wall-clock reads: every decision takes an explicit <c>now</c> and refills are
 /// derived from elapsed time, so it is fully testable without sleeping. The limiter is PURE domain
@@ -79,6 +79,7 @@ public class MessageRateLimiter
     {
         RateLimitDecision decision;
         var logAutoThrottle = false;
+        double appliedThrottleSeconds = 0;
 
         lock (_lock)
         {
@@ -117,10 +118,11 @@ public class MessageRateLimiter
             var retryAfter = Math.Max(channelBucket.SecondsUntilToken(), state.GlobalBucket.SecondsUntilToken());
 
             // 4) Record the violation in the rolling window; escalate if it crosses the threshold.
-            if (RecordViolationAndCheckEscalation(state, now))
+            if (RecordViolationAndCheckEscalation(state, now) is TimeSpan applied)
             {
                 logAutoThrottle = true;
-                decision = new RateLimitDecision(false, ChatLimits.AutoThrottleDuration.TotalSeconds, true);
+                appliedThrottleSeconds = applied.TotalSeconds;
+                decision = new RateLimitDecision(false, appliedThrottleSeconds, true);
             }
             else
             {
@@ -135,7 +137,7 @@ public class MessageRateLimiter
             Log.Warning(
                 "Auto-throttling chat connection {ConnectionId} for {DurationSeconds}s after {ViolationThreshold} rate-limit violations within {WindowSeconds}s",
                 connectionId,
-                ChatLimits.AutoThrottleDuration.TotalSeconds,
+                appliedThrottleSeconds,
                 ChatLimits.AutoThrottleViolationThreshold,
                 ChatLimits.AutoThrottleWindow.TotalSeconds);
         }
@@ -174,9 +176,10 @@ public class MessageRateLimiter
     }
 
     // Caller must already hold _lock. Records a throttle violation at now, ages out ones older than
-    // the rolling window, and returns true if the connection just crossed into hard auto-throttle
-    // (setting the deadline and clearing the counter) — false for a plain non-escalating throttle.
-    private static bool RecordViolationAndCheckEscalation(ConnectionState state, DateTime now)
+    // the rolling window, and — when the count crosses the threshold — escalates into the NEXT tier
+    // (10s → 30s → 60s cap; the ladder resets first if AutoThrottleTierDecay has passed since the
+    // last trigger), returning the applied duration. Null for a plain non-escalating throttle.
+    private static TimeSpan? RecordViolationAndCheckEscalation(ConnectionState state, DateTime now)
     {
         state.Violations.Add(now);
         var cutoff = now - ChatLimits.AutoThrottleWindow;
@@ -184,12 +187,22 @@ public class MessageRateLimiter
 
         if (state.Violations.Count < ChatLimits.AutoThrottleViolationThreshold)
         {
-            return false;
+            return null;
         }
 
-        state.HardThrottleUntil = now + ChatLimits.AutoThrottleDuration;
+        // Tier decay: 10 clean minutes since the last trigger reset the ladder to the first tier.
+        if (state.LastAutoThrottleAt is DateTime last && now - last >= ChatLimits.AutoThrottleTierDecay)
+        {
+            state.TierLevel = 0;
+        }
+
+        var tierIndex = Math.Min(state.TierLevel, ChatLimits.AutoThrottleTierDurations.Length - 1);
+        var duration = ChatLimits.AutoThrottleTierDurations[tierIndex];
+        state.HardThrottleUntil = now + duration;
+        state.LastAutoThrottleAt = now;
+        state.TierLevel++;
         state.Violations.Clear();
-        return true;
+        return duration;
     }
 
     /// <summary>
@@ -205,6 +218,10 @@ public class MessageRateLimiter
             new Dictionary<string, TokenBucket>();
         internal readonly List<DateTime> Violations = new List<DateTime>();
         internal DateTime? HardThrottleUntil;
+        // Follow-up spec §1: completed auto-throttle triggers (the ladder position) + when the last one
+        // fired (anchors the 10-minute decay). Mutated only under the limiter's lock, like every sibling.
+        internal int TierLevel;
+        internal DateTime? LastAutoThrottleAt;
 
         internal ConnectionState(DateTime now)
         {

--- a/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
+++ b/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
@@ -75,8 +75,9 @@ public class MessageRateLimiter
     /// of <paramref name="now"/>. State is keyed by LOWERCASED battleTag (follow-up spec §1) so
     /// violations, the tier ladder, and an active hard throttle survive reconnect/relaunch; entries
     /// quiescent past <see cref="ChatLimits.AutoThrottleTierDecay"/> are pruned opportunistically
-    /// (mirrors <see cref="Sessions.MintRateLimiter"/>'s stale-window purge) so the map cannot grow
-    /// unboundedly across the user population. Allowed only when the per-channel AND global buckets
+    /// (mirrors <see cref="Sessions.MintRateLimiter"/>'s stale-window purge), bounding the map to
+    /// roughly the users active within one decay window rather than letting it grow across the
+    /// service's entire historical user population. Allowed only when the per-channel AND global buckets
     /// each hold a token; otherwise throttled with a positive retry-after. A throttle counts as a
     /// violation, and crossing the escalation threshold hard-throttles the whole user (every channel,
     /// across every connection) for the auto-throttle duration, logging one moderation line and

--- a/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
+++ b/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
@@ -78,8 +78,7 @@ public class MessageRateLimiter
     public RateLimitDecision TryAcquire(string connectionId, string channelId, DateTime now)
     {
         RateLimitDecision decision;
-        var logAutoThrottle = false;
-        double appliedThrottleSeconds = 0;
+        TimeSpan? applied = null;
 
         lock (_lock)
         {
@@ -118,26 +117,20 @@ public class MessageRateLimiter
             var retryAfter = Math.Max(channelBucket.SecondsUntilToken(), state.GlobalBucket.SecondsUntilToken());
 
             // 4) Record the violation in the rolling window; escalate if it crosses the threshold.
-            if (RecordViolationAndCheckEscalation(state, now) is TimeSpan applied)
-            {
-                logAutoThrottle = true;
-                appliedThrottleSeconds = applied.TotalSeconds;
-                decision = new RateLimitDecision(false, appliedThrottleSeconds, true);
-            }
-            else
-            {
-                decision = new RateLimitDecision(false, retryAfter, false);
-            }
+            applied = RecordViolationAndCheckEscalation(state, now);
+            decision = applied is TimeSpan escalated
+                ? new RateLimitDecision(false, escalated.TotalSeconds, true)
+                : new RateLimitDecision(false, retryAfter, false);
         }
 
         // Emit the moderation line outside the lock. The transition it reports happened exactly once
         // (inside the lock), so this fires exactly once per hard-throttle episode.
-        if (logAutoThrottle)
+        if (applied is TimeSpan d)
         {
             Log.Warning(
                 "Auto-throttling chat connection {ConnectionId} for {DurationSeconds}s after {ViolationThreshold} rate-limit violations within {WindowSeconds}s",
                 connectionId,
-                appliedThrottleSeconds,
+                d.TotalSeconds,
                 ChatLimits.AutoThrottleViolationThreshold,
                 ChatLimits.AutoThrottleWindow.TotalSeconds);
         }
@@ -196,11 +189,13 @@ public class MessageRateLimiter
             state.TierLevel = 0;
         }
 
-        var tierIndex = Math.Min(state.TierLevel, ChatLimits.AutoThrottleTierDurations.Length - 1);
+        var tierIndex = Math.Min(state.TierLevel, ChatLimits.AutoThrottleTierDurations.Count - 1);
         var duration = ChatLimits.AutoThrottleTierDurations[tierIndex];
         state.HardThrottleUntil = now + duration;
         state.LastAutoThrottleAt = now;
-        state.TierLevel++;
+        // Saturate rather than grow unbounded: TierLevel only ever needs to reach the tier count
+        // (any further increments would be equivalent to the cap anyway, via the Math.Min above).
+        state.TierLevel = Math.Min(state.TierLevel + 1, ChatLimits.AutoThrottleTierDurations.Count);
         state.Violations.Clear();
         return duration;
     }

--- a/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
+++ b/W3ChampionsChatService/FanOut/MessageRateLimiter.cs
@@ -21,9 +21,9 @@ namespace W3ChampionsChatService.FanOut;
 /// blocking window. Null when <paramref name="Allowed"/> is true.
 /// </param>
 /// <param name="JustAutoThrottled">
-/// True on the SINGLE decision that transitions the connection into hard auto-throttle — the hub's
+/// True on the SINGLE decision that transitions the user into hard auto-throttle — the hub's
 /// cue to push exactly one <see cref="Protocol.ChatEvents.ThrottleNotice"/>. False on every other
-/// decision, including the denials that follow while the connection stays hard-throttled.
+/// decision, including the denials that follow while the user stays hard-throttled.
 /// </param>
 public readonly record struct RateLimitDecision(
     bool Allowed,
@@ -31,13 +31,13 @@ public readonly record struct RateLimitDecision(
     bool JustAutoThrottled);
 
 /// <summary>
-/// Pure, deterministic send-path abuse control (spec §13, C3 Task 6). Two classic token buckets per
-/// connection:
+/// Pure, deterministic send-path abuse control (spec §13, C3 Task 6; re-keyed to battleTag by the
+/// 2026-08-04 follow-up spec §1). Two classic token buckets per user (battleTag-keyed):
 /// <list type="bullet">
-/// <item>a per-(connection, channel) bucket — capacity <see cref="ChatLimits.PerChannelBurst"/>,
+/// <item>a per-(user, channel) bucket — capacity <see cref="ChatLimits.PerChannelBurst"/>,
 /// refilling one token every <see cref="ChatLimits.PerChannelSustainedInterval"/> (5 immediate, then
 /// 1/sec); and</item>
-/// <item>a per-connection GLOBAL bucket — capacity <see cref="ChatLimits.GlobalMessageBurst"/> over
+/// <item>a per-user GLOBAL bucket — capacity <see cref="ChatLimits.GlobalMessageBurst"/> over
 /// <see cref="ChatLimits.GlobalMessageWindow"/>, enforced across every channel (10 per 5s, i.e. one
 /// token every 0.5s).</item>
 /// </list>
@@ -61,31 +61,43 @@ public readonly record struct RateLimitDecision(
 /// </summary>
 public class MessageRateLimiter
 {
-    private readonly Dictionary<string, ConnectionState> _byConnection =
-        new Dictionary<string, ConnectionState>();
+    private readonly Dictionary<string, UserState> _byUser =
+        new Dictionary<string, UserState>();
 
     private readonly object _lock = new object();
 
+    // Last time PruneQuiescentNoLock actually swept the map (see that method for why this is
+    // time-gated rather than run on every call).
+    private DateTime _lastPruneAt;
+
     /// <summary>
-    /// Attempts to consume one send for <paramref name="connectionId"/> on <paramref name="channelId"/>
-    /// as of <paramref name="now"/>. Allowed only when the per-channel AND global buckets each hold a
-    /// token; otherwise throttled with a positive retry-after. A throttle counts as a violation, and
-    /// crossing the escalation threshold hard-throttles the whole connection for the auto-throttle
-    /// duration (all channels), logging one moderation line and signalling the notice once.
+    /// Attempts to consume one send for <paramref name="battleTag"/> on <paramref name="channelId"/> as
+    /// of <paramref name="now"/>. State is keyed by LOWERCASED battleTag (follow-up spec §1) so
+    /// violations, the tier ladder, and an active hard throttle survive reconnect/relaunch; entries
+    /// quiescent past <see cref="ChatLimits.AutoThrottleTierDecay"/> are pruned opportunistically
+    /// (mirrors <see cref="Sessions.MintRateLimiter"/>'s stale-window purge) so the map cannot grow
+    /// unboundedly across the user population. Allowed only when the per-channel AND global buckets
+    /// each hold a token; otherwise throttled with a positive retry-after. A throttle counts as a
+    /// violation, and crossing the escalation threshold hard-throttles the whole user (every channel,
+    /// across every connection) for the auto-throttle duration, logging one moderation line and
+    /// signalling the notice once.
     /// <para><paramref name="now"/> MUST be a trusted server-side clock read (never derived from
     /// client-supplied data); the buckets fail safe on a backwards clock but assume a monotone one.</para>
     /// </summary>
-    public RateLimitDecision TryAcquire(string connectionId, string channelId, DateTime now)
+    public RateLimitDecision TryAcquire(string battleTag, string channelId, DateTime now)
     {
+        var key = battleTag.ToLowerInvariant();
         RateLimitDecision decision;
         TimeSpan? applied = null;
 
         lock (_lock)
         {
-            var state = GetOrCreateState(connectionId, now);
+            PruneQuiescentNoLock(now);
+            var state = GetOrCreateState(key, now);
+            state.LastTouchedAt = now;
 
             // 1) Hard auto-throttle gate: while serving the penalty, deny EVERYTHING for this
-            //    connection (no bucket work, no new violation) with the remaining time as retry-after.
+            //    user (no bucket work, no new violation) with the remaining time as retry-after.
             if (state.HardThrottleUntil is DateTime until)
             {
                 if (now < until)
@@ -128,8 +140,8 @@ public class MessageRateLimiter
         if (applied is TimeSpan d)
         {
             Log.Warning(
-                "Auto-throttling chat connection {ConnectionId} for {DurationSeconds}s after {ViolationThreshold} rate-limit violations within {WindowSeconds}s",
-                connectionId,
+                "Auto-throttling chat user {BattleTag} for {DurationSeconds}s after {ViolationThreshold} rate-limit violations within {WindowSeconds}s",
+                key,
                 d.TotalSeconds,
                 ChatLimits.AutoThrottleViolationThreshold,
                 ChatLimits.AutoThrottleWindow.TotalSeconds);
@@ -138,41 +150,72 @@ public class MessageRateLimiter
         return decision;
     }
 
-    /// <summary>Drops all bucket, violation, and hard-throttle state for a connection (on disconnect).</summary>
-    public void RemoveConnection(string connectionId)
+    // Test seam (assembly has InternalsVisibleTo): number of live per-channel buckets a user is
+    // tracking. Used to assert the idle-bucket purge keeps that map bounded. Mirrors MintRateLimiter.Count.
+    internal int TrackedChannelCount(string battleTag)
     {
         lock (_lock)
         {
-            _byConnection.Remove(connectionId);
+            var key = battleTag.ToLowerInvariant();
+            return _byUser.TryGetValue(key, out var state) ? state.ChannelBucketCount : 0;
         }
     }
 
-    // Test seam (assembly has InternalsVisibleTo): number of live per-channel buckets a connection is
-    // tracking. Used to assert the idle-bucket purge keeps that map bounded. Mirrors MintRateLimiter.Count.
-    internal int TrackedChannelCount(string connectionId)
+    // Test seam (InternalsVisibleTo): number of tracked user entries — asserts the quiescent prune
+    // keeps the map bounded. Mirrors MintRateLimiter.Count.
+    internal int TrackedUserCount
     {
-        lock (_lock)
-        {
-            return _byConnection.TryGetValue(connectionId, out var state) ? state.ChannelBucketCount : 0;
-        }
+        get { lock (_lock) { return _byUser.Count; } }
     }
 
     // Caller must already hold _lock.
-    private ConnectionState GetOrCreateState(string connectionId, DateTime now)
+    private UserState GetOrCreateState(string key, DateTime now)
     {
-        if (!_byConnection.TryGetValue(connectionId, out var state))
+        if (!_byUser.TryGetValue(key, out var state))
         {
-            state = new ConnectionState(now);
-            _byConnection[connectionId] = state;
+            state = new UserState(now);
+            _byUser[key] = state;
         }
         return state;
+    }
+
+    // Caller must already hold _lock. Sweeps at most once per AutoThrottleTierDecay: an entry idle
+    // that long is fully reset in every dimension (buckets guaranteed full — refill horizons are
+    // seconds; violations aged out — the window is 60s; penalty served — tiers cap at 60s; ladder
+    // decayed — the horizon IS the decay), so removal is behavior-preserving by construction. Gated by
+    // time (not run on every call) because TryAcquire is the hot path — a full-map sweep on every send
+    // would be O(n) per message.
+    private void PruneQuiescentNoLock(DateTime now)
+    {
+        if (now - _lastPruneAt < ChatLimits.AutoThrottleTierDecay)
+        {
+            return;
+        }
+        _lastPruneAt = now;
+
+        List<string> quiescent = null;
+        foreach (var kvp in _byUser)
+        {
+            if (now - kvp.Value.LastTouchedAt >= ChatLimits.AutoThrottleTierDecay)
+            {
+                (quiescent ??= new List<string>()).Add(kvp.Key);
+            }
+        }
+        if (quiescent == null)
+        {
+            return;
+        }
+        foreach (var key in quiescent)
+        {
+            _byUser.Remove(key);
+        }
     }
 
     // Caller must already hold _lock. Records a throttle violation at now, ages out ones older than
     // the rolling window, and — when the count crosses the threshold — escalates into the NEXT tier
     // (10s → 30s → 60s cap; the ladder resets first if AutoThrottleTierDecay has passed since the
     // last trigger), returning the applied duration. Null for a plain non-escalating throttle.
-    private static TimeSpan? RecordViolationAndCheckEscalation(ConnectionState state, DateTime now)
+    private static TimeSpan? RecordViolationAndCheckEscalation(UserState state, DateTime now)
     {
         state.Violations.Add(now);
         var cutoff = now - ChatLimits.AutoThrottleWindow;
@@ -201,12 +244,14 @@ public class MessageRateLimiter
     }
 
     /// <summary>
-    /// All rate-limiting state for a single connection: its per-channel buckets, the shared global
-    /// bucket, the rolling violation timestamps, and an optional hard-throttle deadline. Mutated only
-    /// under the limiter's lock, so plain mutable fields (mirrors the in-place-under-lock idiom of the
-    /// sibling registries).
+    /// All rate-limiting state for a single user (battleTag-keyed — follow-up spec §1): its per-channel
+    /// buckets, the shared global bucket, the rolling violation timestamps, an optional hard-throttle
+    /// deadline, and when it was last touched (<see cref="LastTouchedAt"/>, the quiescent-prune anchor
+    /// consulted by <see cref="MessageRateLimiter.PruneQuiescentNoLock"/>). Mutated only under the
+    /// limiter's lock, so plain mutable fields (mirrors the in-place-under-lock idiom of the sibling
+    /// registries).
     /// </summary>
-    private sealed class ConnectionState
+    private sealed class UserState
     {
         internal readonly TokenBucket GlobalBucket;
         internal readonly Dictionary<string, TokenBucket> ChannelBuckets =
@@ -217,8 +262,11 @@ public class MessageRateLimiter
         // fired (anchors the 10-minute decay). Mutated only under the limiter's lock, like every sibling.
         internal int TierLevel;
         internal DateTime? LastAutoThrottleAt;
+        // Follow-up spec §1: refreshed on every TryAcquire — the anchor PruneQuiescentNoLock uses to
+        // decide whether this user's whole state (buckets, violations, tier, throttle) is quiescent.
+        internal DateTime LastTouchedAt;
 
-        internal ConnectionState(DateTime now)
+        internal UserState(DateTime now)
         {
             // Global bucket: 10 tokens over 5s ⇒ one token every 0.5s. Derived from the constants so
             // the "per 5s" window and the burst stay in one place.
@@ -226,6 +274,7 @@ public class MessageRateLimiter
                 ChatLimits.GlobalMessageBurst,
                 ChatLimits.GlobalMessageWindow / ChatLimits.GlobalMessageBurst,
                 now);
+            LastTouchedAt = now;
         }
 
         internal int ChannelBucketCount => ChannelBuckets.Count;
@@ -243,10 +292,11 @@ public class MessageRateLimiter
         /// <summary>
         /// Drops every per-channel bucket (except <paramref name="keepChannelId"/>) that has sat idle
         /// long enough to be guaranteed full: such a bucket is indistinguishable from a fresh one, so
-        /// removing it is behaviour-preserving and bounds the map to the channels a connection is
-        /// actively sending in. Mirrors <see cref="Sessions.MintRateLimiter"/>'s opportunistic
-        /// stale-window purge — without it a connection blasting a new channel per message (which
-        /// never trips the per-channel bucket) could grow this map without limit until disconnect.
+        /// removing it is behaviour-preserving and bounds the map to the channels a user is actively
+        /// sending in. Mirrors <see cref="Sessions.MintRateLimiter"/>'s opportunistic stale-window
+        /// purge — without it a user blasting a new channel per message (which never trips the
+        /// per-channel bucket) could grow this map without limit for as long as this user's state
+        /// lives, which — now that state survives reconnect — can span far longer than one connection.
         /// </summary>
         internal void PruneIdleChannelBuckets(string keepChannelId, DateTime now)
         {

--- a/W3ChampionsChatService/FanOut/OnlineMemberRegistry.cs
+++ b/W3ChampionsChatService/FanOut/OnlineMemberRegistry.cs
@@ -70,6 +70,30 @@ public class OnlineMemberRegistry
         }
     }
 
+    /// <summary>
+    /// Adds/replaces a single (channelId, connectionId) membership entry like <see cref="Join"/>, but
+    /// never REGRESSES an already-tracked <see cref="MemberState.LastReadSeq"/>: if an entry already
+    /// exists, the stored value becomes <c>Math.Max(existing.LastReadSeq, state.LastReadSeq)</c> instead
+    /// of a plain overwrite; every other field of <paramref name="state"/> (NotificationLevel, etc.) is
+    /// applied as given. <see cref="Chats.ChatHub.GetConversations"/> (2026-08-04 follow-up spec §6)
+    /// calls this instead of <see cref="Join"/>: its per-shell loop awaits a Mongo unread count between
+    /// reading a membership's DB LastReadSeq and seeding it here, so a concurrent <c>MarkRead</c> that
+    /// lands in that window (which advances the registry via <see cref="AdvanceLastReadSeq"/>) must never
+    /// be regressed back down by the now-stale DB value. Absent entry ⇒ identical to <see cref="Join"/>
+    /// (first seed, nothing to preserve). Single locked pass — read-then-write is atomic, no separate
+    /// caller-side TryGetMember/Join TOCTOU window.
+    /// </summary>
+    public void JoinPreservingReadCursor(string channelId, string connectionId, MemberState state)
+    {
+        lock (_lock)
+        {
+            var merged = TryGetNoLock(channelId, connectionId, out var existing)
+                ? state with { LastReadSeq = Math.Max(existing.LastReadSeq, state.LastReadSeq) }
+                : state;
+            JoinNoLock(channelId, connectionId, merged);
+        }
+    }
+
     /// <summary>Removes a single (channelId, connectionId) membership entry. No-op if absent.</summary>
     public void Leave(string channelId, string connectionId)
     {

--- a/W3ChampionsChatService/FanOut/ReadRateLimiter.cs
+++ b/W3ChampionsChatService/FanOut/ReadRateLimiter.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using W3ChampionsChatService.Domain;
+
+namespace W3ChampionsChatService.FanOut;
+
+/// <summary>
+/// The outcome of a single <see cref="ReadRateLimiter.TryAcquire"/> call. Deliberately simpler than
+/// <see cref="RateLimitDecision"/>: there is no escalation signal because this limiter has no violation
+/// ladder (see <see cref="ReadRateLimiter"/>'s class doc).
+/// </summary>
+/// <param name="Allowed">True when the read may proceed (a token was consumed from the bucket).</param>
+/// <param name="RetryAfterSeconds">
+/// When throttled, seconds until the caller could read again — strictly positive. Null when
+/// <paramref name="Allowed"/> is true.
+/// </param>
+public readonly record struct ReadRateLimitDecision(bool Allowed, double? RetryAfterSeconds);
+
+/// <summary>
+/// Pure, deterministic abuse guard for READ-shaped hub methods (2026-08-05 PR36 feedback, Part 3 —
+/// Marco: server protection, NOT UX pacing). <c>GetConversations</c> and <c>GetMessages</c> (the
+/// GetMessages scope decision + its supporting evidence are recorded in the task report) share ONE
+/// per-battleTag token bucket — capacity <see cref="ChatLimits.ReadBurst"/>, refilling
+/// <see cref="ChatLimits.ReadRefillPerSecond"/> tokens/second (burst 30, sustained 5/s — far above any
+/// legitimate client's per-user-action handful of loads).
+/// <para>
+/// Deliberately simpler than <see cref="MessageRateLimiter"/>: a single bucket, no per-channel
+/// dimension, NO violation ladder / hard auto-throttle escalation, and NO
+/// <see cref="Protocol.ChatEvents.ThrottleNotice"/> push. A denial is just the existing typed
+/// <c>Throttled</c> result code with a retry-after — the SAME shape these methods already use for their
+/// relationship-outage fail-closed path, so callers have nothing new to special-case.
+/// </para>
+/// <para>
+/// DELIBERATE DUPLICATION (do not refactor to share code with <see cref="MessageRateLimiter"/>): both
+/// implement a continuous token bucket, but the two limiters' semantics genuinely differ — dual-bucket-
+/// plus-escalation-ladder vs a single bucket with none of that — and forcing a shared abstraction across
+/// that split would cost more than the ~30 lines of duplicated <c>TokenBucket</c> logic it would save.
+/// </para>
+/// <para>
+/// NO timers and NO wall-clock reads: every decision takes an explicit <c>now</c> and refills are
+/// derived from elapsed time, so it is fully testable without sleeping. Singleton, hit concurrently by
+/// many connections — mirrors <see cref="MessageRateLimiter"/>'s single-lock-guards-all-state idiom.
+/// </para>
+/// </summary>
+public class ReadRateLimiter
+{
+    private readonly Dictionary<string, UserBucket> _byUser = new Dictionary<string, UserBucket>();
+
+    private readonly object _lock = new object();
+
+    // Last time PruneQuiescentNoLock actually swept the map — time-gated so the hot path never pays for
+    // an O(n) sweep on every call (mirrors MessageRateLimiter.PruneQuiescentNoLock).
+    private DateTime _lastPruneAt;
+
+    /// <summary>
+    /// Attempts to consume one read for <paramref name="battleTag"/> as of <paramref name="now"/>. State
+    /// is keyed by LOWERCASED battleTag (mirrors <see cref="MessageRateLimiter"/>) so the budget is
+    /// shared across every guarded method and every connection/casing a caller might use. Entries
+    /// quiescent past <see cref="ChatLimits.ReadRateLimiterPruneHorizon"/> are pruned opportunistically,
+    /// bounding the map to roughly the users active within one prune window.
+    /// <para><paramref name="now"/> MUST be a trusted server-side clock read (never client-supplied); the
+    /// bucket fails safe on a backwards clock but assumes a monotone one.</para>
+    /// </summary>
+    public ReadRateLimitDecision TryAcquire(string battleTag, DateTime now)
+    {
+        var key = battleTag.ToLowerInvariant();
+
+        lock (_lock)
+        {
+            PruneQuiescentNoLock(now);
+            var bucket = GetOrCreateBucket(key, now);
+            bucket.LastTouchedAt = now;
+            bucket.Tokens.Refill(now);
+
+            if (bucket.Tokens.HasToken)
+            {
+                bucket.Tokens.Consume();
+                return new ReadRateLimitDecision(true, null);
+            }
+
+            return new ReadRateLimitDecision(false, bucket.Tokens.SecondsUntilToken());
+        }
+    }
+
+    // Test seam (assembly has InternalsVisibleTo): number of tracked user entries — asserts the
+    // quiescent prune keeps the map bounded. Mirrors MessageRateLimiter.TrackedUserCount.
+    internal int TrackedUserCount
+    {
+        get { lock (_lock) { return _byUser.Count; } }
+    }
+
+    // Caller must already hold _lock.
+    private UserBucket GetOrCreateBucket(string key, DateTime now)
+    {
+        if (!_byUser.TryGetValue(key, out var bucket))
+        {
+            bucket = new UserBucket(now);
+            _byUser[key] = bucket;
+        }
+        return bucket;
+    }
+
+    // Caller must already hold _lock. Sweeps at most once per ReadRateLimiterPruneHorizon: an entry idle
+    // that long is guaranteed to hold a full bucket again regardless of how empty it was (the pinned
+    // invariant on ChatLimits.ReadRateLimiterPruneHorizon), so removing it and letting a later call
+    // recreate it fresh is behaviour-preserving. Gated by time (not run on every call) because TryAcquire
+    // is the hot path — a full-map sweep on every read would be O(n) per call.
+    private void PruneQuiescentNoLock(DateTime now)
+    {
+        if (now - _lastPruneAt < ChatLimits.ReadRateLimiterPruneHorizon)
+        {
+            return;
+        }
+        _lastPruneAt = now;
+
+        List<string> quiescent = null;
+        foreach (var kvp in _byUser)
+        {
+            if (now - kvp.Value.LastTouchedAt >= ChatLimits.ReadRateLimiterPruneHorizon)
+            {
+                (quiescent ??= new List<string>()).Add(kvp.Key);
+            }
+        }
+        if (quiescent == null)
+        {
+            return;
+        }
+        foreach (var key in quiescent)
+        {
+            _byUser.Remove(key);
+        }
+    }
+
+    /// <summary>One user's read-bucket state: the token bucket itself plus when it was last touched (the
+    /// quiescent-prune anchor). Mutated only under the limiter's lock, so plain mutable fields (mirrors
+    /// MessageRateLimiter.UserState).</summary>
+    private sealed class UserBucket
+    {
+        internal readonly TokenBucket Tokens;
+        internal DateTime LastTouchedAt;
+
+        internal UserBucket(DateTime now)
+        {
+            Tokens = new TokenBucket(
+                ChatLimits.ReadBurst,
+                TimeSpan.FromSeconds(1.0 / ChatLimits.ReadRefillPerSecond),
+                now);
+            LastTouchedAt = now;
+        }
+    }
+
+    /// <summary>
+    /// A continuous token bucket: starts full (burst available immediately) and regenerates one token
+    /// every <c>refillPerToken</c> of elapsed time, capped at capacity. Deterministic — all motion is
+    /// driven by the <c>now</c> handed to <see cref="Refill"/>. Deliberately duplicated from
+    /// <see cref="MessageRateLimiter"/>'s private nested type of the same name (see this file's class
+    /// doc) rather than shared — independently owned so the two limiters can diverge freely.
+    /// </summary>
+    private sealed class TokenBucket
+    {
+        private readonly double _capacity;
+        private readonly double _refillPerTokenSeconds;
+        private double _tokens;
+        private DateTime _lastRefill;
+
+        internal TokenBucket(double capacity, TimeSpan refillPerToken, DateTime now)
+        {
+            _capacity = capacity;
+            _refillPerTokenSeconds = refillPerToken.TotalSeconds;
+            _tokens = capacity;
+            _lastRefill = now;
+        }
+
+        internal bool HasToken => _tokens >= 1.0;
+
+        internal void Refill(DateTime now)
+        {
+            // Guard non-monotonic / same-instant calls: never subtract, never over-count.
+            if (now <= _lastRefill)
+            {
+                return;
+            }
+
+            var elapsedSeconds = (now - _lastRefill).TotalSeconds;
+            _tokens = Math.Min(_capacity, _tokens + elapsedSeconds / _refillPerTokenSeconds);
+            _lastRefill = now;
+        }
+
+        internal void Consume() => _tokens -= 1.0;
+
+        /// <summary>Seconds until this bucket next holds a whole token (0 if it already does).</summary>
+        internal double SecondsUntilToken()
+        {
+            if (_tokens >= 1.0)
+            {
+                return 0;
+            }
+            return (1.0 - _tokens) * _refillPerTokenSeconds;
+        }
+    }
+}

--- a/W3ChampionsChatService/FanOut/ReadRateLimiter.cs
+++ b/W3ChampionsChatService/FanOut/ReadRateLimiter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Serilog;
 using W3ChampionsChatService.Domain;
 
 namespace W3ChampionsChatService.FanOut;
@@ -40,7 +41,12 @@ public readonly record struct ReadRateLimitDecision(bool Allowed, double? RetryA
 /// <para>
 /// NO timers and NO wall-clock reads: every decision takes an explicit <c>now</c> and refills are
 /// derived from elapsed time, so it is fully testable without sleeping. Singleton, hit concurrently by
-/// many connections — mirrors <see cref="MessageRateLimiter"/>'s single-lock-guards-all-state idiom.
+/// many connections — mirrors <see cref="MessageRateLimiter"/>'s single-lock-guards-all-state idiom. The
+/// one exception is the denial <see cref="Log.Warning"/> (fix round 1, finding F3 — denials were
+/// otherwise invisible to operators): the once-per-<see cref="ChatLimits.ReadRateLimiterDenyLogInterval"/>
+/// decision and its <c>LastDenyLoggedAt</c> stamp are computed/mutated INSIDE the lock, but the actual
+/// log I/O is deliberately emitted AFTER releasing it — no I/O under lock, mirroring
+/// <see cref="MessageRateLimiter"/>'s own moderation-log idiom exactly.
 /// </para>
 /// </summary>
 public class ReadRateLimiter
@@ -65,6 +71,8 @@ public class ReadRateLimiter
     public ReadRateLimitDecision TryAcquire(string battleTag, DateTime now)
     {
         var key = battleTag.ToLowerInvariant();
+        ReadRateLimitDecision decision;
+        bool shouldLog;
 
         lock (_lock)
         {
@@ -79,8 +87,33 @@ public class ReadRateLimiter
                 return new ReadRateLimitDecision(true, null);
             }
 
-            return new ReadRateLimitDecision(false, bucket.Tokens.SecondsUntilToken());
+            decision = new ReadRateLimitDecision(false, bucket.Tokens.SecondsUntilToken());
+
+            // Fix round 1, finding F3: shouldLog + the LastDenyLoggedAt stamp are both decided/mutated
+            // HERE, inside the lock — the state transition (has enough time passed since the last logged
+            // denial for THIS user) must be atomic, or two concurrent denials could both observe a stale
+            // stamp and both decide to log. The actual Log.Warning call happens after the lock is
+            // released (below) — see this class's doc comment for why.
+            shouldLog = bucket.LastDenyLoggedAt is null
+                || now - bucket.LastDenyLoggedAt >= ChatLimits.ReadRateLimiterDenyLogInterval;
+            if (shouldLog)
+            {
+                bucket.LastDenyLoggedAt = now;
+            }
         }
+
+        if (shouldLog)
+        {
+            // ORIGINAL-casing battleTag (not the internal lowercased `key`) — mirrors
+            // MessageRateLimiter's log-searchability convention, so a case-sensitive log search for a
+            // particular battleTag finds this line too.
+            Log.Warning(
+                "Read rate limit denied {BattleTag} (retryAfter {RetryAfterSeconds}s)",
+                battleTag,
+                decision.RetryAfterSeconds);
+        }
+
+        return decision;
     }
 
     // Test seam (assembly has InternalsVisibleTo): number of tracked user entries — asserts the
@@ -88,6 +121,19 @@ public class ReadRateLimiter
     internal int TrackedUserCount
     {
         get { lock (_lock) { return _byUser.Count; } }
+    }
+
+    // Test seam (assembly has InternalsVisibleTo): the last time a denial was logged for battleTag, or
+    // null if never logged (including "no tracked bucket at all"). UserBucket is a private nested type,
+    // so this is the only way outside the lock for a test to observe the once-per-
+    // ReadRateLimiterDenyLogInterval logging decision (fix round 1, finding F3) without a log-capture
+    // harness — none exists in this test suite, so the tests assert this stamp/refresh behavior directly.
+    internal DateTime? LastDenyLoggedAtFor(string battleTag)
+    {
+        lock (_lock)
+        {
+            return _byUser.TryGetValue(battleTag.ToLowerInvariant(), out var bucket) ? bucket.LastDenyLoggedAt : null;
+        }
     }
 
     // Caller must already hold _lock.
@@ -139,6 +185,12 @@ public class ReadRateLimiter
     {
         internal readonly TokenBucket Tokens;
         internal DateTime LastTouchedAt;
+
+        // Fix round 1, finding F3: when this user's denial was last logged — null until the first
+        // denial. Test seam (assembly has InternalsVisibleTo, mirrors TrackedUserCount below): tests
+        // assert the stamp/refresh behavior directly rather than via a log-capture harness (none exists
+        // in this test suite).
+        internal DateTime? LastDenyLoggedAt;
 
         internal UserBucket(DateTime now)
         {

--- a/W3ChampionsChatService/FanOut/ReadRateLimiter.cs
+++ b/W3ChampionsChatService/FanOut/ReadRateLimiter.cs
@@ -21,8 +21,9 @@ public readonly record struct ReadRateLimitDecision(bool Allowed, double? RetryA
 /// Marco: server protection, NOT UX pacing). <c>GetConversations</c> and <c>GetMessages</c> (the
 /// GetMessages scope decision + its supporting evidence are recorded in the task report) share ONE
 /// per-battleTag token bucket — capacity <see cref="ChatLimits.ReadBurst"/>, refilling
-/// <see cref="ChatLimits.ReadRefillPerSecond"/> tokens/second (burst 30, sustained 5/s — far above any
-/// legitimate client's per-user-action handful of loads).
+/// <see cref="ChatLimits.ReadRefillPerSecond"/> tokens/second (burst 60, sustained 5/s — sized for the
+/// CONNECT FAN-OUT shape, not a per-user-action handful of loads; see <see cref="ChatLimits.ReadBurst"/>'s
+/// doc comment for the full rationale, fix round 1 finding F1).
 /// <para>
 /// Deliberately simpler than <see cref="MessageRateLimiter"/>: a single bucket, no per-channel
 /// dimension, NO violation ladder / hard auto-throttle escalation, and NO

--- a/W3ChampionsChatService/Memberships/MembershipRepository.cs
+++ b/W3ChampionsChatService/Memberships/MembershipRepository.cs
@@ -59,10 +59,18 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
         return Memberships.Find(m => m.ChannelId == channelId && m.BattleTag == tag).FirstOrDefaultAsync();
     }
 
+    // 2026-08-04 follow-up (carried launcher-review item): sorted JoinedAt ascending — without an
+    // explicit sort Mongo returns natural/insertion order (arbitrary, not contractual), which the
+    // launcher was silently relying on to preserve "join order" for name-joinable (SemiPublic) channels
+    // across a reconnect. SessionStateAssembler.AssembleAndSeed (and every other caller) consumes this
+    // list straight through for the non-DM slice of SessionStateDto.Channels, so sorting once here
+    // fixes the contract at the single durable choke point rather than re-sorting at every call site.
+    // The bounded, recency-ordered 1:1-DM slice (follow-up spec §6, SelectSnapshotMemberships) is
+    // unaffected — it re-sorts its own DM subset by LastMessageAt regardless of this base ordering.
     public Task<List<ChannelMembership>> LoadForUser(string battleTag)
     {
         var tag = NormalizeTag(battleTag);
-        return Memberships.Find(m => m.BattleTag == tag).ToListAsync();
+        return Memberships.Find(m => m.BattleTag == tag).SortBy(m => m.JoinedAt).ToListAsync();
     }
 
     public Task Delete(string channelId, string battleTag)

--- a/W3ChampionsChatService/Memberships/MembershipRepository.cs
+++ b/W3ChampionsChatService/Memberships/MembershipRepository.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -73,6 +72,19 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
         return Memberships.Find(m => m.BattleTag == tag).SortBy(m => m.JoinedAt).ToListAsync();
     }
 
+    /// <summary>
+    /// Minimal-payload sibling of <see cref="LoadForUser"/> (2026-08-05 PR36 feedback, Part 3) — a
+    /// projected read returning ONLY the <see cref="ChannelMembership.ChannelId"/> values for a user,
+    /// never the full membership documents. Backs <see cref="CountNameJoinableMembershipsForUser"/>,
+    /// which only ever needs the id set. No sort (callers of this projection don't need ordering; unlike
+    /// <see cref="LoadForUser"/>, whose JoinedAt-ascending sort is a client-order contract).
+    /// </summary>
+    public Task<List<string>> LoadChannelIdsForUser(string battleTag)
+    {
+        var tag = NormalizeTag(battleTag);
+        return Memberships.Find(m => m.BattleTag == tag).Project(m => m.ChannelId).ToListAsync();
+    }
+
     public Task Delete(string channelId, string battleTag)
     {
         var tag = NormalizeTag(battleTag);
@@ -99,24 +111,27 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
 
     /// <summary>
     /// Membership cap gate (acceptance 10) — counts only name-joinable (Public + SemiPublic)
-    /// memberships; System/Dm/GroupDm never count against the cap. KISS at realistic
-    /// per-user scale (a user's channel count is bounded, in practice far under 50):
-    /// LoadForUser + ChannelRepository.LoadByIds type filter, no new aggregation pipeline.
+    /// memberships; System/Dm/GroupDm never count against the cap.
+    /// <para>
+    /// 2026-08-05 PR36 feedback (Part 3): previously loaded the caller's FULL membership documents
+    /// (<c>LoadForUser</c>, DMs included) and the FULL channel documents behind them
+    /// (<c>ChannelRepository.LoadByIds</c>) just to count a type-filtered subset client-side — wasted
+    /// payload for a call site (<c>ChatHub.Channels.JoinChannel</c>'s join-by-name path) that only ever
+    /// needs a number. Rewritten to two minimal round-trips: (1) <see cref="LoadChannelIdsForUser"/>, a
+    /// projected membership read returning ONLY ChannelId values; (2)
+    /// <see cref="Channels.ChannelRepository.CountNameJoinableAmongIds"/>, a server-side
+    /// <c>CountDocumentsAsync(Id ∈ ids AND (Type == Public OR Type == SemiPublic))</c>. Same semantics as
+    /// before — the unique <c>ux_channelId_battleTag</c> index guarantees at most one membership per
+    /// (channel, user), so distinct channel ids among a user's memberships correspond 1:1 with the
+    /// memberships themselves.
+    /// </para>
     /// </summary>
     public async Task<int> CountNameJoinableMembershipsForUser(string battleTag)
     {
-        var memberships = await LoadForUser(battleTag);
-        if (memberships.Count == 0) return 0;
+        var channelIds = await LoadChannelIdsForUser(battleTag);
+        if (channelIds.Count == 0) return 0;
 
-        // Reuses the injected ChannelRepository so the type filter reuses LoadByIds rather than
-        // duplicating its query.
-        var channels = await channelRepository.LoadByIds(memberships.Select(m => m.ChannelId));
-        var nameJoinableChannelIds = channels
-            .Where(c => c.Type == ChannelType.Public || c.Type == ChannelType.SemiPublic)
-            .Select(c => c.Id)
-            .ToHashSet();
-
-        return memberships.Count(m => nameJoinableChannelIds.Contains(m.ChannelId));
+        return (int)await channelRepository.CountNameJoinableAmongIds(channelIds);
     }
 
     /// <summary>All memberships of one channel (C5 D12) — legitimate here: the never-enumerate-

--- a/W3ChampionsChatService/Memberships/MembershipRepository.cs
+++ b/W3ChampionsChatService/Memberships/MembershipRepository.cs
@@ -74,8 +74,10 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
 
     /// <summary>
     /// Minimal-payload sibling of <see cref="LoadForUser"/> (2026-08-05 PR36 feedback, Part 3) — a
-    /// projected read returning ONLY the <see cref="ChannelMembership.ChannelId"/> values for a user,
-    /// never the full membership documents. Backs <see cref="CountNameJoinableMembershipsForUser"/>,
+    /// projected read returning ONLY the <see cref="ChannelMembership.ChannelId"/> values for a user —
+    /// minimal WIRE payload (the server still fetches the documents; ix_battleTag_joinedAt is
+    /// BattleTag-prefixed only, so the projection is not index-covered — the point is that no document
+    /// bodies cross the wire). Backs <see cref="CountNameJoinableMembershipsForUser"/>,
     /// which only ever needs the id set. No sort (callers of this projection don't need ordering; unlike
     /// <see cref="LoadForUser"/>, whose JoinedAt-ascending sort is a client-order contract).
     /// </summary>

--- a/W3ChampionsChatService/Memberships/NotificationPreference.cs
+++ b/W3ChampionsChatService/Memberships/NotificationPreference.cs
@@ -1,0 +1,30 @@
+using System;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using W3ChampionsChatService.Domain;
+
+namespace W3ChampionsChatService.Memberships;
+
+/// <summary>
+/// PR36 follow-up (task-1-brief.md, D2): one doc per (battleTag, channelId) holding the LAST
+/// EXPLICITLY-set <see cref="NotificationLevel"/> for a name-joinable (Public/SemiPublic) room — the
+/// durable carrier that survives a leave/rejoin cycle, since <see cref="ChannelMembership"/> itself does
+/// not (<c>ChatHub.LeaveChannel</c> hard-deletes the membership row). Written ONLY by
+/// <c>ChatHub.SetNotificationLevel</c> for Public/SemiPublic channels; read by <c>ChatHub.JoinChannel</c>
+/// (seeds a (re)joined membership with the persisted level instead of the fresh-join
+/// <see cref="NotificationLevel.Mentions"/> default) and by <see cref="Mentions.MentionFanOut"/>'s
+/// non-member Public branch (keeps a mention silenced for a room the target left after opting out).
+/// Independent of <see cref="ChannelMembership"/>'s lifecycle by design — leaving stays a hard delete;
+/// this collection is what carries the setting across.
+/// </summary>
+public class NotificationPreference
+{
+    public string Id { get; set; } = ObjectId.GenerateNewId().ToString();
+    public string BattleTag { get; set; }
+    public string ChannelId { get; set; }
+
+    [BsonRepresentation(BsonType.String)]
+    public NotificationLevel NotificationLevel { get; set; }
+
+    public DateTime UpdatedAt { get; set; }
+}

--- a/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
+++ b/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
@@ -68,7 +68,7 @@ public class NotificationPreferenceRepository(MongoClient mongoClient) : MongoDb
             // string-typed Id property here cannot deserialize back (a BsonSerializationException on the
             // very next Load).
             .SetOnInsert(p => p.Id, ObjectId.GenerateNewId().ToString());
-        var options = new FindOneAndUpdateOptions<NotificationPreference> { IsUpsert = true };
+        var options = new FindOneAndUpdateOptions<NotificationPreference> { IsUpsert = true, ReturnDocument = ReturnDocument.After };
 
         return RetryOnceOnDuplicateKey(() => Prefs.FindOneAndUpdateAsync(filter, update, options));
     }

--- a/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
+++ b/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using W3ChampionsChatService.Domain;
 
@@ -47,7 +48,12 @@ public class NotificationPreferenceRepository(MongoClient mongoClient) : MongoDb
             .Set(p => p.NotificationLevel, level)
             .Set(p => p.UpdatedAt, now)
             .SetOnInsert(p => p.BattleTag, tag)
-            .SetOnInsert(p => p.ChannelId, channelId);
+            .SetOnInsert(p => p.ChannelId, channelId)
+            // Explicit string _id on insert (mirrors MembershipRepository.InsertIfAbsent) — an upsert
+            // that never names _id would otherwise let Mongo assign its own native ObjectId, which the
+            // string-typed Id property here cannot deserialize back (a BsonSerializationException on the
+            // very next Load).
+            .SetOnInsert(p => p.Id, ObjectId.GenerateNewId().ToString());
 
         return Prefs.UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true });
     }

--- a/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
+++ b/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
@@ -39,8 +39,19 @@ public class NotificationPreferenceRepository(MongoClient mongoClient) : MongoDb
     /// by the unique <c>ux_battleTag_channelId</c> index (<see cref="Domain.ChatDomainIndexes"/>), so a
     /// repeated set for the same (battleTag, channelId) overwrites the existing row rather than
     /// accumulating duplicates.
+    /// <para>
+    /// Fix round 1 (F1): a plain <c>$setOnInsert</c> + <c>IsUpsert</c> races against the unique index —
+    /// two callers upserting the same not-yet-existing (battleTag, channelId) at the same instant can
+    /// make the LOSING call's insert half violate <c>ux_battleTag_channelId</c>. Mirrors
+    /// <see cref="MembershipRepository.InsertIfAbsent"/> / <c>ChannelRepository.FindOrCreate*</c>'s
+    /// established fix for this exact race: use the findAndModify form (<c>FindOneAndUpdateAsync</c>,
+    /// NOT <c>UpdateOneAsync</c>) wrapped in <see cref="MongoDbRepositoryBase.RetryOnceOnDuplicateKey{T}"/>
+    /// — that helper only catches the <see cref="MongoCommandException"/>{Code==11000} shape findAndModify
+    /// throws, not the <see cref="MongoWriteException"/> a plain <c>UpdateOneAsync</c> would throw instead,
+    /// so the write MUST go through <c>FindOneAndUpdateAsync</c> for the retry to actually catch the race.
+    /// </para>
     /// </summary>
-    public Task Upsert(string battleTag, string channelId, NotificationLevel level, DateTime now)
+    public Task<NotificationPreference> Upsert(string battleTag, string channelId, NotificationLevel level, DateTime now)
     {
         var tag = NormalizeTag(battleTag);
         var filter = Builders<NotificationPreference>.Filter.Where(p => p.BattleTag == tag && p.ChannelId == channelId);
@@ -54,7 +65,8 @@ public class NotificationPreferenceRepository(MongoClient mongoClient) : MongoDb
             // string-typed Id property here cannot deserialize back (a BsonSerializationException on the
             // very next Load).
             .SetOnInsert(p => p.Id, ObjectId.GenerateNewId().ToString());
+        var options = new FindOneAndUpdateOptions<NotificationPreference> { IsUpsert = true };
 
-        return Prefs.UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true });
+        return RetryOnceOnDuplicateKey(() => Prefs.FindOneAndUpdateAsync(filter, update, options));
     }
 }

--- a/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
+++ b/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3ChampionsChatService.Domain;
+
+namespace W3ChampionsChatService.Memberships;
+
+/// <summary>
+/// PR36 follow-up (D2): durable (battleTag, channelId) → last-explicitly-set <see cref="NotificationLevel"/>
+/// store — see <see cref="NotificationPreference"/>'s class doc for the write/seed/consult wiring.
+/// <para>
+/// BATTLETAG KEY CONVENTION: mirrors <see cref="MembershipRepository"/> and
+/// <see cref="Mentions.MentionInboxRepository"/> — the persisted <see cref="NotificationPreference.BattleTag"/>
+/// is ALWAYS stored lowercased, and every read/write below lowercases its incoming <c>battleTag</c>
+/// argument before building the Mongo filter, so a caller may pass the JWT-cased identity battleTag
+/// straight through.
+/// </para>
+/// </summary>
+public class NotificationPreferenceRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient)
+{
+    private IMongoCollection<NotificationPreference> Prefs =>
+        CreateCollection<NotificationPreference>(ChatCollections.NotificationPreferences);
+
+    /// <summary>Lowercases a battleTag to the durable notification-preference key convention (see the class doc).</summary>
+    private static string NormalizeTag(string battleTag) => battleTag.ToLowerInvariant();
+
+    /// <summary>The last explicitly-set level for (battleTag, channelId), or null if one was never set
+    /// (or was set and the collection has since been pruned — callers must treat null as "no opinion",
+    /// never as an implicit None).</summary>
+    public Task<NotificationPreference> Load(string battleTag, string channelId)
+    {
+        var tag = NormalizeTag(battleTag);
+        return Prefs.Find(p => p.BattleTag == tag && p.ChannelId == channelId).FirstOrDefaultAsync();
+    }
+
+    /// <summary>
+    /// Idempotent last-write-wins upsert — <c>ChatHub.SetNotificationLevel</c>'s sole write path. Backed
+    /// by the unique <c>ux_battleTag_channelId</c> index (<see cref="Domain.ChatDomainIndexes"/>), so a
+    /// repeated set for the same (battleTag, channelId) overwrites the existing row rather than
+    /// accumulating duplicates.
+    /// </summary>
+    public Task Upsert(string battleTag, string channelId, NotificationLevel level, DateTime now)
+    {
+        var tag = NormalizeTag(battleTag);
+        var filter = Builders<NotificationPreference>.Filter.Where(p => p.BattleTag == tag && p.ChannelId == channelId);
+        var update = Builders<NotificationPreference>.Update
+            .Set(p => p.NotificationLevel, level)
+            .Set(p => p.UpdatedAt, now)
+            .SetOnInsert(p => p.BattleTag, tag)
+            .SetOnInsert(p => p.ChannelId, channelId);
+
+        return Prefs.UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true });
+    }
+}

--- a/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
+++ b/W3ChampionsChatService/Memberships/NotificationPreferenceRepository.cs
@@ -51,7 +51,10 @@ public class NotificationPreferenceRepository(MongoClient mongoClient) : MongoDb
     /// so the write MUST go through <c>FindOneAndUpdateAsync</c> for the retry to actually catch the race.
     /// </para>
     /// </summary>
-    public Task<NotificationPreference> Upsert(string battleTag, string channelId, NotificationLevel level, DateTime now)
+    // virtual: a test seam (mirroring MembershipRepository.LoadForChannel / MentionInboxRepository.Insert)
+    // so a test double can simulate a write failure here — exercises the ChatHub.SetNotificationLevel
+    // best-effort posture (fix round 1, F5) without needing a real Mongo fault.
+    public virtual Task<NotificationPreference> Upsert(string battleTag, string channelId, NotificationLevel level, DateTime now)
     {
         var tag = NormalizeTag(battleTag);
         var filter = Builders<NotificationPreference>.Filter.Where(p => p.BattleTag == tag && p.ChannelId == channelId);

--- a/W3ChampionsChatService/Mentions/MentionFanOut.cs
+++ b/W3ChampionsChatService/Mentions/MentionFanOut.cs
@@ -10,6 +10,7 @@ using W3ChampionsChatService.Memberships;
 using W3ChampionsChatService.Messages;
 using W3ChampionsChatService.Protocol;
 using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
 
 namespace W3ChampionsChatService.Mentions;
 
@@ -33,7 +34,10 @@ namespace W3ChampionsChatService.Mentions;
 /// non-participant. This wall is the SOLE authority on who is notified: the send-side gate (step 5.25)
 /// validates only the mention COUNT cap — never resolvability or membership — so mentioning a non-member
 /// (or an unresolvable/garbage tag) is legal content that delivers verbatim and simply notifies nobody
-/// here.</item>
+/// here. Follow-up spec §4 EXCEPTION: for <see cref="ChannelType.Public"/> rooms only, a target with NO
+/// membership row is still eligible provided the tag resolves to a <see cref="UserDirectoryRepository"/>
+/// row — a public room's excerpt is public content, so the membership wall protects nothing there;
+/// Dm/GroupDm/SemiPublic/System are unaffected and keep the membership wall exactly as before.</item>
 /// <item>The target's membership <see cref="ChannelMembership.NotificationLevel"/> is not
 /// <see cref="NotificationLevel.None"/> — "none: silence" (spec §7) is an explicit opt-out that outranks
 /// mentions, not just level-All activity.</item>
@@ -69,7 +73,8 @@ public class MentionFanOut(
     IHubContext<ChatHub> hubContext,
     ISessionRegistry sessionRegistry,
     MembershipRepository membershipRepository,
-    MentionInboxRepository mentionInboxRepository)
+    MentionInboxRepository mentionInboxRepository,
+    UserDirectoryRepository userDirectory)
 {
     // The SignalR delivery channel — pushes the targeted MentionNotified to a specific connection.
     private readonly IHubContext<ChatHub> _hubContext = hubContext;
@@ -82,6 +87,10 @@ public class MentionFanOut(
 
     // The offline mention-notification store — one row per eligible target per mentioning message.
     private readonly MentionInboxRepository _mentionInboxRepository = mentionInboxRepository;
+
+    // Follow-up spec §4: resolvability source for PUBLIC-room mentions of non-members — the same D14
+    // existence check OpenDm uses. Read ONLY on the public/no-membership branch below.
+    private readonly UserDirectoryRepository _userDirectory = userDirectory;
 
     /// <summary>
     /// Fans a persisted, non-shadow message's validated mention tags out to the eligible members —
@@ -127,28 +136,37 @@ public class MentionFanOut(
                 // (Dm/GroupDm) conversation's excerpt must NEVER reach a non-participant. Load lowercases
                 // the tag internally (C5 T4 key convention), so the display-cased mention tag matches.
                 var membership = await _membershipRepository.Load(channel.Id, tag);
-                if (membership == null)
+                if (membership != null)
                 {
-                    continue;
+                    // Rules (d)/(e) — unchanged for JOINED targets: an explicit NotificationLevel.None
+                    // opt-out outranks mentions, and a decline-suppressed Dm recipient is never pinged.
+                    if (membership.NotificationLevel == NotificationLevel.None)
+                    {
+                        continue;
+                    }
+                    if (membership.DeclinedUntil.HasValue && membership.DeclinedUntil.Value > now)
+                    {
+                        continue;
+                    }
                 }
-
-                // Rule (d): "none: silence" (spec §7) outranks mentions — an explicit opt-out suppresses
-                // the mention too, not just level-All activity.
-                if (membership.NotificationLevel == NotificationLevel.None)
+                else if (channel.Type == ChannelType.Public)
                 {
-                    continue;
+                    // Follow-up spec §4: PUBLIC rooms are mentionable WITHOUT membership — a public
+                    // room's excerpt is public content, so rule (c)'s wall protects nothing here. The
+                    // target must still be a RESOLVABLE user (a user_directory row; Load lowercases the
+                    // display-cased tag), so garbage tags keep producing nothing. v1 accepted gap: a
+                    // non-member cannot silence mentions from a room they haven't joined — join +
+                    // NotificationLevel.None (the membership branch above) is the opt-out.
+                    var directoryEntry = await _userDirectory.Load(tag);
+                    if (directoryEntry == null)
+                    {
+                        continue;
+                    }
                 }
-
-                // Rule (e): the C5 decline-suppression window (D3). A pending-Dm recipient who DECLINED
-                // keeps their membership at NotificationLevel.All — a decline sets ONLY DeclinedUntil
-                // (ChatHub.Dm.DeclineRequest) and never lowers the level — so rules (c)/(d) alone would let
-                // the initiator's pending mentions ping straight through the 24h soft-suppression window,
-                // contradicting the C5 guarantee that a declined request never pings them. Mirror
-                // SessionStateAssembler.BuildPendingDmTray's `DeclinedUntil > now` boundary against the SAME
-                // trusted `now` this send already read (not a fresh clock) — the window is temporal, so an
-                // elapsed DeclinedUntil resumes normal notification (self-heals in 24h).
-                if (membership.DeclinedUntil.HasValue && membership.DeclinedUntil.Value > now)
+                else
                 {
+                    // Rule (c) — UNCHANGED for every non-public type: the Dm/GroupDm excerpt PRIVACY
+                    // WALL, and SemiPublic/System keep the membership wall too (§4 widens Public only).
                     continue;
                 }
 

--- a/W3ChampionsChatService/Mentions/MentionFanOut.cs
+++ b/W3ChampionsChatService/Mentions/MentionFanOut.cs
@@ -9,6 +9,7 @@ using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.Memberships;
 using W3ChampionsChatService.Messages;
 using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Relationships;
 using W3ChampionsChatService.Sessions;
 using W3ChampionsChatService.Users;
 
@@ -46,6 +47,13 @@ namespace W3ChampionsChatService.Mentions;
 /// recipient who DECLINED (C5 D3's 24h soft window) must never be pinged by the initiator's mentions, even
 /// though a decline never lowers the membership level. Mirrors
 /// <see cref="SessionStateAssembler.BuildPendingDmTray"/>, which hides the same window from the tray.</item>
+/// <item>PR36 follow-up (D1): the TARGET has NOT blocked the sender — checked LAST, only for a target
+/// that is otherwise eligible per rules (a)-(e) above, via <see cref="IRelationshipProvider.GetSnapshotAsync"/>
+/// on the TARGET's own tag (direction matters: sender-side blocking is deliberately out of scope here —
+/// see the per-target body for the one-line note). FAIL OPEN on a provider failure: a relationship-service
+/// outage DELIVERS the mention rather than suppressing it (never breaks the send pipeline or blanket-mutes
+/// every mention). This is a notification-only gate — the message and its mention chip still render
+/// normally in the channel for everyone; only the inbox entry + push are withheld from a blocking target.</item>
 /// </list>
 /// FOCUS IS IRRELEVANT here (unlike C3 activity routing, which suppresses focused members): a focused
 /// target STILL gets the entry + event. The server never guesses whether a mention was "seen"; a
@@ -74,7 +82,14 @@ public class MentionFanOut(
     ISessionRegistry sessionRegistry,
     MembershipRepository membershipRepository,
     MentionInboxRepository mentionInboxRepository,
-    UserDirectoryRepository userDirectory)
+    UserDirectoryRepository userDirectory,
+    // PR36 follow-up (D1): the block-enforcement source — GetSnapshotAsync is read for the TARGET's own
+    // tag, ONLY for a target that already cleared the cheap eligibility checks below (bounded to at most
+    // ChatLimits.MaxMentionsPerMessage calls per message).
+    IRelationshipProvider relationshipProvider,
+    // PR36 follow-up (D2): the persisted-preference carrier — consulted in the non-member Public branch
+    // so a target who opted out (None) before leaving a room stays silenced even without a membership row.
+    NotificationPreferenceRepository notificationPreferenceRepository)
 {
     // The SignalR delivery channel — pushes the targeted MentionNotified to a specific connection.
     private readonly IHubContext<ChatHub> _hubContext = hubContext;
@@ -92,9 +107,15 @@ public class MentionFanOut(
     // existence check OpenDm uses. Read ONLY on the public/no-membership branch below.
     private readonly UserDirectoryRepository _userDirectory = userDirectory;
 
+    // PR36 follow-up (D1): the block-enforcement source — see the ctor param doc comment above.
+    private readonly IRelationshipProvider _relationshipProvider = relationshipProvider;
+
+    // PR36 follow-up (D2): the persisted-preference carrier — see the ctor param doc comment above.
+    private readonly NotificationPreferenceRepository _notificationPreferenceRepository = notificationPreferenceRepository;
+
     /// <summary>
     /// Fans a persisted, non-shadow message's validated mention tags out to the eligible members —
-    /// see the class doc for the five eligibility rules and the fault-isolation contract.
+    /// see the class doc for the six eligibility rules and the fault-isolation contract.
     /// <paramref name="now"/> is the trusted server clock the hub already read once for this send
     /// (threaded in, not re-read, so the entry's CreatedAt/ExpiresAt decide against the same instant).
     /// </summary>
@@ -157,11 +178,23 @@ public class MentionFanOut(
                     // Follow-up spec §4: PUBLIC rooms are mentionable WITHOUT membership — a public
                     // room's excerpt is public content, so rule (c)'s wall protects nothing here. The
                     // target must still be a RESOLVABLE user (a user_directory row; Load lowercases the
-                    // display-cased tag), so garbage tags keep producing nothing. v1 accepted gap: a
-                    // non-member cannot silence mentions from a room they haven't joined — join +
-                    // NotificationLevel.None (the membership branch above) is the opt-out.
+                    // display-cased tag), so garbage tags keep producing nothing. PR36 follow-up (D2)
+                    // narrowed the v1 gap here — see the pref check right below.
                     var directoryEntry = await _userDirectory.Load(tag);
                     if (directoryEntry == null)
+                    {
+                        continue;
+                    }
+
+                    // PR36 follow-up (D2): the narrowed v1 gap — a non-member can silence mentions from
+                    // a room they haven't (re)joined by: join → NotificationLevel.None → leave. Leave
+                    // hard-deletes the membership row (so rule (c) above no longer sees it), but the
+                    // LAST EXPLICITLY-SET level persists independently here (written by
+                    // ChatHub.SetNotificationLevel, and seeded back into a rejoined membership by
+                    // JoinChannel). Only an explicit None suppresses; any other level, or no pref at all
+                    // (never explicitly set), delivers normally.
+                    var pref = await _notificationPreferenceRepository.Load(tag, channel.Id);
+                    if (pref != null && pref.NotificationLevel == NotificationLevel.None)
                     {
                         continue;
                     }
@@ -171,6 +204,36 @@ public class MentionFanOut(
                     // Rule (c) — UNCHANGED for every non-public type: the Dm/GroupDm excerpt PRIVACY
                     // WALL, and SemiPublic/System keep the membership wall too (§4 widens Public only).
                     continue;
+                }
+
+                // PR36 follow-up (D1): block suppression, consulted LAST — the target has cleared every
+                // cheap check above and is otherwise ELIGIBLE, so this is the only point a relationship
+                // snapshot fetch (worst case a wb HTTP round-trip) ever runs, bounded to at most
+                // ChatLimits.MaxMentionsPerMessage calls for this message. Direction is deliberate: only
+                // the TARGET's OWN block list matters here — sender-side blocking (the sender having
+                // blocked the target) is out of scope for mention gating and is never consulted.
+                // OUTAGE POSTURE — FAIL OPEN: this catch is LOCAL (not the per-target catch below), so a
+                // relationship-provider failure — including RelationshipUnavailableException once the
+                // provider's own stale-cache fallback is exhausted — DELIVERS the mention instead of
+                // suppressing it. A relationship outage must never blanket-mute every mention or break
+                // the send pipeline; it only means this one target's block state couldn't be proven, and
+                // we default to delivering rather than guessing a block.
+                try
+                {
+                    var targetSnapshot = await _relationshipProvider.GetSnapshotAsync(tag);
+                    if (targetSnapshot.HasBlocked(message.Sender?.BattleTag))
+                    {
+                        continue;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(
+                        ex,
+                        "Relationship snapshot unavailable for mention target {Tag} on channel {ChannelId} for message {MessageId} — delivering fail-open",
+                        tag,
+                        channel.Id,
+                        message.Id);
                 }
 
                 // Eligible. Write the offline inbox entry FIRST — its id rides in the event payload. Expiry

--- a/W3ChampionsChatService/Mentions/MentionFanOut.cs
+++ b/W3ChampionsChatService/Mentions/MentionFanOut.cs
@@ -131,9 +131,12 @@ public class MentionFanOut(
             // to the OTHER eligible targets. Failures log-and-continue.
             try
             {
-                // Rule (c): the excerpt PRIVACY WALL. The target must have a durable channel_memberships
-                // row for THIS channel — an inbox entry carries a ~120-char content excerpt, and a private
-                // (Dm/GroupDm) conversation's excerpt must NEVER reach a non-participant. Load lowercases
+                // Rule (c): the excerpt PRIVACY WALL — two branches. When a durable channel_memberships
+                // row exists, the target is JOINED and rules (d)/(e) below decide. When it does NOT: for
+                // every non-Public channel type (Dm/GroupDm/SemiPublic/System) the wall holds and the
+                // target is dropped — an inbox entry carries a ~120-char content excerpt, and a private
+                // conversation's excerpt must NEVER reach a non-participant; for Public specifically (§4
+                // below) the wall is replaced by a directory-resolvability check instead. Load lowercases
                 // the tag internally (C5 T4 key convention), so the display-cased mention tag matches.
                 var membership = await _membershipRepository.Load(channel.Id, tag);
                 if (membership != null)

--- a/W3ChampionsChatService/Mentions/MentionFanOut.cs
+++ b/W3ChampionsChatService/Mentions/MentionFanOut.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Serilog;
@@ -17,7 +18,8 @@ namespace W3ChampionsChatService.Mentions;
 
 /// <summary>
 /// C6 (Task 5, C6-plan.md D3/D4): the mention fan-out. Called by the send pipeline
-/// (<c>ChatHub.SendMessage</c> step 7.75) once a message is durably persisted, with the validated,
+/// (<c>ChatHub.SendMessage</c> step 8 — fix round 1 (F2b) moved it after the step-7.75 channel fan-out
+/// seam, see that method's doc) once a message is durably persisted, with the validated,
 /// deduped mention-tag list produced by the Task 4 markup gate. For each ELIGIBLE target it writes an
 /// offline <see cref="MentionInboxEntry"/> and pushes a targeted <see cref="ChatEvents.MentionNotified"/>
 /// to that target's live connection.
@@ -75,6 +77,17 @@ namespace W3ChampionsChatService.Mentions;
 /// abort delivery to the OTHER eligible targets — each target's whole body is wrapped, failures
 /// log-and-continue. The inbox insert happens BEFORE the push because the entry's id rides in the event
 /// payload; if the insert fails there is nothing to notify about, so that target is skipped entirely.
+/// </para>
+/// <para>
+/// Fix round 1 (F2a): <see cref="NotifyAsync"/> runs three STAGES rather than one per-target loop that
+/// awaits everything in-line. Stage 1 resolves the cheap eligibility rules (b)-(e) per target, exactly as
+/// before (sequential — these are local Mongo point-reads). Stage 2 resolves EVERY otherwise-eligible
+/// target's D1 block snapshot CONCURRENTLY (<see cref="Task.WhenAll{TResult}(System.Collections.Generic.IEnumerable{Task{TResult}})"/>),
+/// each individually fail-open — at steady state nearly every one is a wb HTTP round-trip (the 5-min
+/// cache TTL), so resolving them serially ahead of the C3 channel fan-out could otherwise delay
+/// <c>MessageReceived</c> for the whole channel by up to <see cref="ChatLimits.MaxMentionsPerMessage"/>
+/// timeouts; concurrently, the worst case is ONE. Stage 3 writes (insert + push) for every non-blocked
+/// target, sequentially, under the SAME per-target fault isolation described above.
 /// </para>
 /// </summary>
 public class MentionFanOut(
@@ -136,6 +149,12 @@ public class MentionFanOut(
         // sender tag simply never self-matches below (tagLower is never null), which is the safe outcome.
         var senderTagLower = message.Sender?.BattleTag?.ToLowerInvariant();
 
+        // STAGE 1 — cheap eligibility (rules (b)-(e) plus the Public non-member directory/pref checks —
+        // IsOtherwiseEligibleAsync). Sequential, exactly as before this fix: these are local Mongo
+        // point-reads, not the wb round-trip stage 2 batches. Each target's check is still individually
+        // fault-isolated (mirrors the old single-catch-per-target loop) so a Mongo hiccup here skips only
+        // that target, logs, and never breaks the sender's already-persisted Ok ack.
+        var otherwiseEligible = new List<(string Tag, string TagLower)>();
         foreach (var tag in mentionTags)
         {
             var tagLower = tag.ToLowerInvariant();
@@ -146,133 +165,56 @@ public class MentionFanOut(
                 continue;
             }
 
-            // PER-TARGET FAULT ISOLATION (mirrors FanOutEngine.OnMessagePersisted): the whole per-target
-            // body — membership read, inbox insert, and live push — is wrapped so a single target's Mongo
-            // hiccup or dead socket can never break the sender's already-persisted Ok ack or abort delivery
-            // to the OTHER eligible targets. Failures log-and-continue.
             try
             {
-                // Rule (c): the excerpt PRIVACY WALL — two branches. When a durable channel_memberships
-                // row exists, the target is JOINED and rules (d)/(e) below decide. When it does NOT: for
-                // every non-Public channel type (Dm/GroupDm/SemiPublic/System) the wall holds and the
-                // target is dropped — an inbox entry carries a ~120-char content excerpt, and a private
-                // conversation's excerpt must NEVER reach a non-participant; for Public specifically (§4
-                // below) the wall is replaced by a directory-resolvability check instead. Load lowercases
-                // the tag internally (C5 T4 key convention), so the display-cased mention tag matches.
-                var membership = await _membershipRepository.Load(channel.Id, tag);
-                if (membership != null)
+                if (await IsOtherwiseEligibleAsync(channel, tag, now))
                 {
-                    // Rules (d)/(e) — unchanged for JOINED targets: an explicit NotificationLevel.None
-                    // opt-out outranks mentions, and a decline-suppressed Dm recipient is never pinged.
-                    if (membership.NotificationLevel == NotificationLevel.None)
-                    {
-                        continue;
-                    }
-                    if (membership.DeclinedUntil.HasValue && membership.DeclinedUntil.Value > now)
-                    {
-                        continue;
-                    }
+                    otherwiseEligible.Add((tag, tagLower));
                 }
-                else if (channel.Type == ChannelType.Public)
-                {
-                    // Follow-up spec §4: PUBLIC rooms are mentionable WITHOUT membership — a public
-                    // room's excerpt is public content, so rule (c)'s wall protects nothing here. The
-                    // target must still be a RESOLVABLE user (a user_directory row; Load lowercases the
-                    // display-cased tag), so garbage tags keep producing nothing. PR36 follow-up (D2)
-                    // narrowed the v1 gap here — see the pref check right below.
-                    var directoryEntry = await _userDirectory.Load(tag);
-                    if (directoryEntry == null)
-                    {
-                        continue;
-                    }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(
+                    ex,
+                    "Mention fan-out eligibility check for {Tag} on channel {ChannelId} for message {MessageId} failed — skipping; other targets and the sender ack are unaffected",
+                    tag,
+                    channel.Id,
+                    message.Id);
+            }
+        }
 
-                    // PR36 follow-up (D2): the narrowed v1 gap — a non-member can silence mentions from
-                    // a room they haven't (re)joined by: join → NotificationLevel.None → leave. Leave
-                    // hard-deletes the membership row (so rule (c) above no longer sees it), but the
-                    // LAST EXPLICITLY-SET level persists independently here (written by
-                    // ChatHub.SetNotificationLevel, and seeded back into a rejoined membership by
-                    // JoinChannel). Only an explicit None suppresses; any other level, or no pref at all
-                    // (never explicitly set), delivers normally.
-                    var pref = await _notificationPreferenceRepository.Load(tag, channel.Id);
-                    if (pref != null && pref.NotificationLevel == NotificationLevel.None)
-                    {
-                        continue;
-                    }
-                }
-                else
-                {
-                    // Rule (c) — UNCHANGED for every non-public type: the Dm/GroupDm excerpt PRIVACY
-                    // WALL, and SemiPublic/System keep the membership wall too (§4 widens Public only).
-                    continue;
-                }
+        if (otherwiseEligible.Count == 0)
+        {
+            return;
+        }
 
-                // PR36 follow-up (D1): block suppression, consulted LAST — the target has cleared every
-                // cheap check above and is otherwise ELIGIBLE, so this is the only point a relationship
-                // snapshot fetch (worst case a wb HTTP round-trip) ever runs, bounded to at most
-                // ChatLimits.MaxMentionsPerMessage calls for this message. Direction is deliberate: only
-                // the TARGET's OWN block list matters here — sender-side blocking (the sender having
-                // blocked the target) is out of scope for mention gating and is never consulted.
-                // OUTAGE POSTURE — FAIL OPEN: this catch is LOCAL (not the per-target catch below), so a
-                // relationship-provider failure — including RelationshipUnavailableException once the
-                // provider's own stale-cache fallback is exhausted — DELIVERS the mention instead of
-                // suppressing it. A relationship outage must never blanket-mute every mention or break
-                // the send pipeline; it only means this one target's block state couldn't be proven, and
-                // we default to delivering rather than guessing a block.
-                try
-                {
-                    var targetSnapshot = await _relationshipProvider.GetSnapshotAsync(tag);
-                    if (targetSnapshot.HasBlocked(message.Sender?.BattleTag))
-                    {
-                        continue;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning(
-                        ex,
-                        "Relationship snapshot unavailable for mention target {Tag} on channel {ChannelId} for message {MessageId} — delivering fail-open",
-                        tag,
-                        channel.Id,
-                        message.Id);
-                }
+        // STAGE 2 — PR36 follow-up (D1), fix round 1 (F2a): resolve every otherwise-eligible target's
+        // block snapshot CONCURRENTLY rather than one at a time. Direction is deliberate: only the
+        // TARGET's OWN block list matters here — sender-side blocking (the sender having blocked the
+        // target) is out of scope for mention gating and is never consulted. Bounded to at most
+        // ChatLimits.MaxMentionsPerMessage concurrent calls for this message. Each call still fails open
+        // individually (IsBlockedFailOpenAsync) — a relationship-provider outage on ONE target's fetch
+        // never suppresses another target whose own snapshot resolves fine, and never blanket-mutes the
+        // whole message or breaks the send pipeline.
+        var senderTag = message.Sender?.BattleTag;
+        var blockedFlags = await Task.WhenAll(
+            otherwiseEligible.Select(target => IsBlockedFailOpenAsync(target.Tag, senderTag, channel.Id, message.Id)));
 
-                // Eligible. Write the offline inbox entry FIRST — its id rides in the event payload. Expiry
-                // via ExpiryCalculator.ForMentionInboxEntry (30d, always <= the message TTL) — the wiring
-                // of the C1 amendment-1 calculator into a production write path. BattleTag is stored
-                // LOWERCASED (D8 key convention); author fields keep the sender's DISPLAY casing.
-                var entry = new MentionInboxEntry
-                {
-                    BattleTag = tagLower,
-                    ChannelId = channel.Id,
-                    MessageId = message.Id,
-                    Seq = message.Seq,
-                    AuthorBattleTag = message.Sender.BattleTag,
-                    AuthorName = message.Sender.Name,
-                    Excerpt = Excerpts.Bounded(message.Content),
-                    CreatedAt = now,
-                    ExpiresAt = ExpiryCalculator.ForMentionInboxEntry(now),
-                };
-                await _mentionInboxRepository.Insert(entry);
+        // STAGE 3 — write (inbox insert + live push) for every non-blocked target, sequentially. PER-TARGET
+        // FAULT ISOLATION (mirrors FanOutEngine.OnMessagePersisted): a single target's failed inbox insert
+        // or dead/torn-down socket must NEVER break the sender's already-persisted Ok ack, and must never
+        // abort delivery to the OTHER eligible targets. Failures log-and-continue.
+        for (var i = 0; i < otherwiseEligible.Count; i++)
+        {
+            if (blockedFlags[i])
+            {
+                continue;
+            }
 
-                // Targeted live push — ONLY to this target's own connection (never a broadcast), and only
-                // if online. A focused target STILL gets it (the server never guesses "seen"; the client
-                // acks — Task 6). An OFFLINE target gets the durable entry above only; Task 6's
-                // GetMentionInbox / SessionState.MentionUnreadCount surface it on their next connect.
-                // GetByBattleTag is case-insensitive, so the display-cased mention tag resolves the session.
-                var session = _sessionRegistry.GetByBattleTag(tag);
-                if (session != null)
-                {
-                    var dto = new MentionNotifiedDto(
-                        entry.Id,
-                        entry.ChannelId,
-                        entry.MessageId,
-                        entry.Seq,
-                        entry.AuthorBattleTag,
-                        entry.AuthorName,
-                        entry.Excerpt,
-                        entry.CreatedAt);
-                    await _hubContext.Clients.Client(session.ConnectionId).SendAsync(ChatEvents.MentionNotified, dto);
-                }
+            var (tag, tagLower) = otherwiseEligible[i];
+            try
+            {
+                await DeliverAsync(channel, message, tag, tagLower, now);
             }
             catch (Exception ex)
             {
@@ -283,6 +225,135 @@ public class MentionFanOut(
                     channel.Id,
                     message.Id);
             }
+        }
+    }
+
+    /// <summary>
+    /// STAGE 1 body: rules (c)/(d)/(e) plus the Public non-member directory + PR36 (D2) pref checks —
+    /// everything EXCEPT the D1 block check (stage 2, batched) and the actual write (stage 3). Returns
+    /// false for every outcome the original inline loop used to <c>continue</c> past; a throw here is the
+    /// caller's problem to fault-isolate (mirrors the old per-target catch).
+    /// </summary>
+    private async Task<bool> IsOtherwiseEligibleAsync(ChatChannel channel, string tag, DateTime now)
+    {
+        // Rule (c): the excerpt PRIVACY WALL — two branches. When a durable channel_memberships row
+        // exists, the target is JOINED and rules (d)/(e) below decide. When it does NOT: for every
+        // non-Public channel type (Dm/GroupDm/SemiPublic/System) the wall holds and the target is dropped
+        // — an inbox entry carries a ~120-char content excerpt, and a private conversation's excerpt must
+        // NEVER reach a non-participant; for Public specifically (§4 below) the wall is replaced by a
+        // directory-resolvability check instead. Load lowercases the tag internally (C5 T4 key
+        // convention), so the display-cased mention tag matches.
+        var membership = await _membershipRepository.Load(channel.Id, tag);
+        if (membership != null)
+        {
+            // Rules (d)/(e) — unchanged for JOINED targets: an explicit NotificationLevel.None opt-out
+            // outranks mentions, and a decline-suppressed Dm recipient is never pinged.
+            if (membership.NotificationLevel == NotificationLevel.None)
+            {
+                return false;
+            }
+            if (membership.DeclinedUntil.HasValue && membership.DeclinedUntil.Value > now)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        if (channel.Type != ChannelType.Public)
+        {
+            // Rule (c) — UNCHANGED for every non-public type: the Dm/GroupDm excerpt PRIVACY WALL, and
+            // SemiPublic/System keep the membership wall too (§4 widens Public only).
+            return false;
+        }
+
+        // Follow-up spec §4: PUBLIC rooms are mentionable WITHOUT membership — a public room's excerpt
+        // is public content, so rule (c)'s wall protects nothing here. The target must still be a
+        // RESOLVABLE user (a user_directory row; Load lowercases the display-cased tag), so garbage tags
+        // keep producing nothing. PR36 follow-up (D2) narrowed the v1 gap here — see the pref check below.
+        var directoryEntry = await _userDirectory.Load(tag);
+        if (directoryEntry == null)
+        {
+            return false;
+        }
+
+        // PR36 follow-up (D2): the narrowed v1 gap — a non-member can silence mentions from a room they
+        // haven't (re)joined by: join → NotificationLevel.None → leave. Leave hard-deletes the membership
+        // row (so rule (c) above no longer sees it), but the LAST EXPLICITLY-SET level persists
+        // independently here (written by ChatHub.SetNotificationLevel, and seeded back into a rejoined
+        // membership by JoinChannel). Only an explicit None suppresses; any other level, or no pref at all
+        // (never explicitly set), delivers normally.
+        var pref = await _notificationPreferenceRepository.Load(tag, channel.Id);
+        return pref == null || pref.NotificationLevel != NotificationLevel.None;
+    }
+
+    /// <summary>
+    /// STAGE 2 body: PR36 follow-up (D1), the TARGET's own block-check, individually fail-open.
+    /// OUTAGE POSTURE — FAIL OPEN: this catch DELIVERS (returns false / "not blocked") on any failure —
+    /// including <see cref="RelationshipUnavailableException"/> once the provider's own stale-cache
+    /// fallback is exhausted — rather than suppressing the mention. A relationship outage must never
+    /// blanket-mute every mention or break the send pipeline; it only means this one target's block state
+    /// couldn't be proven, and we default to delivering rather than guessing a block.
+    /// </summary>
+    private async Task<bool> IsBlockedFailOpenAsync(string tag, string senderTag, string channelId, string messageId)
+    {
+        try
+        {
+            var targetSnapshot = await _relationshipProvider.GetSnapshotAsync(tag);
+            return targetSnapshot.HasBlocked(senderTag);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(
+                ex,
+                "Relationship snapshot unavailable for mention target {Tag} on channel {ChannelId} for message {MessageId} — delivering fail-open",
+                tag,
+                channelId,
+                messageId);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// STAGE 3 body: writes the durable inbox entry FIRST — its id rides in the event payload — then the
+    /// targeted live push, for one already-eligible, non-blocked target. Expiry via
+    /// ExpiryCalculator.ForMentionInboxEntry (30d, always &lt;= the message TTL) — the wiring of the C1
+    /// amendment-1 calculator into a production write path. BattleTag is stored LOWERCASED (D8 key
+    /// convention); author fields keep the sender's DISPLAY casing.
+    /// </summary>
+    private async Task DeliverAsync(ChatChannel channel, ChannelMessage message, string tag, string tagLower, DateTime now)
+    {
+        var entry = new MentionInboxEntry
+        {
+            BattleTag = tagLower,
+            ChannelId = channel.Id,
+            MessageId = message.Id,
+            Seq = message.Seq,
+            AuthorBattleTag = message.Sender.BattleTag,
+            AuthorName = message.Sender.Name,
+            Excerpt = Excerpts.Bounded(message.Content),
+            CreatedAt = now,
+            ExpiresAt = ExpiryCalculator.ForMentionInboxEntry(now),
+        };
+        await _mentionInboxRepository.Insert(entry);
+
+        // Targeted live push — ONLY to this target's own connection (never a broadcast), and only if
+        // online. A focused target STILL gets it (the server never guesses "seen"; the client acks —
+        // Task 6). An OFFLINE target gets the durable entry above only; Task 6's GetMentionInbox /
+        // SessionState.MentionUnreadCount surface it on their next connect. GetByBattleTag is
+        // case-insensitive, so the display-cased mention tag resolves the session.
+        var session = _sessionRegistry.GetByBattleTag(tag);
+        if (session != null)
+        {
+            var dto = new MentionNotifiedDto(
+                entry.Id,
+                entry.ChannelId,
+                entry.MessageId,
+                entry.Seq,
+                entry.AuthorBattleTag,
+                entry.AuthorName,
+                entry.Excerpt,
+                entry.CreatedAt);
+            await _hubContext.Clients.Client(session.ConnectionId).SendAsync(ChatEvents.MentionNotified, dto);
         }
     }
 }

--- a/W3ChampionsChatService/Messages/MessageRepository.cs
+++ b/W3ChampionsChatService/Messages/MessageRepository.cs
@@ -138,11 +138,13 @@ public class MessageRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
     }
 
     /// <summary>
-    /// D7 (consumed by a later C4 task's unread math): count of rows in <paramref name="channelId"/>
-    /// visible to <paramref name="viewerBattleTag"/> (same rule as <see cref="UserVisible"/>) with
+    /// D7: count of rows in <paramref name="channelId"/> visible to
+    /// <paramref name="viewerBattleTag"/> (same rule as <see cref="UserVisible"/>) with
     /// <c>Seq &gt; afterSeq</c>. The filter leads with ChannelId equality + a Seq range so the
     /// count is an INDEXED RANGE COUNT bounded by <c>ux_channelId_seq</c> — never a full-collection
-    /// scan.
+    /// scan. Retained as the documented single-channel primitive and as the equivalence baseline for
+    /// <see cref="CountUserVisibleAfterMany"/>'s tests; no production call site since 2026-08-05
+    /// (both former callers migrated to the batched sibling — do NOT remove as dead code).
     /// </summary>
     public Task<long> CountUserVisibleAfter(string channelId, string viewerBattleTag, long afterSeq)
     {

--- a/W3ChampionsChatService/Messages/MessageRepository.cs
+++ b/W3ChampionsChatService/Messages/MessageRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using MongoDB.Bson;
@@ -10,6 +11,13 @@ namespace W3ChampionsChatService.Messages;
 
 /// <summary>(Id, ChannelId) projection for a moderator bulk-purge target list (D6, consumed by a later C4 task).</summary>
 public record PurgeTarget(string Id, string ChannelId);
+
+/// <summary>
+/// One (channel, read-cursor) input pair for <see cref="MessageRepository.CountUserVisibleAfterMany"/>
+/// (2026-08-05 PR36 feedback, Part 1) — mirrors <see cref="MessageRepository.CountUserVisibleAfter"/>'s
+/// <c>(channelId, afterSeq)</c> argument pair as a single batchable unit.
+/// </summary>
+public record ChannelUnreadCursor(string ChannelId, long AfterSeq);
 
 public class MessageRepository(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient)
 {
@@ -146,6 +154,53 @@ public class MessageRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
             ShadowVisibleToSelf(viewerBattleTag));
 
         return Messages.CountDocumentsAsync(filter);
+    }
+
+    /// <summary>
+    /// Batched sibling of <see cref="CountUserVisibleAfter"/> (2026-08-05 PR36 feedback, Part 1) — one
+    /// aggregation round-trip in place of one <c>CountDocumentsAsync</c> per channel (the connect
+    /// snapshot and <c>GetConversations</c> page hydration both used to award one Mongo round-trip PER
+    /// KEPT SHELL; an extreme DM account turned that into tens of sequential queries per connect/page).
+    /// <para>
+    /// The <c>$match</c> stage is a <c>$or</c> of per-pair <c>{ChannelId, Seq &gt; afterSeq}</c> branches
+    /// (each branch alone is served by <c>ux_channelId_seq</c>, ChannelId-then-Seq, exactly like the
+    /// single-channel version) ANDed with the SAME <c>Deleted == null</c> + <see cref="ShadowVisibleToSelf"/>
+    /// visibility predicates <see cref="CountUserVisibleAfter"/> applies — this is a pure batching of that
+    /// query, never a relaxation of its semantics. The subsequent <c>$group</c> by ChannelId with a
+    /// <c>$sum: 1</c> accumulator (via LINQ <c>g.Count()</c>) then yields one count per channel that had
+    /// at least one matching row.
+    /// </para>
+    /// A <paramref name="cursors"/> entry whose ChannelId never matches (fully caught up, or genuinely no
+    /// rows) is simply ABSENT from the returned dictionary — callers must treat a missing key as count 0
+    /// (<c>GetValueOrDefault(channelId, 0)</c>), never index it directly. Empty input short-circuits to an
+    /// empty result WITHOUT issuing any query — <c>$or: []</c> would otherwise match everything.
+    /// </summary>
+    public async Task<IReadOnlyDictionary<string, long>> CountUserVisibleAfterMany(
+        IReadOnlyCollection<ChannelUnreadCursor> cursors, string viewerBattleTag)
+    {
+        if (cursors.Count == 0)
+        {
+            return new Dictionary<string, long>();
+        }
+
+        var filterBuilder = Builders<ChannelMessage>.Filter;
+        var perChannelBranches = cursors
+            .Select(cursor => filterBuilder.And(
+                filterBuilder.Eq(m => m.ChannelId, cursor.ChannelId),
+                filterBuilder.Gt(m => m.Seq, cursor.AfterSeq)))
+            .ToList();
+
+        var filter = filterBuilder.And(
+            filterBuilder.Or(perChannelBranches),
+            filterBuilder.Eq(m => m.Deleted, null),
+            ShadowVisibleToSelf(viewerBattleTag));
+
+        var counted = await Messages.Aggregate()
+            .Match(filter)
+            .Group(m => m.ChannelId, g => new { ChannelId = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        return counted.ToDictionary(x => x.ChannelId, x => (long)x.Count);
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Protocol/Results.cs
+++ b/W3ChampionsChatService/Protocol/Results.cs
@@ -83,3 +83,11 @@ public record GetPresenceResult(
 public record GetPresenceDetailsResult(
     ChatResultCode Code,
     IReadOnlyList<PresenceDetailsDto> Details = null);
+
+/// <summary>GetConversations (2026-08-04 follow-up spec §6) — one page of the caller's OLDER 1:1 Dm
+/// shells, newest-first by (LastMessageAt, ChannelId). Reuses ChannelDto so a paged conversation is
+/// byte-shaped like a SessionState.Channels entry. The client derives the next cursor from the last
+/// element (channel.LastMessageAt, channel.Id) and detects the end by Count &lt; limit.</summary>
+public record GetConversationsResult(
+    ChatResultCode Code,
+    IReadOnlyList<ChannelDto> Conversations = null);

--- a/W3ChampionsChatService/Protocol/Results.cs
+++ b/W3ChampionsChatService/Protocol/Results.cs
@@ -32,8 +32,14 @@ public record FocusChannelResult(
     ChatResultCode Code,
     IReadOnlyList<ChannelViewerDto> Viewers = null);
 
+/// <summary><see cref="RetryAfterSeconds"/> (2026-08-05 PR36 feedback, Part 3) carries the retry hint on
+/// a <see cref="ChatResultCode.Throttled"/> reject from the shared <see cref="FanOut.ReadRateLimiter"/> —
+/// mirrors every other Throttled-capable result's <c>RetryAfterSeconds</c> field. Purely additive: an
+/// older client that doesn't read the field is unaffected (it already treats any non-Ok code as a silent
+/// no-op — see the task report's GetMessages scope determination).</summary>
 public record GetMessagesResult(
     ChatResultCode Code,
+    double? RetryAfterSeconds = null,
     IReadOnlyList<MessageDto> Messages = null);
 
 /// <summary>Leave/SetNotificationLevel/MarkRead/Unfocus — no result payload beyond the code.</summary>

--- a/W3ChampionsChatService/Protocol/Results.cs
+++ b/W3ChampionsChatService/Protocol/Results.cs
@@ -96,7 +96,11 @@ public record GetPresenceDetailsResult(
 /// &lt;= <see cref="Domain.ChatLimits.ConversationsPageSize"/> for its pagination to terminate correctly
 /// — <c>ChatLimitsTests.ConversationsPageSize_IsAtLeastLauncherPageSize</c> pins this cross-repo
 /// dependency. <see cref="RetryAfterSeconds"/> carries the retry hint on a <see cref="ChatResultCode.Throttled"/>
-/// reject (a relationship-provider outage — mirrors <see cref="OpenDmResult"/>).</summary>
+/// reject (a relationship-provider outage — mirrors <see cref="OpenDmResult"/>). NOTE: as of this
+/// writing the launcher does not read this field on a Throttled GetConversations reject — it simply
+/// retries the same scroll request on the user's next scroll gesture rather than scheduling a timed
+/// retry. The field is kept for API completeness/symmetry with <see cref="OpenDmResult"/> and
+/// <see cref="SendMessageResult"/> (a future client could honor it) and costs nothing unused.</summary>
 public record GetConversationsResult(
     ChatResultCode Code,
     double? RetryAfterSeconds = null,

--- a/W3ChampionsChatService/Protocol/Results.cs
+++ b/W3ChampionsChatService/Protocol/Results.cs
@@ -87,7 +87,17 @@ public record GetPresenceDetailsResult(
 /// <summary>GetConversations (2026-08-04 follow-up spec §6) — one page of the caller's OLDER 1:1 Dm
 /// shells, newest-first by (LastMessageAt, ChannelId). Reuses ChannelDto so a paged conversation is
 /// byte-shaped like a SessionState.Channels entry. The client derives the next cursor from the last
-/// element (channel.LastMessageAt, channel.Id) and detects the end by Count &lt; limit.</summary>
+/// element (channel.LastMessageAt, channel.Id) and detects the end by Count &lt; limit — CAVEAT: this
+/// end-detection is only SOUND when the caller's requested <c>limit</c> is at most
+/// <see cref="Domain.ChatLimits.ConversationsPageSize"/>. A caller requesting a larger limit gets a
+/// CLAMPED page (more older shells can remain even though the returned Count equals the clamp
+/// ceiling), so <c>Count &lt; limit</c> would falsely signal the end for such a caller. The launcher's
+/// client-side page size (CONVERSATIONS_PAGE_SIZE, currently 30) MUST stay
+/// &lt;= <see cref="Domain.ChatLimits.ConversationsPageSize"/> for its pagination to terminate correctly
+/// — <c>ChatLimitsTests.ConversationsPageSize_IsAtLeastLauncherPageSize</c> pins this cross-repo
+/// dependency. <see cref="RetryAfterSeconds"/> carries the retry hint on a <see cref="ChatResultCode.Throttled"/>
+/// reject (a relationship-provider outage — mirrors <see cref="OpenDmResult"/>).</summary>
 public record GetConversationsResult(
     ChatResultCode Code,
+    double? RetryAfterSeconds = null,
     IReadOnlyList<ChannelDto> Conversations = null);

--- a/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
+++ b/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
@@ -11,6 +11,7 @@ using W3ChampionsChatService.Memberships;
 using W3ChampionsChatService.Mentions;
 using W3ChampionsChatService.Messages;
 using W3ChampionsChatService.Mutes;
+using W3ChampionsChatService.Relationships;
 
 namespace W3ChampionsChatService.Protocol;
 
@@ -71,7 +72,8 @@ public class SessionStateAssembler(
     // directory upsert); hoisting the ONE resolution into the hub and threading it through here (and
     // into the directory upsert) means a single wb round-trip serves both.
     public async Task<(SessionStateDto Dto, MuteStatus MuteStatus)> AssembleAndSeed(
-        W3CUserAuthentication identity, string connectionId, DateTime now, ChatUser chatUser)
+        W3CUserAuthentication identity, string connectionId, DateTime now, ChatUser chatUser,
+        RelationshipSnapshot relationshipSnapshot = null)
     {
         var memberships = await membershipRepository.LoadForUser(identity.BattleTag);
         var channelsById = (await channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
@@ -96,13 +98,21 @@ public class SessionStateAssembler(
             .Where(m => channelsById.ContainsKey(m.ChannelId))
             .ToList();
 
+        // Follow-up spec §6: bound the 1:1-DM slice of the snapshot. The SELECTED set feeds the DTO's
+        // Channels list, the pending tray, AND the OnlineMemberRegistry seed below — the registry set
+        // must equal the DTO set (the long-standing invariant), so both are bounded TOGETHER. Excluded
+        // shells are repaired by the two §6 companion paths: an incoming message re-announces via
+        // ChannelAdded (ChatHub.MaterializeDmRecipientAndNotify), and GetConversations pages + seeds.
+        var snapshotMemberships = SelectSnapshotMemberships(
+            channelBackedMemberships, channelsById, relationshipSnapshot, identity.BattleTag);
+
         // D7 (Amendment 3): unread is computed per channel as the COUNT of user-visible rows after the
         // member's read cursor (see ToChannelDto) — an async, index-bounded Mongo count per membership.
         // Sequential await (not Task.WhenAll): memberships are bounded (the public+semiPublic cap plus
         // DMs/groups/match), and each count is a fast indexed range count, so the simpler sequential loop
         // is preferred over parallelizing across the Mongo connection pool.
-        var channelDtos = new List<ChannelDto>(channelBackedMemberships.Count);
-        foreach (var membership in channelBackedMemberships)
+        var channelDtos = new List<ChannelDto>(snapshotMemberships.Count);
+        foreach (var membership in snapshotMemberships)
         {
             channelDtos.Add(await ToChannelDto(channelsById[membership.ChannelId], membership, identity.BattleTag));
         }
@@ -115,15 +125,76 @@ public class SessionStateAssembler(
         var dto = new SessionStateDto(
             Channels: channelDtos,
             PublicCatalog: effectivePublicCatalog,
-            PendingDmRequests: BuildPendingDmTray(channelBackedMemberships, channelsById, identity.BattleTag, now),
+            PendingDmRequests: BuildPendingDmTray(snapshotMemberships, channelsById, identity.BattleTag, now),
             MentionUnreadCount: (int)mentionUnreadCount,
             OwnProfile: ToOwnProfileDto(identity, chatUser),
             MuteState: ToMuteStateDto(muteStatus, mutedPlayer));
 
-        SeedOnlineMemberRegistry(connectionId, identity.BattleTag, channelBackedMemberships, channelsById);
+        SeedOnlineMemberRegistry(connectionId, identity.BattleTag, snapshotMemberships, channelsById);
         SeedLegacyMuteCache(connectionId, chatUser, muteStatus, mutedPlayer);
 
         return (dto, muteStatus);
+    }
+
+    /// <summary>
+    /// Follow-up spec §6 connect-snapshot bounds. Keeps: (a) every non-1:1 channel
+    /// (Public/SemiPublic/System/GroupDm — untouched by bounding); (b) every PENDING 1:1 Dm (either
+    /// direction — the tray needs the recipient's, dual-listing and the initiator's outgoing view need
+    /// the rest); (c) every 1:1 Dm whose counterpart is in the caller's block list, regardless of
+    /// recency (the Blocked tray section) — degrades to no blocked-keeps when no snapshot was
+    /// resolvable at connect (self-heals next connect); (d) the DmSnapshotRecentConversations
+    /// most-recent remaining shells by LastMessageAt; (e) any OLDER remaining shell with a POSSIBLE
+    /// unread (raw channel.LastSeq &gt; membership.LastReadSeq — the cheap candidate test; the real D7
+    /// user-visible count is computed on the selected set afterwards, so a phantom candidate rides
+    /// with UnreadCount 0: bounded over-inclusion, never an understated badge).
+    /// </summary>
+    internal static List<ChannelMembership> SelectSnapshotMemberships(
+        List<ChannelMembership> channelBackedMemberships,
+        IReadOnlyDictionary<string, ChatChannel> channelsById,
+        RelationshipSnapshot relationshipSnapshot,
+        string viewerBattleTag)
+    {
+        var kept = new List<ChannelMembership>();
+        var remainingDms = new List<(ChannelMembership Membership, ChatChannel Channel, DateTime SortTime)>();
+
+        foreach (var membership in channelBackedMemberships)
+        {
+            var channel = channelsById[membership.ChannelId];
+
+            if (channel.Type != ChannelType.Dm)
+            {
+                kept.Add(membership); // (a)
+                continue;
+            }
+            if (channel.RequestState == DmRequestState.Pending)
+            {
+                kept.Add(membership); // (b)
+                continue;
+            }
+            if (relationshipSnapshot != null
+                && relationshipSnapshot.HasBlocked(DmPairKey.CounterpartOf(channel.PairKey, viewerBattleTag)))
+            {
+                kept.Add(membership); // (c)
+                continue;
+            }
+
+            remainingDms.Add((membership, channel, channel.LastMessageAt ?? membership.JoinedAt));
+        }
+
+        var ordered = remainingDms
+            .OrderByDescending(x => x.SortTime)
+            .ThenByDescending(x => x.Channel.Id, StringComparer.Ordinal)
+            .ToList();
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            if (i < ChatLimits.DmSnapshotRecentConversations                 // (d)
+                || ordered[i].Channel.LastSeq > ordered[i].Membership.LastReadSeq) // (e)
+            {
+                kept.Add(ordered[i].Membership);
+            }
+        }
+
+        return kept;
     }
 
     private static MuteStatus ResolveMuteStatus(LoungeMute mute, DateTime now)

--- a/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
+++ b/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
@@ -107,15 +107,17 @@ public class SessionStateAssembler(
             channelBackedMemberships, channelsById, relationshipSnapshot, identity.BattleTag);
 
         // D7 (Amendment 3): unread is computed per channel as the COUNT of user-visible rows after the
-        // member's read cursor (see ToChannelDto) — an async, index-bounded Mongo count per membership.
-        // Sequential await (not Task.WhenAll): memberships are bounded (the public+semiPublic cap plus
-        // DMs/groups/match), and each count is a fast indexed range count, so the simpler sequential loop
-        // is preferred over parallelizing across the Mongo connection pool.
-        var channelDtos = new List<ChannelDto>(snapshotMemberships.Count);
-        foreach (var membership in snapshotMemberships)
-        {
-            channelDtos.Add(await ToChannelDto(channelsById[membership.ChannelId], membership, identity.BattleTag));
-        }
+        // member's read cursor (see ToChannelDto). 2026-08-05 PR36 feedback (Part 1): this used to be a
+        // deliberately sequential per-shell Mongo count — bounded but still ONE round-trip per kept
+        // membership (a 500-DM account with 40 older-unread shells meant 70 sequential queries per
+        // connect). Now a SINGLE CountUserVisibleAfterMany aggregation covers the whole kept set in one
+        // round-trip; ToChannelDto is a pure in-memory lookup against the returned per-channel dictionary.
+        var unreadCounts = await messageRepository.CountUserVisibleAfterMany(
+            snapshotMemberships.Select(m => new ChannelUnreadCursor(m.ChannelId, m.LastReadSeq)).ToList(),
+            identity.BattleTag);
+        var channelDtos = snapshotMemberships
+            .Select(m => ToChannelDto(channelsById[m.ChannelId], m, unreadCounts))
+            .ToList();
 
         // C6 (Task 6, D6): the live unread-mention count — CountUnread(ReadAt == null). identity.BattleTag
         // is passed straight through (JWT-cased); the repository normalizes it to the lowercased
@@ -146,7 +148,12 @@ public class SessionStateAssembler(
     /// most-recent remaining shells by LastMessageAt; (e) any OLDER remaining shell with a POSSIBLE
     /// unread (raw channel.LastSeq &gt; membership.LastReadSeq — the cheap candidate test; the real D7
     /// user-visible count is computed on the selected set afterwards, so a phantom candidate rides
-    /// with UnreadCount 0: bounded over-inclusion, never an understated badge).
+    /// with UnreadCount 0: bounded over-inclusion, never an understated badge) — CAPPED at
+    /// <see cref="ChatLimits.DmSnapshotMaxOlderUnread"/> (2026-08-05 PR36 feedback, Part 2): the ordered
+    /// (recency-desc) scan stops applying rule (e) once that many older-unread shells have been kept, so
+    /// the kept tail is always the MOST RECENT older-unread shells, never an unbounded scan of a
+    /// pathological account's entire history. Rules (a)-(d) and pending/blocked handling are unaffected
+    /// by the cap.
     /// </summary>
     internal static List<ChannelMembership> SelectSnapshotMemberships(
         List<ChannelMembership> channelBackedMemberships,
@@ -189,12 +196,31 @@ public class SessionStateAssembler(
             .OrderByDescending(x => x.SortTime)
             .ThenByDescending(x => x.Channel.Id, StringComparer.Ordinal)
             .ToList();
+
+        // Part 2 (2026-08-05 PR36 feedback): olderUnreadKept counts rule-(e) keeps ONLY — once it hits
+        // the DmSnapshotMaxOlderUnread cap, rule (e) stops applying entirely. The list is already
+        // recency-ordered, so the cap naturally keeps the MOST RECENT older-unread shells and drops the
+        // rest of the (older still) tail.
+        var olderUnreadKept = 0;
         for (var i = 0; i < ordered.Count; i++)
         {
-            if (i < ChatLimits.DmSnapshotRecentConversations                 // (d)
-                || ordered[i].Channel.LastSeq > ordered[i].Membership.LastReadSeq) // (e)
+            if (i < ChatLimits.DmSnapshotRecentConversations) // (d)
             {
                 kept.Add(ordered[i].Membership);
+                continue;
+            }
+
+            if (olderUnreadKept >= ChatLimits.DmSnapshotMaxOlderUnread)
+            {
+                // Cap reached: every remaining index is past rule (d)'s threshold already, and rule (e)
+                // is now closed too, so nothing further in this recency-ordered list can ever be kept.
+                break;
+            }
+
+            if (ordered[i].Channel.LastSeq > ordered[i].Membership.LastReadSeq) // (e)
+            {
+                kept.Add(ordered[i].Membership);
+                olderUnreadKept++;
             }
         }
 
@@ -209,16 +235,19 @@ public class SessionStateAssembler(
         return mute.isShadowBan ? MuteStatus.Shadow : MuteStatus.Full;
     }
 
-    private async Task<ChannelDto> ToChannelDto(ChatChannel channel, ChannelMembership membership, string viewerBattleTag)
+    private static ChannelDto ToChannelDto(
+        ChatChannel channel, ChannelMembership membership, IReadOnlyDictionary<string, long> unreadCounts)
     {
         // D7 (Amendment 3): unread is the COUNT of USER-VISIBLE rows after the member's read cursor —
         // NOT channel.LastSeq − membership.LastReadSeq. That raw-seq delta counts INVISIBLE rows
         // (foreign-author shadow rows + soft-deleted rows), so on reconnect it produced PHANTOM unread
         // for a shadow-banned author's message or a purged message — the exact defect pinned acceptance 2
-        // ("shadow messages generate NO unread for others") forbids. CountUserVisibleAfter applies the
-        // UserVisible predicate (Deleted == null AND (Shadow == false OR sender == viewer)) with
-        // Seq > LastReadSeq, index-bounded on ux_channelId_seq. The viewer's OWN shadow rows still count
-        // toward THEIR own unread (via the sender == viewer disjunct) — the symmetric illusion.
+        // ("shadow messages generate NO unread for others") forbids. CountUserVisibleAfterMany (2026-08-05
+        // PR36 feedback, Part 1 — one batched aggregation for the whole kept set, see AssembleAndSeed)
+        // applies the UserVisible predicate (Deleted == null AND (Shadow == false OR sender == viewer))
+        // with Seq > LastReadSeq per channel, index-bounded on ux_channelId_seq. The viewer's OWN shadow
+        // rows still count toward THEIR own unread (via the sender == viewer disjunct) — the symmetric
+        // illusion. A channel absent from unreadCounts (fully caught up, or zero matching rows) is 0.
         //
         // KNOWN LIVE-PATH RESIDUAL (documented here, deliberately NOT fixed — a launcher/L4 concern, out
         // of C4 scope, and self-healing): this fixes the CONNECT-time snapshot only. A shadow/soft-deleted
@@ -228,7 +257,7 @@ public class SessionStateAssembler(
         // the unread gap — until the next MarkRead (sets lastReadSeq to the max VISIBLE seq the member
         // rendered → the count returns to correct) or the next reconnect (re-baselines via this D7
         // snapshot). Bounded, rare (shadow bans are rare), and self-healing.
-        var unreadCount = await messageRepository.CountUserVisibleAfter(channel.Id, viewerBattleTag, membership.LastReadSeq);
+        var unreadCount = unreadCounts.GetValueOrDefault(channel.Id, 0L);
         return new ChannelDto(
             channel,
             MembershipDto.From(membership),

--- a/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
+++ b/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
@@ -171,7 +171,11 @@ public class SessionStateAssembler(
                 kept.Add(membership); // (b)
                 continue;
             }
-            if (relationshipSnapshot != null
+            // Defensive — a malformed doc (null PairKey) can never come from FindOrCreateDm's
+            // DmPairKey.For + unique-index path, but if one ever exists it must degrade to "not
+            // blocked-kept", never NRE and brick connect for both members.
+            if (channel.PairKey != null
+                && relationshipSnapshot != null
                 && relationshipSnapshot.HasBlocked(DmPairKey.CounterpartOf(channel.PairKey, viewerBattleTag)))
             {
                 kept.Add(membership); // (c)
@@ -234,7 +238,7 @@ public class SessionStateAssembler(
 
     /// <summary>
     /// C5 T6 — the pending-Dm-request tray (spec §11 SessionState slot). Built ENTIRELY from the
-    /// already-loaded <paramref name="channelBackedMemberships"/> + <paramref name="channelsById"/> (zero
+    /// already-loaded <paramref name="snapshotMemberships"/> + <paramref name="channelsById"/> (zero
     /// extra Mongo reads): the connecting viewer sees one <see cref="PendingDmRequestDto"/> per channel that
     /// is a <see cref="ChannelType.Dm"/> whose <see cref="ChatChannel.RequestState"/> is
     /// <see cref="DmRequestState.Pending"/>, was initiated by SOMEONE ELSE (<see cref="ChatChannel.RequestInitiatedBy"/>
@@ -244,16 +248,18 @@ public class SessionStateAssembler(
     /// the tray for the 24h window). <see cref="PendingDmRequestDto.RequestedAt"/> is the channel's last
     /// message time, falling back to the membership's join time for a shell with no message yet. The same
     /// pending-recipient channels ALSO remain in the DTO's <see cref="SessionStateDto.Channels"/> (D4
-    /// dual-listing) — this tray is additive, never a filter on that list.
+    /// dual-listing) — this tray is additive, never a filter on that list. Follow-up spec §6: pending 1:1
+    /// Dms are always kept by <see cref="SelectSnapshotMemberships"/> regardless of recency, so bounding
+    /// never hides a pending request from this tray.
     /// </summary>
     private static IReadOnlyList<PendingDmRequestDto> BuildPendingDmTray(
-        List<ChannelMembership> channelBackedMemberships,
+        List<ChannelMembership> snapshotMemberships,
         IReadOnlyDictionary<string, ChatChannel> channelsById,
         string viewerBattleTag,
         DateTime now)
     {
         var tray = new List<PendingDmRequestDto>();
-        foreach (var membership in channelBackedMemberships)
+        foreach (var membership in snapshotMemberships)
         {
             var channel = channelsById[membership.ChannelId];
             if (channel.Type != ChannelType.Dm || channel.RequestState != DmRequestState.Pending)
@@ -310,17 +316,17 @@ public class SessionStateAssembler(
     private void SeedOnlineMemberRegistry(
         string connectionId,
         string battleTag,
-        List<ChannelMembership> channelBackedMemberships,
+        List<ChannelMembership> snapshotMemberships,
         IReadOnlyDictionary<string, ChatChannel> channelsById)
     {
-        // channelBackedMemberships is already filtered to rows whose channel exists (same filter the
-        // DTO's Channels list uses) — the registry's channel set must match the DTO's exactly, so
-        // nothing ever fans out to a channel with no row. Materialized (ToList) before crossing into
-        // the registry's locked Seed — Seed enumerates its argument while holding the lock
-        // (FanOut/OnlineMemberRegistry.cs carry-forward note). C5 (Task 5, D11): each entry's
+        // snapshotMemberships is the SAME §6-bounded selection (SelectSnapshotMemberships) that feeds the
+        // DTO's Channels list above — the registry's channel set must match the DTO's exactly, so nothing
+        // ever fans out to a channel excluded from this connection's snapshot. Materialized (ToList)
+        // before crossing into the registry's locked Seed — Seed enumerates its argument while holding
+        // the lock (FanOut/OnlineMemberRegistry.cs carry-forward note). C5 (Task 5, D11): each entry's
         // ChannelType comes from the already-loaded channelsById map (zero extra Mongo reads) so
         // ChatHub can later zero-DB-lookup whether a (channel, connection) is a Dm/GroupDm private lane.
-        var seed = channelBackedMemberships
+        var seed = snapshotMemberships
             .Select(m => (m.ChannelId, new MemberState(battleTag, m.NotificationLevel, m.LastReadSeq, channelsById[m.ChannelId].Type)))
             .ToList();
         onlineMemberRegistry.Seed(connectionId, seed);

--- a/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
+++ b/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
@@ -48,6 +48,23 @@ public class SessionStateAssembler(
     private static readonly IReadOnlySet<EPermission> ChatRelevantPermissions =
         new HashSet<EPermission> { EPermission.Moderation };
 
+    // Follow-up spec §3: position of each seeded room in the hardcoded catalog (DefaultChatRooms.Rooms,
+    // "W3C Lounge" first), keyed by normalized name. Computed once — ordering and seeding read the SAME
+    // constant, so the contract "catalog order == seed list order" cannot drift.
+    private static readonly IReadOnlyDictionary<string, int> CatalogOrder = DefaultChatRooms.Rooms
+        .Select((name, index) => (Name: ChannelNames.Normalize(name), Index: index))
+        .ToDictionary(x => x.Name, x => x.Index);
+
+    /// <summary>
+    /// Orders the public catalog deterministically: seed-list position first (follow-up spec §3 —
+    /// "catalog order == seed order"); any public channel whose name is NOT in the seed list (legacy
+    /// leftover) sorts after all seeded rooms, alphabetically by normalized name.
+    /// </summary>
+    internal static List<ChatChannel> OrderByCatalog(List<ChatChannel> channels) => channels
+        .OrderBy(c => CatalogOrder.TryGetValue(c.NormalizedName ?? string.Empty, out var index) ? index : int.MaxValue)
+        .ThenBy(c => c.NormalizedName, StringComparer.Ordinal)
+        .ToList();
+
     // D9: chatUser is now RESOLVED BY THE CALLER (ChatHub, hoisted) and handed straight through — this
     // method no longer calls IChatAuthenticationService.GetUserFromIdentity itself. Before this change
     // the connect path resolved the flair TWICE per connect (once here, once again for the connect-time
@@ -59,7 +76,7 @@ public class SessionStateAssembler(
         var memberships = await membershipRepository.LoadForUser(identity.BattleTag);
         var channelsById = (await channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
             .ToDictionary(c => c.Id);
-        var publicCatalog = await channelRepository.LoadAllOfType(ChannelType.Public);
+        var publicCatalog = OrderByCatalog(await channelRepository.LoadAllOfType(ChannelType.Public));
         var mutedPlayer = await muteRepository.GetMutedPlayer(identity.BattleTag);
 
         var muteStatus = ResolveMuteStatus(mutedPlayer, now);

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -77,6 +77,9 @@ public class Startup
         services.AddTransient<UserDirectoryRepository>();
         services.AddTransient<UserSettingsRepository>();
         services.AddTransient<MentionInboxRepository>();
+        // PR36 follow-up (D2): the notification-preference carrier — read by JoinChannel (rejoin seed)
+        // and MentionFanOut (non-member Public consult path), written by SetNotificationLevel.
+        services.AddTransient<NotificationPreferenceRepository>();
         services.AddTransient<PublicChannelSeeder>();
         services.AddTransient<CleanupJobs>();
         services.AddHostedService<ChatDomainBootstrap>();   // indexes + catalog seeding at boot

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -127,6 +127,10 @@ public class Startup
         services.AddSingleton<FocusRegistry>();
         services.AddSingleton<OnlineMemberRegistry>();
         services.AddSingleton<MessageRateLimiter>();
+        // 2026-08-05 PR36 feedback, Part 3: the read-shaped hub methods' abuse guard (GetConversations,
+        // GetMessages — see FanOut/ReadRateLimiter.cs). Singleton for the same reason as MessageRateLimiter:
+        // its per-battleTag budget must be shared across every connection/method that guards against it.
+        services.AddSingleton<ReadRateLimiter>();
 
         // Task 13: the coalescing/suppressing sink for unfocused level-All ChannelActivity. Singleton —
         // it holds the per-(connection, channel) coalescing window state that the fan-out routing (every


### PR DESCRIPTION
Server half of the 2026-08-04 chat follow-up spec (launcher half: launcher-e `feat/chat-followup-fixes`). Deploy **chat-service first** — every new surface tolerates old clients; the launcher fails soft against an old server.

## What's in here (40 commits, 1155/1155 tests)

### §1 Escalating auto-throttle
- Flat 60s block → tiers **10s → 30s → 60s** (cap), tier decays after 10 clean minutes.
- State keyed by **battleTag** (was connectionId) — relaunching no longer resets a penalty; quiescent entries pruned (10-min horizon, provably ≥ any active penalty).
- `ThrottleNotice {retryAfterSeconds}` now fires on **every** tier trigger with the actual duration. Wire shapes unchanged.

### §3 Deterministic catalog order
- `SessionState.PublicCatalog` arrives in `DefaultChatRooms` seed order ("W3C Lounge" first); unknown legacy channels sort last. In-memory ordering, no migration.
- `SessionState.Channels` now sorted by membership **JoinedAt** (compound index `{BattleTag, JoinedAt}` added via the established drop/recreate migration) — the client's semiPublic "join order" survives reconnects.

### §4 Mentions reach non-members in public rooms
- A mention of any directory-resolvable user in a **Public** room creates the inbox entry + push regardless of membership. Walled types (Dm/GroupDm/SemiPublic/System) keep the membership wall byte-for-byte; `NotificationLevel.None` opt-out unchanged.
- `GetMessages` allows **read-only** public-channel history for non-members (mention-inbox jump works into unjoined rooms) — **full-banned users are rejected with the same `NotMember` as before** (no probe signal), Shadow passes (illusion preserved).

### §6 Bounded connect snapshot + pagination
- `SessionState` DM slice bounded: all pending + all blocked + all groups + **30 most-recent** 1:1 shells + older-with-unread (capped, see round 2). `OnlineMemberRegistry` bounded together with the DTO (invariant: registry == client knowledge).
- Repair paths: `ChannelAdded` **re-announce** when a message arrives for an online recipient's excluded shell (before fan-out, idempotent); new hub method **`GetConversations(cursorLastMessageAt, cursorChannelId, limit)`** — keyset pagination, newest-first, accepted+non-blocked+non-null-timestamp shells only, `Throttled` on relationship-provider outage (fail-closed, never unfiltered), registry seeded monotonically (`JoinPreservingReadCursor`).
- Connect makes exactly **one** wb relationship fetch (friend-presence push reuses it), catches all exceptions (wb outage can never fail connect), degrades to null.

---

## Round 2 — review-feedback fixes (2026-08-05, commits d4d8e1a..45145ca)

All four open questions from round 1 are now resolved per Marco's decisions; both former "ship-debt" perf items are fixed.

### Blocked users can no longer mention-ping (decision: implemented)
- `MentionFanOut` consults the **target's** relationship snapshot: if the target has blocked the sender, no inbox entry and no `MentionNotified` — in every channel type, both eligibility branches. The message and chip still render (suppression is notification-only). Sender-side block lists deliberately not consulted.
- **Fail-open** on relationship-provider outage (a wb outage never suppresses mentions or breaks sends). Block snapshots resolved **concurrently** (≤5, one shared ~2s HTTP ceiling); channel fan-out now runs **before** mention fan-out, so viewers' delivery never waits on relationship reads — only the sender's ack carries the ceiling (same coupling DM sends already have). Ordering pinned by test.

### NotificationLevel survives leave/rejoin (new `notification_prefs` collection)
- `SetNotificationLevel` on Public/SemiPublic rooms upserts a per-(battleTag, channelId) pref that outlives the hard-deleted membership; rejoin seeds from it; the non-member mention branch suppresses on a persisted `None`.
- Net effect: **join → set None → leave now permanently silences that room** — the §4 "can't silence an unjoined room" gap is closed via this path. Best-effort write (never fails the ack), unique index, race-guarded upsert, pruned with the 1-year idle-user sweep.

### Connect/read query-cost round (extreme-account hardening)
- Per-shell sequential unread counts (70 sequential Mongo round-trips for a 500-DM account) → **one batched aggregation** for both the connect snapshot and each `GetConversations` page (index-verified: no COLLSCAN up to 5000 `$or` branches). Connect is now ~7 round-trips regardless of account size.
- Older-with-unread tail **capped at 100** (`DmSnapshotMaxOlderUnread`, most-recent kept; badge may undercount only for accounts with >100 unread older conversations — accepted trade; everything stays reachable via pagination).
- `CountNameJoinableMembershipsForUser`: full-doc double-load → projected channel-ids + server-side count (join-by-name path).

### Read rate limiter (abuse guard)
- New `ReadRateLimiter`: per-battleTag token bucket, **burst 60 / 5 per sec sustained**, shared budget across `GetConversations` + `GetMessages`, checked before any Mongo work, returns `Throttled + RetryAfterSeconds` (never throws — a throw would trip the launcher's old-server detection). Sized against the connect fan-out (reseed of up to ~12 surfaces × a 0ms-retry flap), so legitimate clients never hit it; denials logged (1/min/user) so that claim is falsifiable in production.
- `GetMessagesResult` gains additive `RetryAfterSeconds` (JSON by-name — old clients unaffected; every non-Ok code already degrades silently at all 7 launcher call sites).

### Residual notes (known, accepted)
- Pending + blocked shells remain uncapped in the connect snapshot (pending is bounded by 30d expiry + sender caps; measured non-degrading to 5000 aggregation branches).
- `notification_prefs` rows for channels later GC'd are orphaned until the idle-user sweep (tiny rows, bounded growth).
- Limiter is per-process (single-replica deployment assumption, same as `MessageRateLimiter`).

## Decisions for review
- ~~Blocking doesn't shield the widened mention surface~~ → **implemented in round 2** (see above).
- ~~No way to silence mentions from an unjoined room~~ → **closed in round 2** via persisted prefs (join → None → leave).
