### PR TITLE
Server-canonical mentions: send-path validation + member-scoped search

### DIFF
--- a/W3ChampionsChatService.Tests/ChatHubMentionSearchScopingTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionSearchScopingTests.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+using W3ChampionsChatService.Memberships;
+using W3ChampionsChatService.Mentions;
+using W3ChampionsChatService.Messages;
+using W3ChampionsChatService.Mutes;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// D1 (2026-08-05 follow-up, mention-canonicalization brief, Part 2): <c>SearchMentionCandidates</c>
+/// (<c>ChatHub.Mentions.cs</c>) must never offer someone who isn't a legal mention target for the
+/// channel. <see cref="ChatHubMentionSearchTests"/> already covers tier ordering, dedup, prefix
+/// matching, the 90d gate, enrichment, the Dm/GroupDm private lane, and the result cap — this file is
+/// scoped narrowly to the NEW SemiPublic/System member-scoping lane added by D1: candidate-side
+/// filtering via <see cref="MembershipRepository.LoadMemberBattleTags"/>, deliberately NOT
+/// <see cref="MembershipRepository.LoadForChannel"/> (which the Dm/GroupDm lane still uses safely,
+/// since those channels are small and ACL-bound) — a SemiPublic/System room can be unboundedly large.
+/// Direct-hub-instantiation idiom, mirroring <see cref="ChatHubMentionSearchTests"/> exactly.
+/// </summary>
+public class ChatHubMentionSearchScopingTests : IntegrationTestBase
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 7, 4, 12, 0, 0, TimeSpan.Zero);
+
+    private ConnectionMapping _connectionMapping;
+    private UserDirectoryRepository _userDirectory;
+    private MuteReconciliationTestHarness _reconcileHarness;
+    private TicketStore _ticketStore;
+    private Mock<IChatAuthenticationService> _authService;
+
+    private ChannelRepository _channelRepository;
+    private MembershipRepository _membershipRepository;
+    private MessageRepository _messageRepository;
+    private SessionRegistry _sessionRegistry;
+    private FocusRegistry _focusRegistry;
+    private OnlineMemberRegistry _onlineMemberRegistry;
+    private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
+    private ChannelCreationRateLimiter _channelCreationRateLimiter;
+    private SessionStateAssembler _assembler;
+    private FanOutEngine _fanOutEngine;
+    private MentionInboxRepository _mentionInboxRepository;
+    private FakeTimeProvider _time;
+
+    private DateTime Now => _time.GetUtcNow().UtcDateTime;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _time = new FakeTimeProvider(FixedNow);
+
+        _connectionMapping = new ConnectionMapping();
+        _userDirectory = new UserDirectoryRepository(MongoClient);
+        _reconcileHarness = new MuteReconciliationTestHarness(_connectionMapping, new MuteRepository(MongoClient));
+        _ticketStore = new TicketStore();
+
+        _authService = new Mock<IChatAuthenticationService>();
+        _authService.Setup(m => m.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .ReturnsAsync((W3CUserAuthentication id) =>
+                new ChatUserResolution(new ChatUser(id.BattleTag, id.IsAdmin, id.Name, new ProfilePicture(), null, null), true));
+
+        _channelRepository = new ChannelRepository(MongoClient);
+        _membershipRepository = new MembershipRepository(MongoClient, _channelRepository);
+        _messageRepository = new MessageRepository(MongoClient);
+        _sessionRegistry = new SessionRegistry();
+        _focusRegistry = new FocusRegistry();
+        _onlineMemberRegistry = new OnlineMemberRegistry();
+        _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
+        _channelCreationRateLimiter = new ChannelCreationRateLimiter();
+        _fanOutEngine = FanOutEngineTestFactory.CreateIgnored();
+        _mentionInboxRepository = new MentionInboxRepository(MongoClient);
+
+        _assembler = new SessionStateAssembler(
+            _membershipRepository,
+            _channelRepository,
+            _messageRepository,
+            new MuteRepository(MongoClient),
+            _onlineMemberRegistry,
+            _connectionMapping,
+            _mentionInboxRepository);
+    }
+
+    private ChatHub BuildHub(string connectionId, MembershipRepository membershipRepository = null)
+    {
+        var hub = new ChatHub(
+            _connectionMapping,
+            _reconcileHarness.Service,
+            _ticketStore,
+            _sessionRegistry,
+            _userDirectory,
+            _assembler,
+            _focusRegistry,
+            _onlineMemberRegistry,
+            _messageRateLimiter,
+            _readRateLimiter,
+            _time,
+            _channelRepository,
+            membershipRepository ?? _membershipRepository,
+            _channelCreationRateLimiter,
+            _messageRepository,
+            _fanOutEngine,
+            ViewersAccumulatorTestFactory.CreateIgnored(),
+            new NoOpMentionInboxCleaner(),
+            RelationshipProviderTestFactory.CreateIgnored(),
+            new UserSettingsRepository(MongoClient),
+            new DmInitiationTracker(),
+            _authService.Object,
+            MentionFanOutTestFactory.CreateIgnored(MongoClient),
+            new PresenceInterestRegistry(),
+            _mentionInboxRepository,
+            new NotificationPreferenceRepository(MongoClient));
+
+        hub.Clients = new Mock<IHubCallerClients>().Object;
+
+        var context = new Mock<HubCallerContext>();
+        context.Setup(c => c.ConnectionId).Returns(connectionId);
+        hub.Context = context.Object;
+        hub.Groups = new Mock<IGroupManager>().Object;
+
+        return hub;
+    }
+
+    private void RegisterSession(string connectionId, string battleTag) =>
+        _sessionRegistry.Register(
+            connectionId,
+            new W3CUserAuthentication { BattleTag = battleTag, Name = battleTag.Split('#')[0] },
+            null);
+
+    private void JoinChannel(string channelId, string connectionId, string battleTag, ChannelType type) =>
+        _onlineMemberRegistry.Join(channelId, connectionId, new MemberState(battleTag, NotificationLevel.All, 0, type));
+
+    private Task SeedDirectory(string battleTag, DateTime lastSeenAt) =>
+        _userDirectory.Upsert(new UserDirectoryEntry
+        {
+            BattleTag = battleTag,
+            DisplayBattleTag = battleTag,
+            NormalizedName = battleTag.ToLowerInvariant(),
+            LastSeenAt = lastSeenAt,
+        });
+
+    private Task SeedMembership(string channelId, string battleTag) =>
+        _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = channelId,
+            BattleTag = battleTag,
+            Role = MembershipRole.Member,
+            NotificationLevel = NotificationLevel.All,
+            JoinedAt = Now,
+        });
+
+    // ---------------------------------------------------------------------------------------------
+    // (i)/(j): SemiPublic and System — a non-member is NEVER offered, even though online AND
+    // directory-fresh; an actual member IS still offered.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Search_SemiPublicChannel_NonMemberExcluded_ActualMemberOffered()
+    {
+        const string channelId = "semi-1";
+        const string caller = "caller#1";
+        const string buddy = "buddy#2";       // actual member, offline but recently active
+        const string intruder = "intruder#3"; // NOT a member — online AND directory-fresh
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.SemiPublic);
+        await SeedMembership(channelId, buddy);
+        await SeedDirectory(buddy, Now.AddDays(-1));
+
+        RegisterSession("conn-intruder", intruder); // tier-2-eligible if scoping didn't hold
+        await SeedDirectory(intruder, Now.AddDays(-1)); // tier-3-eligible if scoping didn't hold
+
+        var hub = BuildHub("conn-caller");
+        var result = await hub.SearchMentionCandidates(channelId, "");
+
+        var tags = result.Candidates.Select(c => c.BattleTag).ToList();
+        Assert.That(tags, Does.Contain(buddy), "an actual SemiPublic member must still be offered");
+        Assert.That(tags, Does.Not.Contain(intruder),
+            "D1: a non-member must NEVER be offered inside a SemiPublic room, even though it is online and directory-fresh");
+    }
+
+    [Test]
+    public async Task Search_SystemChannel_NonMemberExcluded_ActualMemberOffered()
+    {
+        const string channelId = "system-1";
+        const string caller = "caller#1";
+        const string buddy = "buddy#2";       // actual member, offline but recently active
+        const string intruder = "intruder#3"; // NOT a member — online AND directory-fresh
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.System);
+        await SeedMembership(channelId, buddy);
+        await SeedDirectory(buddy, Now.AddDays(-1));
+
+        RegisterSession("conn-intruder", intruder);
+        await SeedDirectory(intruder, Now.AddDays(-1));
+
+        var hub = BuildHub("conn-caller");
+        var result = await hub.SearchMentionCandidates(channelId, "");
+
+        var tags = result.Candidates.Select(c => c.BattleTag).ToList();
+        Assert.That(tags, Does.Contain(buddy), "an actual System-channel member must still be offered");
+        Assert.That(tags, Does.Not.Contain(intruder),
+            "D1: a non-member must NEVER be offered inside a System channel (any SystemChannelKind), even though it is online and directory-fresh");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // (k): Public is UNCHANGED — still the universe-wide "mention anywhere" lane, no membership read.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Search_PublicChannel_NonMemberStillOffered_Unchanged()
+    {
+        const string channelId = "pub-1";
+        const string caller = "caller#1";
+        const string stranger = "stranger#2"; // online, but never a member of this Public channel
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.Public);
+        RegisterSession("conn-stranger", stranger);
+
+        var hub = BuildHub("conn-caller");
+        var result = await hub.SearchMentionCandidates(channelId, "");
+
+        Assert.That(result.Candidates.Select(c => c.BattleTag), Does.Contain(stranger),
+            "D1: Public stays the universe-wide, unrestricted lane — a non-member online user is still offered");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // (m): big-room boundedness — the SemiPublic/System lane must never call LoadForChannel (the
+    // full-room membership scan); it stays bounded to the already-capped candidate list via
+    // LoadMemberBattleTags instead.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Search_SemiPublicChannel_NeverCallsLoadForChannel()
+    {
+        const string channelId = "semi-1";
+        const string caller = "caller#1";
+        const string buddy = "buddy#2";
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.SemiPublic);
+        await SeedMembership(channelId, buddy);
+        await SeedDirectory(buddy, Now.AddDays(-1));
+
+        var countingMembership = new CountingMembershipRepository(MongoClient, _channelRepository);
+        var hub = BuildHub("conn-caller", countingMembership);
+
+        var result = await hub.SearchMentionCandidates(channelId, "");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        Assert.That(result.Candidates.Select(c => c.BattleTag), Does.Contain(buddy), "the candidate-side check must still find the real member");
+        Assert.That(countingMembership.LoadForChannelCallCount, Is.EqualTo(0),
+            "D1: the SemiPublic/System lane must stay bounded to the candidate list via LoadMemberBattleTags — " +
+            "it must NEVER fall back to LoadForChannel's full-room membership scan");
+    }
+
+    [Test]
+    public async Task Search_SystemChannel_NeverCallsLoadForChannel()
+    {
+        const string channelId = "system-1";
+        const string caller = "caller#1";
+        const string buddy = "buddy#2";
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.System);
+        await SeedMembership(channelId, buddy);
+        await SeedDirectory(buddy, Now.AddDays(-1));
+
+        var countingMembership = new CountingMembershipRepository(MongoClient, _channelRepository);
+        var hub = BuildHub("conn-caller", countingMembership);
+
+        var result = await hub.SearchMentionCandidates(channelId, "");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        Assert.That(result.Candidates.Select(c => c.BattleTag), Does.Contain(buddy), "the candidate-side check must still find the real member");
+        Assert.That(countingMembership.LoadForChannelCallCount, Is.EqualTo(0),
+            "D1: the SemiPublic/System lane must stay bounded to the candidate list via LoadMemberBattleTags — " +
+            "it must NEVER fall back to LoadForChannel's full-room membership scan");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Tier 1 (live viewers) is exempt from the candidate-side re-check by construction (see the class
+    // doc on ChatHub.Mentions.cs's SearchMentionCandidates): reaching tier 1 requires a successful
+    // FocusChannel call, which itself requires OnlineMemberRegistry membership — always seeded from a
+    // durable row. This proves an ACTUAL member who is currently focused (tier 1) is still returned by
+    // the SemiPublic lane (i.e. the candidate-side filter never accidentally excludes a genuine tier-1 hit).
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Search_SemiPublicChannel_Tier1Viewer_ActualMember_StillOffered()
+    {
+        const string channelId = "semi-1";
+        const string caller = "caller#1";
+        const string viewer = "viewer#2";
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.SemiPublic);
+
+        RegisterSession("conn-viewer", viewer);
+        JoinChannel(channelId, "conn-viewer", viewer, ChannelType.SemiPublic);
+        await SeedMembership(channelId, viewer);
+        _focusRegistry.Focus("conn-viewer", channelId, viewer);
+
+        var hub = BuildHub("conn-caller");
+        var result = await hub.SearchMentionCandidates(channelId, "");
+
+        var candidate = result.Candidates.SingleOrDefault(c => c.BattleTag == viewer);
+        Assert.That(candidate, Is.Not.Null, "a genuine tier-1 (focused) member must still be offered by the SemiPublic lane");
+        Assert.That(candidate.Tier, Is.EqualTo(1));
+    }
+}

--- a/W3ChampionsChatService.Tests/ChatHubMentionSearchScopingTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionSearchScopingTests.cs
@@ -294,11 +294,14 @@ public class ChatHubMentionSearchScopingTests : IntegrationTestBase
     }
 
     // ---------------------------------------------------------------------------------------------
-    // Tier 1 (live viewers) is exempt from the candidate-side re-check by construction (see the class
+    // Tier 1 (live viewers) is EXEMPT from the candidate-side re-check by construction (see the class
     // doc on ChatHub.Mentions.cs's SearchMentionCandidates): reaching tier 1 requires a successful
     // FocusChannel call, which itself requires OnlineMemberRegistry membership — always seeded from a
-    // durable row. This proves an ACTUAL member who is currently focused (tier 1) is still returned by
-    // the SemiPublic lane (i.e. the candidate-side filter never accidentally excludes a genuine tier-1 hit).
+    // durable row. Fix round 1 (finding F6b): this test only pins the POSITIVE half of that invariant —
+    // a genuine tier-1 (focused) member is still returned by the SemiPublic lane. The NEGATIVE half (a
+    // non-member somehow reaching tier 1 and wrongly surviving the exemption) is not something this test
+    // CAN exercise: the registry invariant makes that state impossible to construct in the first place,
+    // not merely untested here.
     // ---------------------------------------------------------------------------------------------
 
     [Test]
@@ -322,5 +325,141 @@ public class ChatHubMentionSearchScopingTests : IntegrationTestBase
         var candidate = result.Candidates.SingleOrDefault(c => c.BattleTag == viewer);
         Assert.That(candidate, Is.Not.Null, "a genuine tier-1 (focused) member must still be offered by the SemiPublic lane");
         Assert.That(candidate.Tier, Is.EqualTo(1));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Fix round 1, finding F1 — the member-scoped RECALL BACKFILL. Filtering tiers 2/3 down to real
+    // members (the tests above) can, on a big room, leave a short prefix with near-nothing: the global
+    // tiers rank+cap against the WORLD before the member filter ever runs, so non-member noise can
+    // crowd a genuine member entirely out of the pre-filter candidate window. These prove the backfill
+    // (MembershipRepository.SearchMemberBattleTagsByPrefix) restores recall for that member without
+    // ever loading the whole room.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Search_SemiPublicChannel_ShortPrefix_BigRoomNoise_MemberStillOffered_ViaBackfill()
+    {
+        const string channelId = "semi-1";
+        const string caller = "caller#1";
+        const string member = "m-buddy#2"; // actual member: OFFLINE, no directory row — findable ONLY via the backfill
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.SemiPublic);
+
+        // Global noise matching the SAME 1-char prefix, sized well past the result cap — enough to fill
+        // tier 2 (online anywhere) BEFORE the member-scope filter ever runs, so the member (who is never
+        // registered as online) has zero chance of reaching `candidates` through the global tiers at all.
+        for (var i = 0; i < ChatLimits.MentionSearchMaxResults + 10; i++)
+        {
+            RegisterSession($"conn-noise-{i}", $"m-noise{i}#1");
+        }
+
+        await SeedMembership(channelId, member);
+
+        var hub = BuildHub("conn-caller");
+        var result = await hub.SearchMentionCandidates(channelId, "m");
+
+        Assert.That(result.Candidates.Select(c => c.BattleTag), Does.Contain(member),
+            "F1: a member matching a short prefix must be recalled via the backfill even when global-tier " +
+            "noise fully dominates the pre-filter candidate window");
+    }
+
+    [Test]
+    public async Task Search_SystemChannel_ShortPrefix_BigRoomNoise_MemberStillOffered_ViaBackfill()
+    {
+        const string channelId = "system-1";
+        const string caller = "caller#1";
+        const string member = "m-buddy#2";
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.System);
+
+        for (var i = 0; i < ChatLimits.MentionSearchMaxResults + 10; i++)
+        {
+            RegisterSession($"conn-noise-{i}", $"m-noise{i}#1");
+        }
+
+        await SeedMembership(channelId, member);
+
+        var hub = BuildHub("conn-caller");
+        var result = await hub.SearchMentionCandidates(channelId, "m");
+
+        Assert.That(result.Candidates.Select(c => c.BattleTag), Does.Contain(member),
+            "F1: the same recall backfill applies to System channels (any SystemChannelKind)");
+    }
+
+    [Test]
+    public async Task Search_SemiPublicChannel_ShortPrefix_NonMemberStillAbsent_ViaBackfill()
+    {
+        const string channelId = "semi-1";
+        const string caller = "caller#1";
+        const string intruder = "m-intruder#9"; // matches the prefix, has a directory row, but NO membership
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.SemiPublic);
+        await SeedDirectory(intruder, Now.AddDays(-1));
+
+        var hub = BuildHub("conn-caller");
+        var result = await hub.SearchMentionCandidates(channelId, "m");
+
+        Assert.That(result.Candidates.Select(c => c.BattleTag), Does.Not.Contain(intruder),
+            "F1: the backfill queries channel_memberships DIRECTLY, so it can never surface a non-member " +
+            "regardless of prefix or directory freshness");
+    }
+
+    [Test]
+    public async Task Search_SemiPublicChannel_Backfill_BoundedAndNeverCallsLoadForChannel()
+    {
+        const string channelId = "semi-1";
+        const string caller = "caller#1";
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.SemiPublic);
+
+        // More matching members than the result cap — the backfill's own `limit` (remaining slots) must
+        // bound the read, never the room's total membership.
+        for (var i = 0; i < ChatLimits.MentionSearchMaxResults + 10; i++)
+        {
+            await SeedMembership(channelId, $"m-member{i}#1");
+        }
+
+        var countingMembership = new CountingMembershipRepository(MongoClient, _channelRepository);
+        var hub = BuildHub("conn-caller", countingMembership);
+
+        var result = await hub.SearchMentionCandidates(channelId, "m");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        Assert.That(result.Candidates.Count, Is.LessThanOrEqualTo(ChatLimits.MentionSearchMaxResults),
+            "F1: the backfill's own limit (remaining cap slots) must bound the result, never the room's total membership");
+        Assert.That(countingMembership.LoadForChannelCallCount, Is.EqualTo(0),
+            "F1: the backfill must stay bounded via SearchMemberBattleTagsByPrefix — it must NEVER fall back to LoadForChannel's full-room scan");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Fix round 1, finding F6a — Public is the ONLY lane that must never perform ANY membership-scoping
+    // read at all (not just never the full-room LoadForChannel — the batched LoadMemberBattleTags check
+    // itself must never run either).
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Search_PublicChannel_PerformsNoMembershipScopingRead()
+    {
+        const string channelId = "pub-1";
+        const string caller = "caller#1";
+        const string stranger = "stranger#2";
+
+        RegisterSession("conn-caller", caller);
+        JoinChannel(channelId, "conn-caller", caller, ChannelType.Public);
+        RegisterSession("conn-stranger", stranger);
+
+        var countingMembership = new CountingMembershipRepository(MongoClient, _channelRepository);
+        var hub = BuildHub("conn-caller", countingMembership);
+
+        var result = await hub.SearchMentionCandidates(channelId, "");
+
+        Assert.That(result.Candidates.Select(c => c.BattleTag), Does.Contain(stranger));
+        Assert.That(countingMembership.LoadMemberBattleTagsCallCount, Is.EqualTo(0),
+            "F6a: Public is the universe-wide lane — it must never perform ANY membership-scoping read, batched or otherwise");
+        Assert.That(countingMembership.LoadForChannelCallCount, Is.EqualTo(0));
     }
 }

--- a/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
@@ -29,7 +29,7 @@ namespace W3ChampionsChatService.Tests;
 /// gates (step 5.5) and the mute gate (step 6). After the amendment the gate validates EXACTLY ONE thing:
 /// the mention COUNT cap (an anti-abuse bound). A message is NEVER rejected for the resolvability or
 /// access of its mentions — an unresolvable/garbage tag, or a tag naming a non-member, is legal content
-/// that delivers VERBATIM and simply never fans out (the membership wall in <see cref="MentionFanOut"/>
+/// that delivers with its markup rewritten to plain text by step 5.26 and never fans out (the membership wall in <see cref="MentionFanOut"/>
 /// is the sole authority on who is notified — proven directly in <see cref="MentionFanOutTests"/> and
 /// end-to-end in <see cref="ChatHubSendMessageTests"/>). Two properties are load-bearing here: (1) the
 /// COUNT cap is content-intrinsic, so a blocked sender and an unblocked sender must get an IDENTICAL

--- a/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
@@ -247,15 +247,17 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task Send_UnresolvableMention_StillOk_DeliversVerbatim()
+    public async Task Send_UnresolvableMention_StillOk_StrippedToPlainText()
     {
         var channel = await CreateChannel("general");
         SeedMember("conn-1", Sender, channel.Id);
         var hub = BuildHub("conn-1");
 
-        // "ghost#999" resolves to nobody (never seeded anywhere). Strip-and-deliver-as-plain: the send is
-        // NOT rejected — the message delivers VERBATIM (the client renders the invalid <@…> as plain text),
-        // and the fan-out's membership wall alone drops the (non-member) target. NOT TooLong.
+        // "ghost#999" resolves to nobody (never seeded anywhere) — no membership row, and the channel is
+        // Public but the tag is not directory-resolvable, so it fails the D2 renderability predicate. The
+        // send is NOT rejected, but step 5.26 rewrites the token to its plain-text form before persist —
+        // the fan-out's membership wall (now a redundant second line of defense) still drops the target
+        // for notification purposes independently. NOT TooLong.
         var content = $"hey {Mention("ghost#999")}";
         var result = await hub.SendMessage(channel.Id, content);
 
@@ -264,7 +266,8 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
         var reloaded = await _channelRepository.Load(channel.Id);
         Assert.That(reloaded.LastSeq, Is.EqualTo(1L), "the message persists — an unresolvable mention is legal content");
         var persisted = await _messageRepository.Load(result.MessageId);
-        Assert.That(persisted.Content, Is.EqualTo(content), "the message text delivers verbatim — the invalid <@…> token is kept");
+        Assert.That(persisted.Content, Is.EqualTo("hey @ghost#999"),
+            "D2 (2026-08-05): a non-renderable mention token is stripped to its plain-text form in the persisted content");
     }
 
     [Test]
@@ -282,25 +285,42 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
     }
 
     // ---------------------------------------------------------------------------------------------
-    // Zero-cost / zero-DB: the send path performs NO directory read — even for a message WITH mentions
-    // (the resolvability Load loop was removed by the strip-and-deliver-as-plain amendment).
+    // Bounded-cost: D2 (2026-08-05) reintroduces directory reads on the mention send path — one per
+    // distinct target that has no membership row in a Public channel — but they stay BOUNDED at
+    // MaxMentionsPerMessage (5), never unbounded, and a message with NO mention tokens still pays zero.
     // ---------------------------------------------------------------------------------------------
 
     [Test]
-    public async Task Send_WithMentions_PerformsZeroDirectoryReads()
+    public async Task Send_WithMentions_PerformsBoundedDirectoryReads_ForCanonicalization()
     {
         var channel = await CreateChannel("general");
         SeedMember("conn-1", Sender, channel.Id);
         var countingDirectory = new CountingUserDirectoryRepository(MongoClient);
         var hub = BuildHub("conn-1", countingDirectory);
 
-        // A message carrying real mention markup — under the old gate this would have driven one directory
-        // Load per tag. The resolvability check is gone, so the send path must now do ZERO directory reads.
+        // Two distinct non-member targets in a Public channel — step 5.26's renderability predicate reads
+        // the directory once per target (neither has a membership row) to decide render-vs-strip. Bounded
+        // to the distinct-tag count, never per-occurrence or unbounded.
         var result = await hub.SendMessage(channel.Id, $"hey {Mention("wolf#456")} and {Mention("frank#789")}");
 
         Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        Assert.That(countingDirectory.LoadCallCount, Is.EqualTo(2),
+            "D2's renderability predicate reads the directory exactly once per distinct non-member Public-channel target");
+    }
+
+    [Test]
+    public async Task Send_WithoutMentions_PerformsZeroDirectoryReads()
+    {
+        var channel = await CreateChannel("general");
+        SeedMember("conn-1", Sender, channel.Id);
+        var countingDirectory = new CountingUserDirectoryRepository(MongoClient);
+        var hub = BuildHub("conn-1", countingDirectory);
+
+        var result = await hub.SendMessage(channel.Id, "just a plain message, no mentions here");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
         Assert.That(countingDirectory.LoadCallCount, Is.EqualTo(0),
-            "the send path performs ZERO directory reads — resolvability is no longer validated (strip & deliver as plain)");
+            "a message with no <@tag> tokens must pay zero directory reads — mentionTags.Count == 0 short-circuits step 5.26 entirely");
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -388,5 +408,115 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
             "consequence (D2): a full-muted sender with over-cap markup gets TooLong, not Muted");
         var reloaded = await _channelRepository.Load(channel.Id);
         Assert.That(reloaded.LastSeq, Is.EqualTo(0L));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // D2 (2026-08-05, server-canonical rendering — mention-canonicalization brief, step 5.26):
+    // walled-channel (SemiPublic/System) render canonicalization, verified via the GetMessages
+    // round-trip (not just MessageRepository.Load) — proving a READER, not just the raw persisted row,
+    // sees the canonical content.
+    // ---------------------------------------------------------------------------------------------
+
+    private Task SeedDurableMembership(string channelId, string battleTag, NotificationLevel level = NotificationLevel.All) =>
+        _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = channelId,
+            BattleTag = battleTag,
+            NotificationLevel = level,
+            JoinedAt = Now,
+        });
+
+    [Test]
+    public async Task Send_SemiPublicChannel_NonMemberStripped_MemberKeepsMarkup_ViaGetMessagesRoundTrip()
+    {
+        var channel = await CreateChannel("semi-room", ChannelType.SemiPublic);
+        SeedMember("conn-1", Sender, channel.Id, ChannelType.SemiPublic);
+        await SeedDurableMembership(channel.Id, Recipient); // a real member — a legal render target
+
+        var hub = BuildHub("conn-1");
+        var content = $"hey {Mention(Recipient)} and {Mention("ghost#999")}";
+        var result = await hub.SendMessage(channel.Id, content);
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+
+        var expected = $"hey {Mention(Recipient)} and @ghost#999";
+        var page = await hub.GetMessages(channel.Id, null, null, 10);
+        Assert.That(page.Code, Is.EqualTo(ChatResultCode.Ok));
+        Assert.That(page.Messages.Single(m => m.Id == result.MessageId).Content, Is.EqualTo(expected),
+            "a SemiPublic non-member's mention token is stripped to plain text and a real member's markup " +
+            "is kept — a READER (GetMessages), not just the raw persisted row, sees the canonical content");
+    }
+
+    [Test]
+    public async Task Send_SystemMatchChannel_NonMemberStripped_MemberKeepsMarkup_ViaGetMessagesRoundTrip()
+    {
+        var channel = new ChatChannel
+        {
+            Type = ChannelType.System,
+            SystemKind = SystemChannelKind.Match,
+            SystemRef = "match-1",
+            Name = "Match Chat",
+        };
+        await _channelRepository.Insert(channel);
+        SeedMember("conn-1", Sender, channel.Id, ChannelType.System);
+        await SeedDurableMembership(channel.Id, Recipient); // a real member — a legal render target
+
+        var hub = BuildHub("conn-1");
+        var content = $"hey {Mention(Recipient)} and {Mention("ghost#999")}";
+        var result = await hub.SendMessage(channel.Id, content);
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+
+        var expected = $"hey {Mention(Recipient)} and @ghost#999";
+        var page = await hub.GetMessages(channel.Id, null, null, 10);
+        Assert.That(page.Code, Is.EqualTo(ChatResultCode.Ok));
+        Assert.That(page.Messages.Single(m => m.Id == result.MessageId).Content, Is.EqualTo(expected),
+            "a System (match) channel non-member's mention token is stripped to plain text and a real " +
+            "member's markup is kept — a READER (GetMessages), not just the raw persisted row, sees the canonical content");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // The renderability predicate deliberately IGNORES blocks and notification preferences — those
+    // suppress the PING (MentionFanOut), never the RENDER. A stripped chip for a blocking member would
+    // leak the block state to the sender (explicit Marco pin); ping suppression itself is proven directly
+    // against NotifyAsync in MentionFanOutTests (e.g. Notify_BlockedTarget_MemberBranch_...).
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Send_MentionOfMemberWhoBlockedSender_MarkupKept_RenderNeverLeaksBlocks()
+    {
+        var channel = await CreateChannel("general");
+        SeedMember("conn-1", Sender, channel.Id);
+        await SeedDurableMembership(channel.Id, Recipient);
+        // Configure a real block relationship (Recipient has blocked Sender) on the SAME relationship
+        // provider the hub's private-lane gates use — documents that the render predicate has no path to
+        // it at all (step 5.26 never consults IRelationshipProvider), unlike MentionFanOut's own D1 ping gate.
+        SetBlocked(Recipient, Sender);
+        var hub = BuildHub("conn-1");
+
+        var content = $"hey {Mention(Recipient)}";
+        var result = await hub.SendMessage(channel.Id, content);
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        var persisted = await _messageRepository.Load(result.MessageId);
+        Assert.That(persisted.Content, Is.EqualTo(content),
+            "a mentioned member's markup stays intact even though they blocked the sender — " +
+            "the renderability predicate never consults blocks; only MentionFanOut's separate ping gate does");
+    }
+
+    [Test]
+    public async Task Send_MentionOfMemberWithNotificationLevelNone_MarkupKept()
+    {
+        var channel = await CreateChannel("general");
+        SeedMember("conn-1", Sender, channel.Id);
+        await SeedDurableMembership(channel.Id, Recipient, NotificationLevel.None);
+        var hub = BuildHub("conn-1");
+
+        var content = $"hey {Mention(Recipient)}";
+        var result = await hub.SendMessage(channel.Id, content);
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        var persisted = await _messageRepository.Load(result.MessageId);
+        Assert.That(persisted.Content, Is.EqualTo(content),
+            "a mentioned member's markup stays intact even with NotificationLevel.None — " +
+            "the renderability predicate only checks membership EXISTENCE, never the notification level");
     }
 }

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -732,31 +732,37 @@ public class ChatHubSendMessageTests : IntegrationTestBase
     }
 
     // ---------------------------------------------------------------------------------------------
-    // C6 "strip & deliver as plain" (Marco decision 3): a message is NEVER rejected because of its
-    // mentions' access/resolvability. An unresolvable/garbage tag, or a tag naming a NON-member, delivers
-    // VERBATIM (the client renders the invalid <@…> as plain) and simply produces no inbox entry + no
-    // notification — the membership wall in MentionFanOut is the sole authority on who is notified. Since
-    // follow-up spec §4, that wall is widened for PUBLIC channels: a directory-RESOLVABLE non-member of a
-    // Public channel now DOES get an entry + notification (only an unresolvable tag still gets nothing
-    // there); Dm/GroupDm/SemiPublic/System keep the unconditional membership wall. These exercise the full
-    // SendMessage pipeline end-to-end (real MentionFanOut + inbox repo + push harness).
+    // C6 "strip & deliver as plain" (Marco decision 3), amended by D2 (2026-08-05, server-canonical
+    // rendering): a message is NEVER rejected because of its mentions' access/resolvability. But since D2,
+    // an unresolvable/garbage tag, or a tag naming a NON-legal-render-target, is no longer delivered with
+    // its markup intact — step 5.26 rewrites it to plain text (`@tag`) in the PERSISTED content before the
+    // fan-out ever runs, so every reader sees identical canonical content. The membership wall in
+    // MentionFanOut still independently decides who gets an inbox entry + notification (now a redundant
+    // second line of defense behind the same base condition step 5.26 already evaluated). Since follow-up
+    // spec §4, that wall is widened for PUBLIC channels: a directory-RESOLVABLE non-member of a Public
+    // channel keeps its markup AND gets an entry + notification (only an unresolvable tag still gets
+    // nothing there, and is stripped); Dm/GroupDm/SemiPublic/System keep the unconditional membership wall
+    // for BOTH render and notify. These exercise the full SendMessage pipeline end-to-end (real
+    // MentionFanOut + inbox repo + push harness).
     // ---------------------------------------------------------------------------------------------
 
     [Test]
-    public async Task Mention_GarbageTag_Ok_DeliveredVerbatim_NoInboxEntry()
+    public async Task Mention_GarbageTag_Ok_StrippedToPlainText_NoInboxEntry()
     {
         var channel = await CreateChannel("general");
         SeedMember("conn-1", BattleTag, channel.Id);
         var hub = BuildHub("conn-1");
 
-        // "ghost#999" resolves to nobody (no directory row, no session, no membership) — a garbage mention.
+        // "ghost#999" resolves to nobody (no directory row, no session, no membership) — a garbage mention,
+        // and NOT a legal render target (no membership row; Public but not directory-resolvable).
         var content = $"hey {Mention("ghost#999")} are you real?";
         var result = await hub.SendMessage(channel.Id, content);
 
         Assert.AreEqual(ChatResultCode.Ok, result.Code, "an unresolvable/garbage <@tag> must NEVER reject the send");
         var persisted = await _messageRepository.Load(result.MessageId);
         Assert.IsNotNull(persisted, "the message is durably persisted");
-        Assert.AreEqual(content, persisted.Content, "the message delivers verbatim — the client renders the invalid <@…> as plain text");
+        Assert.AreEqual("hey @ghost#999 are you real?", persisted.Content,
+            "D2: a non-renderable mention token is stripped to its plain-text form in the persisted content");
         Assert.IsEmpty(await _mentionInboxRepository.LoadForUser("ghost#999"), "a garbage mention writes NO inbox entry");
         Assert.IsEmpty(_mentionPushHarness.AllSignals, "and pushes nothing");
     }
@@ -771,9 +777,13 @@ public class ChatHubSendMessageTests : IntegrationTestBase
         await SeedDirectory("stranger#1");
         var hub = BuildHub("conn-1");
 
-        var result = await hub.SendMessage(channel.Id, $"hey {Mention("stranger#1")}");
+        var content = $"hey {Mention("stranger#1")}";
+        var result = await hub.SendMessage(channel.Id, content);
 
         Assert.AreEqual(ChatResultCode.Ok, result.Code, "mentioning a resolvable non-member of a public channel is legal — no reject");
+        var persisted = await _messageRepository.Load(result.MessageId);
+        Assert.AreEqual(content, persisted.Content,
+            "D2: a directory-resolvable target in a Public channel IS a legal render target — markup stays intact, never stripped");
         Assert.AreEqual(1, (await _mentionInboxRepository.LoadForUser("stranger#1")).Count,
             "follow-up spec §4: a directory-resolvable non-member of a PUBLIC channel now gets an inbox entry — the membership wall is widened away for Public rooms only");
         Assert.AreEqual(1, _mentionPushHarness.SignalCount("conn-stranger", ChatEvents.MentionNotified),
@@ -782,13 +792,16 @@ public class ChatHubSendMessageTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task Mention_NonMemberInGroupDm_Ok_DeliveredVerbatim_NonMemberGetsNothing_MemberControlNotified()
+    public async Task Mention_NonMemberInGroupDm_Ok_OutsiderStripped_MemberKeepsMarkup_MemberControlNotified()
     {
         // Marco's headline case: a GroupDm (a PRIVATE conversation). The sender mentions BOTH an outsider
-        // who is NOT a member of the group AND a real member (wolf). The send is NOT rejected — it delivers
-        // VERBATIM — but the excerpt PRIVACY WALL means the non-member outsider gets NO inbox entry and NO
-        // MentionNotified (a private conversation's ~120-char excerpt must never reach a non-participant),
-        // while the member control still gets both (so this fails against a do-nothing stub too).
+        // who is NOT a member of the group AND a real member (wolf). The send is NOT rejected, but D2
+        // (2026-08-05) strips the outsider's token to plain text — a GroupDm is never Public, so a
+        // non-member is never a legal render target there, only a real membership row is — while wolf's
+        // markup stays intact. The excerpt PRIVACY WALL still means the non-member outsider gets NO inbox
+        // entry and NO MentionNotified (a private conversation's ~120-char excerpt must never reach a
+        // non-participant), while the member control still gets both (so this fails against a do-nothing
+        // stub too).
         var group = new ChatChannel { Type = ChannelType.GroupDm, Name = "squad", LastSeq = 0, LastMessageAt = Now, ExpiresAt = Now.AddDays(365) };
         await _channelRepository.Insert(group);
         SeedMember("conn-1", BattleTag, group.Id);                     // sender (a member)
@@ -803,10 +816,11 @@ public class ChatHubSendMessageTests : IntegrationTestBase
 
         Assert.AreEqual(ChatResultCode.Ok, result.Code, "a mention of a non-member must NEVER reject the send (strip & deliver as plain)");
 
-        // The message delivered VERBATIM — persisted with the exact content, including the <@outsider#1> token.
+        // D2: the outsider's token is stripped to plain text; wolf's (an actual member) stays markup.
         var persisted = await _messageRepository.Load(result.MessageId);
         Assert.IsNotNull(persisted, "the message is durably persisted");
-        Assert.AreEqual(content, persisted.Content, "the message text delivers verbatim — the invalid <@…> token is kept as plain text");
+        Assert.AreEqual($"secret plans @outsider#1 and {Mention("wolf#456")}", persisted.Content,
+            "D2: a GroupDm non-member is never a legal render target — only the outsider's token is stripped, the member's markup is untouched");
 
         // The excerpt PRIVACY WALL: the non-member outsider gets NO inbox entry and NO MentionNotified —
         // a private (GroupDm) conversation's excerpt NEVER reaches a non-participant.

--- a/W3ChampionsChatService.Tests/CountingMembershipRepository.cs
+++ b/W3ChampionsChatService.Tests/CountingMembershipRepository.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Memberships;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// A <see cref="MembershipRepository"/> spy (subclass over the real Mongo-backed repository — mirrors
+/// <see cref="CountingUserDirectoryRepository"/>'s spy-over-real-repo idiom) that counts
+/// <see cref="LoadForChannel"/> calls, so a test can assert a bounded-room search path (D1, 2026-08-05
+/// follow-up: <c>ChatHub.SearchMentionCandidates</c>' SemiPublic/System member-scoping lane) never falls
+/// back to the full-room membership scan <see cref="LoadForChannel"/> performs — the whole point of the
+/// candidate-side <see cref="MembershipRepository.LoadMemberBattleTags"/> check being bounded to the
+/// (small, already-capped) candidate list rather than the room's total membership. <see cref="LoadForChannel"/>
+/// is already <c>virtual</c> for exactly this kind of test seam (see its own doc comment).
+/// </summary>
+internal sealed class CountingMembershipRepository(MongoClient client, ChannelRepository channelRepository)
+    : MembershipRepository(client, channelRepository)
+{
+    public int LoadForChannelCallCount { get; private set; }
+
+    public override Task<List<ChannelMembership>> LoadForChannel(string channelId)
+    {
+        LoadForChannelCallCount++;
+        return base.LoadForChannel(channelId);
+    }
+}

--- a/W3ChampionsChatService.Tests/CountingMembershipRepository.cs
+++ b/W3ChampionsChatService.Tests/CountingMembershipRepository.cs
@@ -15,15 +15,27 @@ namespace W3ChampionsChatService.Tests;
 /// candidate-side <see cref="MembershipRepository.LoadMemberBattleTags"/> check being bounded to the
 /// (small, already-capped) candidate list rather than the room's total membership. <see cref="LoadForChannel"/>
 /// is already <c>virtual</c> for exactly this kind of test seam (see its own doc comment).
+/// <para>
+/// Fix round 1 (finding F6a): also counts <see cref="LoadMemberBattleTags"/> calls, so a test can assert
+/// the Public lane — the ONLY channel type that must never perform ANY membership-scoping read at all —
+/// genuinely performs zero, not merely zero of the full-room variant.
+/// </para>
 /// </summary>
 internal sealed class CountingMembershipRepository(MongoClient client, ChannelRepository channelRepository)
     : MembershipRepository(client, channelRepository)
 {
     public int LoadForChannelCallCount { get; private set; }
+    public int LoadMemberBattleTagsCallCount { get; private set; }
 
     public override Task<List<ChannelMembership>> LoadForChannel(string channelId)
     {
         LoadForChannelCallCount++;
         return base.LoadForChannel(channelId);
+    }
+
+    public override Task<HashSet<string>> LoadMemberBattleTags(string channelId, IEnumerable<string> battleTags)
+    {
+        LoadMemberBattleTagsCallCount++;
+        return base.LoadMemberBattleTags(channelId, battleTags);
     }
 }

--- a/W3ChampionsChatService.Tests/MentionMarkupTests.cs
+++ b/W3ChampionsChatService.Tests/MentionMarkupTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using W3ChampionsChatService.Mentions;
@@ -98,5 +100,96 @@ public class MentionMarkupTests
         var tags = MentionMarkup.ExtractTags("<@Zed#9> <@Ann#1> <@Zed#9> <@Mid#5>");
 
         Assert.That(tags.ToList(), Is.EqualTo(new[] { "Zed#9", "Ann#1", "Mid#5" }));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Fix round 1, finding F4 — direct RewriteUnrenderable pins (D2, 2026-08-05 server-canonical
+    // mention rendering). Previously only exercised indirectly through ChatHubMentionValidationTests'
+    // send-path integration tests; these pin the pure function's contract in isolation.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public void RewriteUnrenderable_MixedTargets_OnlyUnrenderableDowngradedToPlainText()
+    {
+        var content = "hi <@Peter#123> and <@Wolf#456>";
+        var decisions = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Peter#123"] = true,
+            ["Wolf#456"] = false,
+        };
+
+        var result = MentionMarkup.RewriteUnrenderable(content, tag => decisions[tag]);
+
+        Assert.That(result, Is.EqualTo("hi <@Peter#123> and @Wolf#456"),
+            "a renderable token's markup is left untouched; an unrenderable one is downgraded to its plain-text form");
+    }
+
+    [Test]
+    public void RewriteUnrenderable_CaseVariantDuplicates_SharePerTagDecision_KeepPerOccurrenceCasing()
+    {
+        var content = "<@Peter#123> ping <@PETER#123>";
+        var decisions = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Peter#123"] = false,
+        };
+
+        var result = MentionMarkup.RewriteUnrenderable(content, tag => decisions.TryGetValue(tag, out var v) && v);
+
+        Assert.That(result, Is.EqualTo("@Peter#123 ping @PETER#123"),
+            "both case-variant occurrences resolve to the SAME (case-insensitive, single-key) decision, " +
+            "but each downgraded occurrence keeps its OWN captured casing rather than normalizing to one");
+    }
+
+    [Test]
+    public void RewriteUnrenderable_AdjacentTokens_EachHandledIndependently()
+    {
+        var content = "<@Peter#123><@Wolf#456>";
+        var decisions = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Peter#123"] = true,
+            ["Wolf#456"] = false,
+        };
+
+        var result = MentionMarkup.RewriteUnrenderable(content, tag => decisions[tag]);
+
+        Assert.That(result, Is.EqualTo("<@Peter#123>@Wolf#456"),
+            "adjacent tokens with no separating text are each decided and rewritten independently");
+    }
+
+    [Test]
+    public void RewriteUnrenderable_NullOrEmptyContent_PassthroughUnchanged()
+    {
+        Assert.That(MentionMarkup.RewriteUnrenderable(null, _ => true), Is.Null);
+        Assert.That(MentionMarkup.RewriteUnrenderable("", _ => true), Is.EqualTo(""));
+    }
+
+    [Test]
+    public void RewriteUnrenderable_NoTokens_ByteIdentical_IsRenderableNeverInvoked()
+    {
+        const string content = "just a plain message with no mentions";
+
+        var result = MentionMarkup.RewriteUnrenderable(
+            content, _ => throw new InvalidOperationException("isRenderable must never be invoked when there are no <@tag> tokens"));
+
+        Assert.That(result, Is.EqualTo(content), "content with no markup tokens is returned byte-identical");
+    }
+
+    [Test]
+    public void RewriteUnrenderable_DecisionsMissForTag_StripsFailClosed()
+    {
+        var content = "<@Peter#123> and <@Wolf#456>";
+        // Deliberately incomplete — Wolf#456 has no entry, simulating the TryGetValue-miss branch a
+        // caller's decisions dictionary can hit (see MentionMarkup.cs's fail-closed comment on the
+        // Replace callback). A tag the caller never computed a decision for strips rather than renders.
+        var decisions = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Peter#123"] = true,
+        };
+
+        var result = MentionMarkup.RewriteUnrenderable(
+            content, tag => decisions.TryGetValue(tag, out var renderable) && renderable);
+
+        Assert.That(result, Is.EqualTo("<@Peter#123> and @Wolf#456"),
+            "a tag missing from the caller's decisions strips (fail-closed) rather than rendering an unvalidated mention");
     }
 }

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -619,8 +619,8 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
 
     // ============================================================================================
     // Slate 3 — MentionValidation_EndToEnd (acceptance 4).
-    // >5 distinct rejected (the COUNT cap); an unresolvable mention is NOT rejected — it delivers verbatim
-    // and simply notifies nobody (strip & deliver as plain); exactly 5 valid mentions fan out to EXACTLY
+    // >5 distinct rejected (the COUNT cap); an unresolvable mention is NOT rejected — it delivers with its
+    // markup stripped to plain text (step 5.26) and simply notifies nobody; exactly 5 valid mentions fan out to EXACTLY
     // those 5 members (a co-present non-mentioned member and the sender get nothing); a mentioned resolvable
     // NON-member of this PUBLIC channel DOES get notified (follow-up spec §4 — Public rooms are
     // membership-independent for a directory-resolvable target).

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -662,16 +662,17 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         Assert.That((await _channelRepository.Load(channel.Id)).LastSeq, Is.EqualTo(0L),
             "the over-cap send allocated no seq and persisted nothing");
 
-        // --- Strip & deliver as plain: an UNRESOLVABLE mention is NOT rejected — it delivers VERBATIM and
-        // simply notifies nobody. This channel is Public, so membership is not the gate here (§4) — the
-        // fan-out drops "nobody#404" because it has NO user_directory row, the directory-resolvability
-        // check §4 substitutes for the membership wall on Public rooms. NOT TooLong.
+        // --- Strip & deliver as plain, amended by D2 (2026-08-05): an UNRESOLVABLE mention is NOT
+        // rejected, but its markup IS stripped to plain text before persist (step 5.26) — this channel is
+        // Public, so membership is not the gate here (§4), but "nobody#404" has NO user_directory row
+        // either, so it fails the renderability predicate entirely. The fan-out (a redundant second line
+        // of defense here) independently drops it for notification too. NOT TooLong.
         var unresolvableContent = "who is <@nobody#404>";
         var unresolvable = await aHub.SendMessage(channel.Id, unresolvableContent);
         Assert.That(unresolvable.Code, Is.EqualTo(ChatResultCode.Ok),
             "an unresolvable battleTag is legal content — the send is never rejected for resolvability");
-        Assert.That((await _messageRepository.Load(unresolvable.MessageId)).Content, Is.EqualTo(unresolvableContent),
-            "the message delivers verbatim — the invalid <@…> token is kept as plain text");
+        Assert.That((await _messageRepository.Load(unresolvable.MessageId)).Content, Is.EqualTo("who is @nobody#404"),
+            "D2: a non-renderable mention token is stripped to its plain-text form in the persisted content");
         Assert.That(await _mentionInboxRepository.LoadForUser("nobody#404"), Is.Empty,
             "the unresolvable target gets no inbox entry (nobody#404 has no user_directory row — unresolvable, not merely a non-member)");
         Assert.That((await _channelRepository.Load(channel.Id)).LastSeq, Is.EqualTo(1L),

--- a/W3ChampionsChatService/Chats/ChatHub.Mentions.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Mentions.cs
@@ -145,18 +145,44 @@ public partial class ChatHub
     /// of what their directory <c>LastSeenAt</c> bookkeeping happens to say.</item>
     /// </list>
     /// <para>
-    /// PRIVATE-LANE SCOPING (<see cref="ChannelType.Dm"/>/<see cref="ChannelType.GroupDm"/> ONLY): every
-    /// tier's universe is additionally restricted to the channel's actual DURABLE member set, resolved
-    /// via <see cref="Memberships.MembershipRepository.LoadForChannel"/> — a non-member is never offered
-    /// as an autocomplete target inside a private conversation (Task 5 already ensures mentioning a
-    /// non-member never actually notifies them; this closes the matching UI-noise gap). Public/
-    /// SemiPublic/System search the full, unrestricted universe (no such read is made for them).
-    /// Tier 3 is resolved DIFFERENTLY in a private lane: rather than the generic UNSCOPED
-    /// <see cref="Users.UserDirectoryRepository.SearchByNormalizedPrefix"/> (whose own Mongo-side cap
-    /// could otherwise let unrelated directory noise crowd out a genuine member's row before it is ever
-    /// fetched — a real member must never be starved out of their own private lane's search), the member
-    /// set's directory rows are loaded ONCE up front (<see cref="Users.UserDirectoryRepository.LoadMany"/>)
-    /// and the prefix/90d filters are applied to that already-known, bounded set in memory instead.
+    /// MEMBER-SCOPING (D1, 2026-08-05 follow-up — <c>SearchMentionCandidates</c> must never OFFER someone
+    /// who isn't a legal mention target for the channel): every non-<see cref="ChannelType.Public"/>
+    /// channel type is member-scoped. Two DIFFERENT mechanisms back this, by channel size:
+    /// <list type="bullet">
+    /// <item><see cref="ChannelType.Dm"/>/<see cref="ChannelType.GroupDm"/> (small, ACL-bound, capped at
+    /// <see cref="ChatLimits.MaxGroupSize"/>): every tier's universe is restricted UP FRONT to the
+    /// channel's actual durable member set, resolved via
+    /// <see cref="Memberships.MembershipRepository.LoadForChannel"/> — safe here because the channel is
+    /// small by construction. A non-member is never offered as an autocomplete target inside a private
+    /// conversation (Task 5 already ensures mentioning a non-member never actually notifies them; this
+    /// closes the matching UI-noise gap). Tier 3 is resolved DIFFERENTLY here too: rather than the
+    /// generic UNSCOPED <see cref="Users.UserDirectoryRepository.SearchByNormalizedPrefix"/> (whose own
+    /// Mongo-side cap could otherwise let unrelated directory noise crowd out a genuine member's row
+    /// before it is ever fetched — a real member must never be starved out of their own private lane's
+    /// search), the member set's directory rows are loaded ONCE up front
+    /// (<see cref="Users.UserDirectoryRepository.LoadMany"/>) and the prefix/90d filters are applied to
+    /// that already-known, bounded set in memory instead.</item>
+    /// <item><see cref="ChannelType.SemiPublic"/>/<see cref="ChannelType.System"/> (any
+    /// <see cref="SystemChannelKind"/> — potentially LARGE rooms): tiers 1-3 run UNSCOPED exactly like
+    /// Public (no <c>LoadForChannel</c> — that could mean scanning an unboundedly large room's full
+    /// membership just to answer one autocomplete keystroke), then the already-assembled, already-capped
+    /// candidate set (≤ <see cref="ChatLimits.MentionSearchMaxResults"/>, ~20) is filtered CANDIDATE-SIDE
+    /// via <see cref="Memberships.MembershipRepository.LoadMemberBattleTags"/> — ONE batched indexed
+    /// <c>$in</c> query sized to the candidate list, not the room. Tier 1 (active viewers of THIS
+    /// channel, <see cref="FanOut.FocusRegistry.GetRoster"/>) is EXEMPT from this re-check: reaching tier
+    /// 1 requires having successfully called <c>FocusChannel</c>, which itself requires
+    /// <see cref="FanOut.OnlineMemberRegistry.IsMember"/> — and every call site that seeds that registry
+    /// (<c>JoinChannel</c>, <c>OpenDm</c>/<c>EnsureCallerMembership</c>, <c>FanOut.FanOutEngine.PushChannelAdded</c>)
+    /// inserts or ensures a durable <c>channel_memberships</c> row FIRST. So a channel's live-viewer
+    /// roster is, by construction, ALWAYS a subset of its actual durable members, for every channel type —
+    /// tier 1 candidates are never sent through the batched check. Tiers 2/3 carry no such guarantee (an
+    /// "online anywhere" or "recently active in the directory" user need not be a member of THIS
+    /// particular room) and are always checked. Results are a strict SUBSET of the pre-D1 unscoped
+    /// output — a genuinely eligible member beyond the pre-filter cap is never backfilled to top the
+    /// result back up to <see cref="ChatLimits.MentionSearchMaxResults"/>.</item>
+    /// </list>
+    /// <see cref="ChannelType.Public"/> is the ONLY type that still searches the full, unrestricted
+    /// universe (§4 "mention anywhere") — no membership read of any kind is made for it.
     /// </para>
     /// <para>
     /// ENRICHMENT: the whole assembled (deduped, capped) candidate list is enriched with display name,
@@ -300,6 +326,21 @@ public partial class ChatHub
                 var directoryMatches = await _userDirectory.SearchByNormalizedPrefix(
                     prefixLower, minLastSeenAt, remaining, seenLower);
                 AddTier(directoryMatches.Select(e => e.DisplayBattleTag ?? e.BattleTag), 3);
+            }
+        }
+
+        // D1 (2026-08-05 follow-up): SemiPublic/System member-scoping — CANDIDATE-SIDE, never
+        // LoadForChannel (see the class doc's MEMBER-SCOPING section for why the two channel groups use
+        // different mechanisms). Tier 1 is exempt from the re-check (a live viewer is, by construction,
+        // already a durable member — see the class doc); tiers 2/3 are batch-verified with ONE indexed
+        // $in query sized to the (already-capped, ~20) candidate list.
+        if (callerState.ChannelType is ChannelType.SemiPublic or ChannelType.System && candidates.Count > 0)
+        {
+            var toVerify = candidates.Where(c => c.Tier != 1).Select(c => c.BattleTag).ToList();
+            if (toVerify.Count > 0)
+            {
+                var verifiedMembers = await _membershipRepository.LoadMemberBattleTags(channelId, toVerify);
+                candidates.RemoveAll(c => c.Tier != 1 && !verifiedMembers.Contains(c.BattleTag));
             }
         }
 

--- a/W3ChampionsChatService/Chats/ChatHub.Mentions.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Mentions.cs
@@ -177,9 +177,39 @@ public partial class ChatHub
     /// roster is, by construction, ALWAYS a subset of its actual durable members, for every channel type —
     /// tier 1 candidates are never sent through the batched check. Tiers 2/3 carry no such guarantee (an
     /// "online anywhere" or "recently active in the directory" user need not be a member of THIS
-    /// particular room) and are always checked. Results are a strict SUBSET of the pre-D1 unscoped
-    /// output — a genuinely eligible member beyond the pre-filter cap is never backfilled to top the
-    /// result back up to <see cref="ChatLimits.MentionSearchMaxResults"/>.</item>
+    /// particular room) and are always checked.
+    /// <para>
+    /// TIER 2 KEEP-OR-DROP (fix round 1, finding F1 — explicitly left as a judgment call): tier 2 (online
+    /// anywhere) is KEPT for scoped rooms rather than dropped in favor of the recall backfill below. The
+    /// overlap is harmless — dedup is first-tier-wins, so a genuine online member the backfill would also
+    /// find stays tagged Tier 2 — and keeping it preserves the "currently online" autocomplete grouping
+    /// the <see cref="Protocol.MentionCandidateDto.Tier"/> contract promises callers; dropping it would
+    /// only ever LOSE that distinction (every online member the backfill can find, it finds regardless of
+    /// their tier-2 status), never gain anything.
+    /// </para>
+    /// <para>
+    /// RECALL BACKFILL (fix round 1, finding F1): filtering tiers 2/3 down to real members can leave a
+    /// short (1-2 char) prefix search with near-nothing on a big room — the global tiers above rank+cap
+    /// against the WORLD before the member filter ever runs, so non-member noise can crowd out genuine
+    /// members before they are even considered, degrading recall to "currently-focused viewers only"
+    /// until the prefix is long enough to narrow the global candidate pool back down. If candidates are
+    /// still under <see cref="ChatLimits.MentionSearchMaxResults"/> after the filter above, a
+    /// member-scoped BACKFILL (<see cref="Memberships.MembershipRepository.SearchMemberBattleTagsByPrefix"/>)
+    /// queries <c>channel_memberships</c> DIRECTLY for the prefix — an anchored range scan on the SAME
+    /// <c>ux_channelId_battleTag</c> index, bounded to the remaining slots, never <c>LoadForChannel</c>.
+    /// This covers BOTH online-but-unfocused members (ranked out of tier 2's own capped window by global
+    /// noise) AND offline members outside tier 3's 90d activity gate — restoring full short-prefix recall
+    /// for every legal mention target of the room without ever loading the whole room. Backfill hits are
+    /// tagged Tier 3 (they are, functionally, the member-scoped completion of tier 3's "not a live
+    /// viewer" bucket) and hydrated the same way every other tier ends up display-cased
+    /// (<see cref="Users.UserDirectoryRepository.LoadMany"/> — <c>channel_memberships</c> itself carries
+    /// no display casing, unlike the directory rows tiers 1-3 draw from), degrading to the bare
+    /// (lowercase) membership battleTag on a directory miss — the same graceful-degrade convention
+    /// <see cref="BuildCandidateDto"/>'s own directory-miss branch already uses. Results remain a strict
+    /// SUBSET of the pre-D1 unscoped output (every surfaced candidate is still a real member) — the
+    /// backfill restores RECALL, it does not relax the membership wall itself.
+    /// </para>
+    /// </item>
     /// </list>
     /// <see cref="ChannelType.Public"/> is the ONLY type that still searches the full, unrestricted
     /// universe (§4 "mention anywhere") — no membership read of any kind is made for it.
@@ -205,7 +235,9 @@ public partial class ChatHub
     /// scoping decision above without a second membership read.</item>
     /// <item>Assemble tiers 1-3 in order (each tier skipped once the cap is already met — tier 3's
     /// directory read never runs if tiers 1-2 alone already filled the cap), capped at
-    /// <see cref="ChatLimits.MentionSearchMaxResults"/> total.</item>
+    /// <see cref="ChatLimits.MentionSearchMaxResults"/> total; for SemiPublic/System, the candidate-side
+    /// member-verification filter and the fix-round-1 recall backfill (see the class doc's MEMBER-SCOPING
+    /// section) then run in sequence.</item>
     /// <item>ONE batch enrichment read, project to <see cref="MentionCandidateDto"/>, return
     /// <see cref="ChatResultCode.Ok"/>.</item>
     /// </list>
@@ -341,6 +373,36 @@ public partial class ChatHub
             {
                 var verifiedMembers = await _membershipRepository.LoadMemberBattleTags(channelId, toVerify);
                 candidates.RemoveAll(c => c.Tier != 1 && !verifiedMembers.Contains(c.BattleTag));
+            }
+        }
+
+        // Fix round 1 (finding F1): member-scoped RECALL BACKFILL for SemiPublic/System — see the class
+        // doc's MEMBER-SCOPING/RECALL BACKFILL section. The global tiers above rank+cap against the WORLD
+        // before the filter just above ever runs, so a short prefix on a big room can be filtered down to
+        // near-nothing even though real members match it. If there's still room under the cap, query
+        // channel_memberships DIRECTLY for the prefix (never LoadForChannel) to restore full recall —
+        // online-but-unfocused AND offline members alike, regardless of tier 3's 90d activity gate (a
+        // legal mention target of THIS room is never activity-gated).
+        if (callerState.ChannelType is ChannelType.SemiPublic or ChannelType.System
+            && candidates.Count < ChatLimits.MentionSearchMaxResults)
+        {
+            var remaining = ChatLimits.MentionSearchMaxResults - candidates.Count;
+            var seenLower = seen.Select(tag => tag.ToLowerInvariant()).ToList();
+            var memberMatches = await _membershipRepository.SearchMemberBattleTagsByPrefix(
+                channelId, prefixLower, remaining, seenLower);
+            if (memberMatches.Count > 0)
+            {
+                // Hydrate display casing/profile the same way the other tiers already carry it —
+                // channel_memberships stores no display casing of its own (unlike the directory rows
+                // tiers 1-3 draw from), so this is a small, separate batched read (bounded to
+                // memberMatches.Count, never a per-candidate lookup); a miss falls back to the bare
+                // (lowercase) membership battleTag — the same graceful-degrade convention
+                // BuildCandidateDto's own directory-miss branch already uses.
+                var backfillDirectory = await _userDirectory.LoadMany(memberMatches);
+                var backfillDirectoryByTag = backfillDirectory.ToDictionary(e => e.BattleTag, StringComparer.OrdinalIgnoreCase);
+                var displayTags = memberMatches.Select(tag =>
+                    backfillDirectoryByTag.TryGetValue(tag, out var entry) ? (entry.DisplayBattleTag ?? tag) : tag);
+                AddTier(displayTags, 3);
             }
         }
 

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
@@ -55,19 +56,31 @@ public partial class ChatHub
     /// <see cref="ChatLimits.MaxMentionsPerMessage"/> distinct tags → <see cref="ChatResultCode.TooLong"/>
     /// (an anti-abuse bound on fan-out work / spam; the pinned 7-member enum has no InvalidContent value —
     /// same C3 precedent as empty-after-trim). A message is NEVER rejected for the access or resolvability
-    /// of its mentions: an unresolvable/garbage tag, or a tag naming someone who is not a current member of
-    /// this channel, is legal content — it delivers VERBATIM (the client renders the invalid
-    /// <c>&lt;@…&gt;</c> as plain text) and simply produces no mention-inbox entry and no notification. So
-    /// there is NO directory read and NO membership check here — resolvability ≠ selectability (that is
-    /// <c>SearchMentionCandidates</c>' job), and who is actually notified is decided SOLELY by the uniform
-    /// membership wall in <see cref="Mentions.MentionFanOut"/> (step 8 below). The count cap is
-    /// content-intrinsic and deterministic, so it runs BEFORE the private-lane gates and the mute gate
-    /// below BY DESIGN: a blocked sender and an unblocked sender must see an IDENTICAL outcome for the same
-    /// over-cap content (running it after the private-lane gate's silent short-circuit would let a fake-Ok
-    /// mask a TooLong reject and leak block state), and a shadow/full-muted sender's over-cap markup must
-    /// still be rejected normally (a rejection does not break either illusion). The extracted, deduped,
-    /// post-cap tag list is kept in a local and threads forward to the (Task 5) mention fan-out call
-    /// site.</item>
+    /// of its mentions: an unresolvable/garbage tag, or a tag naming someone who is not a legal render
+    /// target of this channel, is legal content — it is never a reason to reject the send. The extracted,
+    /// deduped, post-cap tag list is kept in a local and threads forward to both step 5.26 below and the
+    /// (Task 5) mention fan-out call site.</item>
+    /// <item>Server-canonical mention rendering (step 5.26 — D2, 2026-08-05 decision, mention-
+    /// canonicalization brief): for each distinct mentioned target (the same post-cap tag list from step
+    /// 5.25), evaluate the RENDERABILITY predicate — a <see cref="Memberships.MembershipRepository"/> row
+    /// for this channel, OR (the channel is <see cref="ChannelType.Public"/> AND the tag is
+    /// <see cref="Users.UserDirectoryRepository"/>-resolvable) — and rewrite <c>content</c> via
+    /// <see cref="Mentions.MentionMarkup.RewriteUnrenderable"/>: a token whose target fails the predicate is
+    /// downgraded to its plain-text form (<c>@BattleTag#123</c>, no angle brackets — byte-for-byte the
+    /// launcher's pre-existing client-side downgrade text) IN THE PERSISTED CONTENT; every other token's
+    /// markup is left untouched. This is Mongo point reads ONLY (membership +, for Public non-members,
+    /// directory — never both per target, and never the relationship provider), bounded to at most
+    /// <see cref="ChatLimits.MaxMentionsPerMessage"/> (5) targets. Deciding this SERVER-SIDE, once, at
+    /// send time — rather than leaving it to each client to guess a roster — means every reader (live
+    /// delivery, history paging, a non-member's Public read, an old un-upgraded client) sees IDENTICAL
+    /// canonical content; the launcher's own client-side roster-guessing downgrade gate is now redundant
+    /// and has been removed. The predicate deliberately does NOT consult blocks, NotificationLevel,
+    /// notification preferences, or DeclinedUntil — those suppress the PING (<see cref="Mentions.MentionFanOut"/>,
+    /// step 8), never the RENDER: a member who blocked the sender still SEES a normal chip (stripping it
+    /// would leak the block to the sender, an explicit Marco pin), and an opted-out member still sees their
+    /// own name highlighted. Runs BEFORE the private-lane gates (5.5) and the mute gate (6) so a shadow or
+    /// muted send is canonicalized exactly like any other — this is content canonicalization, not
+    /// moderation, and applies unconditionally to whatever eventually gets persisted.</item>
     /// <item>Private-lane gates (C5 Task 4, step 5.5) — <see cref="ChannelType.Dm"/>/
     /// <see cref="ChannelType.GroupDm"/> ONLY: block/consent/cap handling that may silently short-circuit
     /// with a fabricated <see cref="ChatResultCode.Ok"/> (<c>FakeSendAck</c>) or the one fail-closed
@@ -166,21 +179,54 @@ public partial class ChatHub
         // ExtractTags dedupes case-insensitively (D1) — a target mentioned 6 times counts ONCE toward the
         // cap. Zero cost on the hot path: no `<@tag>` tokens means the cap check is skipped entirely, so
         // the common case (most messages have no mentions) pays nothing.
-        // STRIP & DELIVER AS PLAIN: an unresolvable/garbage tag, or a tag naming a non-member of this
-        // channel, is NOT a reject reason — the message text delivers VERBATIM (the client renders the
-        // invalid `<@…>` as plain text) and that target simply gets no inbox entry and no notification. So
-        // the send path performs NO directory read and NO membership check: resolvability ≠ selectability
-        // (that's SearchMentionCandidates' job), and who is actually notified is decided SOLELY by the
-        // uniform membership wall in MentionFanOut (step 8). The cap reject maps to TooLong (the pinned
-        // 7-member enum has no InvalidContent — same C3 precedent as empty-after-trim).
-        // mentionTags (all extracted, deduped, post-cap) threads forward to the (Task 5) mention fan-out
-        // call site that lands after DM materialization (7.5) and AFTER FanOutEngine.OnMessagePersisted
-        // (7.75, fix round 1 F2b — moved earlier so channel delivery never waits on the mention fan-out's
-        // relationship reads).
+        // The cap reject maps to TooLong (the pinned 7-member enum has no InvalidContent — same C3
+        // precedent as empty-after-trim).
+        // mentionTags (all extracted, deduped, post-cap) threads forward to step 5.26 below AND the
+        // (Task 5) mention fan-out call site that lands after DM materialization (7.5) and AFTER
+        // FanOutEngine.OnMessagePersisted (7.75, fix round 1 F2b — moved earlier so channel delivery never
+        // waits on the mention fan-out's relationship reads).
         var mentionTags = MentionMarkup.ExtractTags(content);
         if (mentionTags.Count > ChatLimits.MaxMentionsPerMessage)
         {
             return new SendMessageResult(ChatResultCode.TooLong);
+        }
+
+        // 5.26 Server-canonical mention rendering (D2, 2026-08-05 decision — mention-canonicalization
+        // brief). Zero cost when mentionTags is empty (the common case). For each distinct target, decide
+        // whether it RENDERS (stays a `<@tag>` chip) or is DOWNGRADED to plain text
+        // (`@tag`, no angle brackets — byte-identical to the launcher's pre-existing client-side downgrade
+        // text), then rewrite `content` accordingly BEFORE persist — so every future reader of this
+        // message (live delivery, history paging, a non-member's Public read, an old un-upgraded client)
+        // sees the SAME canonical text; the launcher's own client-side roster-guessing gate is now
+        // redundant and has been removed.
+        // RENDERABILITY PREDICATE (exact — deliberately mirrors, but is independent of, MentionFanOut's
+        // notification eligibility below): the target has a channel_memberships row for THIS channel, OR
+        // the channel is Public AND the target is user-directory-resolvable. Mongo point reads only — the
+        // channel doc is already loaded (step 5), so this is at most one membership read plus (Public,
+        // non-member only) one directory read per target, bounded to MaxMentionsPerMessage (5); the
+        // relationship provider is NEVER consulted here. The predicate deliberately IGNORES blocks,
+        // NotificationLevel, notification preferences, and DeclinedUntil — those suppress the PING
+        // (MentionFanOut, step 8), never the RENDER: a member who has blocked the sender must still SEE a
+        // normal chip (stripping it would leak the block state to the sender — an explicit Marco pin), and
+        // an opted-out member still sees themself mentioned normally.
+        // This runs BEFORE the private-lane gates (5.5) and the mute gate (6) so a shadow/full-muted
+        // sender's content is canonicalized exactly like anyone else's — content canonicalization is
+        // unconditional, not a moderation decision, and the rewritten `content` is what ultimately gets
+        // persisted and fanned out regardless of which path the send takes afterward.
+        if (mentionTags.Count > 0)
+        {
+            var renderableByTag = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+            foreach (var tag in mentionTags)
+            {
+                var isRenderable = await _membershipRepository.Load(channel.Id, tag) != null;
+                if (!isRenderable && channel.Type == ChannelType.Public)
+                {
+                    isRenderable = await _userDirectory.Load(tag) != null;
+                }
+                renderableByTag[tag] = isRenderable;
+            }
+            content = MentionMarkup.RewriteUnrenderable(
+                content, tag => renderableByTag.TryGetValue(tag, out var renderable) && renderable);
         }
 
         // 5.5 Private-lane gates (C5 Task 4) — Dm/GroupDm ONLY. Runs BEFORE persist so a silent-drop or

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -202,9 +202,11 @@ public partial class ChatHub
         // RENDERABILITY PREDICATE (exact — deliberately mirrors, but is independent of, MentionFanOut's
         // notification eligibility below): the target has a channel_memberships row for THIS channel, OR
         // the channel is Public AND the target is user-directory-resolvable. Mongo point reads only — the
-        // channel doc is already loaded (step 5), so this is at most one membership read plus (Public,
-        // non-member only) one directory read per target, bounded to MaxMentionsPerMessage (5); the
-        // relationship provider is NEVER consulted here. The predicate deliberately IGNORES blocks,
+        // channel doc is already loaded (step 5), so this is ONE batched, indexed $in membership read
+        // covering every distinct target (fix round 1, finding F3 — MembershipRepository.LoadMemberBattleTags,
+        // replacing what was up to MaxMentionsPerMessage (5) sequential membership Loads) plus (Public,
+        // non-member only) up to one sequential directory read per still-unresolved target, bounded to
+        // MaxMentionsPerMessage (5); the relationship provider is NEVER consulted here. The predicate deliberately IGNORES blocks,
         // NotificationLevel, notification preferences, and DeclinedUntil — those suppress the PING
         // (MentionFanOut, step 8), never the RENDER: a member who has blocked the sender must still SEE a
         // normal chip (stripping it would leak the block state to the sender — an explicit Marco pin), and
@@ -215,10 +217,16 @@ public partial class ChatHub
         // persisted and fanned out regardless of which path the send takes afterward.
         if (mentionTags.Count > 0)
         {
+            // Fix round 1 (finding F3): ONE batched, indexed $in membership read
+            // (MembershipRepository.LoadMemberBattleTags) covering every distinct target, replacing what
+            // was up to MaxMentionsPerMessage (5) sequential point-reads. The Public/directory fallback
+            // stays sequential and bounded, exactly as before — only ever reached for a target this
+            // batched check already found has no membership row.
+            var memberTags = await _membershipRepository.LoadMemberBattleTags(channel.Id, mentionTags);
             var renderableByTag = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             foreach (var tag in mentionTags)
             {
-                var isRenderable = await _membershipRepository.Load(channel.Id, tag) != null;
+                var isRenderable = memberTags.Contains(tag);
                 if (!isRenderable && channel.Type == ChannelType.Public)
                 {
                     isRenderable = await _userDirectory.Load(tag) != null;

--- a/W3ChampionsChatService/Memberships/MembershipRepository.cs
+++ b/W3ChampionsChatService/Memberships/MembershipRepository.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -151,6 +152,34 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
     /// <see cref="LoadForChannel"/> but returns a bare count.</summary>
     public async Task<int> CountForChannel(string channelId) =>
         (int)await Memberships.CountDocumentsAsync(m => m.ChannelId == channelId);
+
+    /// <summary>
+    /// D1 follow-up (2026-08-05, mention-canonicalization brief): batched member-scope check for
+    /// <c>ChatHub.SearchMentionCandidates</c>' SemiPublic/System lane. Given an already-assembled,
+    /// SMALL candidate battleTag set (bounded to <see cref="ChatLimits.MentionSearchMaxResults"/>, ~20),
+    /// returns the SUBSET that actually has a <c>channel_memberships</c> row for
+    /// <paramref name="channelId"/> — ONE indexed <c>$in</c> query (backed by the same
+    /// <c>ux_channelId_battleTag</c> index <see cref="LoadForChannel"/> uses), never the full-room
+    /// membership scan <see cref="LoadForChannel"/> performs. This is what keeps the search bounded on a
+    /// big SemiPublic/System room: the read is sized to the CANDIDATE list, never the room's total
+    /// membership. A projected read (only <see cref="ChannelMembership.BattleTag"/> crosses the wire).
+    /// Tags are lowercase-normalized both in the query and the returned set (see the class doc's BATTLETAG
+    /// KEY CONVENTION), so callers should compare case-insensitively.
+    /// </summary>
+    public async Task<HashSet<string>> LoadMemberBattleTags(string channelId, IEnumerable<string> battleTags)
+    {
+        var tags = battleTags.Select(NormalizeTag).ToList();
+        if (tags.Count == 0)
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var rows = await Memberships
+            .Find(m => m.ChannelId == channelId && tags.Contains(m.BattleTag))
+            .Project(m => m.BattleTag)
+            .ToListAsync();
+        return new HashSet<string>(rows, StringComparer.OrdinalIgnoreCase);
+    }
 
     public Task SetRole(string channelId, string battleTag, MembershipRole role)
     {

--- a/W3ChampionsChatService/Memberships/MembershipRepository.cs
+++ b/W3ChampionsChatService/Memberships/MembershipRepository.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -164,9 +165,11 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
     /// big SemiPublic/System room: the read is sized to the CANDIDATE list, never the room's total
     /// membership. A projected read (only <see cref="ChannelMembership.BattleTag"/> crosses the wire).
     /// Tags are lowercase-normalized both in the query and the returned set (see the class doc's BATTLETAG
-    /// KEY CONVENTION), so callers should compare case-insensitively.
+    /// KEY CONVENTION), so callers should compare case-insensitively. Virtual solely so tests can
+    /// spy/count calls (mirrors <see cref="LoadForChannel"/>) — fix round 1, finding F6a: proves a lane
+    /// that must never perform this scoping read (e.g. Public) actually doesn't.
     /// </summary>
-    public async Task<HashSet<string>> LoadMemberBattleTags(string channelId, IEnumerable<string> battleTags)
+    public virtual async Task<HashSet<string>> LoadMemberBattleTags(string channelId, IEnumerable<string> battleTags)
     {
         var tags = battleTags.Select(NormalizeTag).ToList();
         if (tags.Count == 0)
@@ -179,6 +182,43 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
             .Project(m => m.BattleTag)
             .ToListAsync();
         return new HashSet<string>(rows, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// D1 fix round 1 (finding F1): member-scoped RECALL BACKFILL for
+    /// <c>ChatHub.SearchMentionCandidates</c>' SemiPublic/System lane. The global tiers (viewer/online/
+    /// directory) run UNSCOPED and are ranked+capped against the WORLD before the candidate-side
+    /// <see cref="LoadMemberBattleTags"/> check ever runs — on a big room, a short (1-2 char) prefix can
+    /// be dominated by non-member noise and filtered down to near-nothing, degrading autocomplete recall
+    /// to "currently-focused viewers only". This method restores full recall (online-but-unfocused AND
+    /// offline members) by querying <c>channel_memberships</c> DIRECTLY for members whose (lowercased)
+    /// BattleTag matches the prefix — an anchored range scan on the SAME compound
+    /// <c>ux_channelId_battleTag</c> index <see cref="LoadForChannel"/> uses (ChannelId equality + a
+    /// BattleTag prefix bound), bounded to <paramref name="limit"/> rows, NEVER the room's total
+    /// membership (never <see cref="LoadForChannel"/>'s full scan). Mirrors
+    /// <see cref="Users.UserDirectoryRepository.SearchByNormalizedPrefix"/>'s contract exactly:
+    /// <paramref name="prefixLower"/> must already be lowercased by the caller (not re-normalized here —
+    /// it is already the durable storage casing), and <paramref name="excludeBattleTagsLower"/> ANDs in a
+    /// <c>$nin</c> against battleTags the caller's tiers 1-3 already claimed, so this query's own
+    /// <paramref name="limit"/> is never wasted re-fetching a dupe ahead of a genuinely new match — the
+    /// same starve-out bug class that method's own doc explains. A projected read: only
+    /// <see cref="ChannelMembership.BattleTag"/> crosses the wire. Virtual solely so tests can spy/count
+    /// calls (mirrors <see cref="LoadForChannel"/>/<see cref="LoadMemberBattleTags"/>).
+    /// </summary>
+    public virtual Task<List<string>> SearchMemberBattleTagsByPrefix(
+        string channelId, string prefixLower, int limit, IReadOnlyCollection<string> excludeBattleTagsLower = null)
+    {
+        var filterBuilder = Builders<ChannelMembership>.Filter;
+        var filter = filterBuilder.And(
+            filterBuilder.Eq(m => m.ChannelId, channelId),
+            filterBuilder.Regex(m => m.BattleTag, new BsonRegularExpression("^" + Regex.Escape(prefixLower))));
+
+        if (excludeBattleTagsLower is { Count: > 0 })
+        {
+            filter = filterBuilder.And(filter, filterBuilder.Nin(m => m.BattleTag, excludeBattleTagsLower));
+        }
+
+        return Memberships.Find(filter).Limit(limit).Project(m => m.BattleTag).ToListAsync();
     }
 
     public Task SetRole(string channelId, string battleTag, MembershipRole role)

--- a/W3ChampionsChatService/Mentions/MentionFanOut.cs
+++ b/W3ChampionsChatService/Mentions/MentionFanOut.cs
@@ -65,6 +65,16 @@ namespace W3ChampionsChatService.Mentions;
 /// their next connect.
 /// </para>
 /// <para>
+/// D2 (2026-08-05, mention-canonicalization decision): <see cref="ChatHub.SendMessage(string, string)"/>'s
+/// step 5.26 now independently evaluates the SAME base condition as rule (c) below (membership OR
+/// Public-and-directory-resolvable) to decide whether a mention RENDERS, and rewrites an unrenderable
+/// token's markup to plain text in the persisted content before this class ever runs. <c>NotifyAsync</c>'s
+/// <c>mentionTags</c> is still the FULL original extracted list (unaffected by that rewrite — this class never re-parses
+/// <c>message.Content</c>), so nothing here changes: rule (c)'s membership/Public-directory wall is left
+/// UNCHANGED deliberately, per the brief, and now doubles as a redundant second line of defense — any
+/// target it would exclude was, by construction, already excluded from rendering by step 5.26 too.
+/// </para>
+/// <para>
 /// Singleton (registered in <see cref="Startup"/>): it holds no per-call state and is shared by every
 /// hub invocation, mirroring the C3 fan-out registries. It pushes through its OWN
 /// <see cref="IHubContext{ChatHub}"/> (targeting the resolved connection), NOT the invoking hub's

--- a/W3ChampionsChatService/Mentions/MentionFanOut.cs
+++ b/W3ChampionsChatService/Mentions/MentionFanOut.cs
@@ -36,8 +36,9 @@ namespace W3ChampionsChatService.Mentions;
 /// entry carries a ~120-char content excerpt, and a private conversation's excerpt must NEVER reach a
 /// non-participant. This wall is the SOLE authority on who is notified: the send-side gate (step 5.25)
 /// validates only the mention COUNT cap — never resolvability or membership — so mentioning a non-member
-/// (or an unresolvable/garbage tag) is legal content that delivers verbatim and simply notifies nobody
-/// here. Follow-up spec §4 EXCEPTION: for <see cref="ChannelType.Public"/> rooms only, a target with NO
+/// (or an unresolvable/garbage tag) is legal content that is delivered with its markup already rewritten
+/// to plain text by step 5.26 (fix round 1, finding F2 — D2's canonical strip, not a verbatim delivery)
+/// and simply notifies nobody here. Follow-up spec §4 EXCEPTION: for <see cref="ChannelType.Public"/> rooms only, a target with NO
 /// membership row is still eligible provided the tag resolves to a <see cref="UserDirectoryRepository"/>
 /// row — a public room's excerpt is public content, so the membership wall protects nothing there;
 /// Dm/GroupDm/SemiPublic/System are unaffected and keep the membership wall exactly as before.</item>

--- a/W3ChampionsChatService/Mentions/MentionMarkup.cs
+++ b/W3ChampionsChatService/Mentions/MentionMarkup.cs
@@ -66,6 +66,13 @@ public static class MentionMarkup
         return TokenPattern.Replace(content, m =>
         {
             var tag = m.Groups[1].Value;
+            // Fix round 1 (finding F5): a caller's TryGetValue-miss on this tag (no decision was ever
+            // computed for it) is unreachable in practice — every real caller builds its decisions from
+            // ExtractTags over this SAME content, so every regex match here already has an entry. Callers
+            // resolve a miss to false (strip), never true (render): rendering an unvalidated mention is
+            // the worse failure — a stripped-but-actually-legal mention is only a cosmetic downgrade,
+            // while a rendered-but-never-checked one could leak a chip nobody actually validated. Hence
+            // fail-closed.
             return isRenderable(tag) ? m.Value : $"@{tag}";
         });
     }

--- a/W3ChampionsChatService/Mentions/MentionMarkup.cs
+++ b/W3ChampionsChatService/Mentions/MentionMarkup.cs
@@ -38,4 +38,35 @@ public static class MentionMarkup
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
+
+    /// <summary>
+    /// D2 (2026-08-05, server-canonical mention rendering): a single pass over the SAME token grammar
+    /// <see cref="ExtractTags"/> uses (reusing <see cref="TokenPattern"/> — this is deliberately NOT a
+    /// second parser) that downgrades every mention token whose target is not a legal render target for
+    /// the channel to its plain-text display form, and leaves every other token's markup untouched.
+    /// <para>
+    /// The plain-text form is <c>@{tag}</c> — no angle brackets, tag byte-for-byte as captured (display
+    /// casing preserved). This matches the launcher's PRE-EXISTING client-side downgrade path byte-for-
+    /// byte (<c>mention-markup.helper.ts</c>'s <c>parseMessageSegments</c>: <c>segment.text = `@${battleTag}`</c>,
+    /// returned verbatim by <c>ChatMessage.tsx</c>'s <c>MessageContent</c> for a non-rendering mention),
+    /// so a pre-change client and a post-change client show byte-identical text for the same content.
+    /// </para>
+    /// <paramref name="isRenderable"/> is invoked once per REGEX MATCH, not once per distinct tag — the
+    /// same target mentioned twice with different casing in one message is evaluated once per occurrence.
+    /// Callers should back it with a case-insensitive lookup (the same dedup convention
+    /// <see cref="ExtractTags"/> uses) so every occurrence of the same target gets the same decision.
+    /// </summary>
+    public static string RewriteUnrenderable(string content, Func<string, bool> isRenderable)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return content;
+        }
+
+        return TokenPattern.Replace(content, m =>
+        {
+            var tag = m.Groups[1].Value;
+            return isRenderable(tag) ? m.Value : $"@{tag}";
+        });
+    }
 }


### PR DESCRIPTION
Follow-up to #36, from Marco's test-deployment findings (2026-08-05). Two decisions:

## 1. Server-canonical mention rendering (new step 5.26)

Whether a mention **renders as a chip** is now decided by the server at send time. Each mention token is validated against the renderability predicate — *target has a membership row in the channel, OR the channel is Public and the target is directory-resolvable* — and tokens that fail are **rewritten to their plain-text form in the persisted content** (byte-identical to what the old client-side downgrade displayed). Every reader — live, history, non-member public reads, old clients — sees identical canonical content forever.

- The predicate deliberately **ignores blocks, NotificationLevel, prefs, and DeclinedUntil** — those suppress the *ping*, never the *render* (a stripped chip would leak a block; pinned by test).
- Mongo point reads only (one batched `$in` for the membership half + Public directory fallback, ≤5 targets); the relationship provider is never touched on this path.
- `MentionFanOut`'s walls stay unchanged as a second line of defense.
- The launcher's client-side roster-guessing gate is deleted in the companion launcher commit (rides PR #839) — it was wrong in both directions (rendered chips for SemiPublic non-members who never got pinged; stripped chips for offline group/match members who DID get pinged).

## 2. Member-scoped mention search for non-Public channels

`SearchMentionCandidates` no longer offers people who aren't legal mention targets: **SemiPublic and System channels (all kinds) are member-scoped** — candidate-side filtering (one covered `$in` on `ux_channelId_battleTag`, never a full-room load) plus a **member-prefix backfill tier** (anchored range scan, bounded by remaining cap slots) so short-prefix recall in big rooms covers online-and-unfocused AND offline members. Public keeps the universe lanes (§4 mention-anywhere); Dm/GroupDm lanes untouched.

This fixes both test observations: a custom-lobby autocomplete offering a non-member whose mention then rendered plain, and SemiPublic chips for non-members who were never notified.

## Rollout

**Deploy this before launcher #839 reaches users** — that launcher build removes the client-side gate and trusts the server's canonical content. Old clients against this server are fine (they receive pre-stripped text and their local gate simply never fires).

## Verification

1177/1177 tests (22 new: canonicalization matrix incl. block-kept-markup and mixed valid/invalid byte-exactness; search scoping incl. RED-verified recall backfill and Public no-scoping-read pins), build 0 warnings, format clean. Reviewed (opus) + fix round + scoped re-review with independent mutation testing — CLEAN.
