### PR TITLE
Match-channel hygiene: orphaned-membership self-heal + sweep, JoinChannel hardening

### DIFF
--- a/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
@@ -87,7 +87,13 @@ public class ChatHubMembershipTests : IntegrationTestBase
             new MentionInboxRepository(MongoClient));
     }
 
-    private ChatHub BuildHub(string connectionId, NotificationPreferenceRepository notificationPreferenceRepository = null)
+    // Fix round 1 (finding F2b): optional channelRepository lets a single test swap in
+    // CountingChannelRepository (spy) without touching the shared _channelRepository field every other
+    // test in this file relies on — mirrors the existing notificationPreferenceRepository override.
+    private ChatHub BuildHub(
+        string connectionId,
+        NotificationPreferenceRepository notificationPreferenceRepository = null,
+        ChannelRepository channelRepository = null)
     {
         var hub = new ChatHub(
             _connectionMapping,
@@ -101,7 +107,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
             _messageRateLimiter,
             _readRateLimiter,
             TimeProvider.System,
-            _channelRepository,
+            channelRepository ?? _channelRepository,
             _membershipRepository,
             _channelCreationRateLimiter,
             new W3ChampionsChatService.Messages.MessageRepository(MongoClient),
@@ -235,6 +241,41 @@ public class ChatHubMembershipTests : IntegrationTestBase
 
         var membership = await _membershipRepository.Load(systemChannel.Id, BattleTag);
         Assert.IsNull(membership, "No membership must have been created against the ACL channel");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Match-channel-hygiene brief (2026-08-05), Part 3 hardening — fix round 1, finding F2b: a
+    // null/whitespace-only name is now rejected BEFORE any DB read, returning the SAME PermissionDenied
+    // the (still-kept, defense-in-depth) ACL-type denial branch above would otherwise yield reaching it
+    // via {NormalizedName: null} matching every absent-field System/Dm/GroupDm document.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task JoinChannel_NullName_ReturnsPermissionDenied_WithZeroChannelCollectionReads()
+    {
+        var spy = new CountingChannelRepository(MongoClient);
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1", channelRepository: spy);
+
+        var result = await hub.JoinChannel(null);
+
+        Assert.AreEqual(ChatResultCode.PermissionDenied, result.Code);
+        Assert.AreEqual(0, spy.LoadAnyByNormalizedNameCallCount,
+            "a null name must be rejected before ANY channel-collection read");
+    }
+
+    [Test]
+    public async Task JoinChannel_WhitespaceOnlyName_ReturnsPermissionDenied_WithZeroChannelCollectionReads()
+    {
+        var spy = new CountingChannelRepository(MongoClient);
+        RegisterSession("conn-1", BattleTag);
+        var hub = BuildHub("conn-1", channelRepository: spy);
+
+        var result = await hub.JoinChannel("   ");
+
+        Assert.AreEqual(ChatResultCode.PermissionDenied, result.Code);
+        Assert.AreEqual(0, spy.LoadAnyByNormalizedNameCallCount,
+            "a whitespace-only name must be rejected before ANY channel-collection read");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/CleanupJobsTests.cs
+++ b/W3ChampionsChatService.Tests/CleanupJobsTests.cs
@@ -160,4 +160,65 @@ public class CleanupJobsTests : IntegrationTestBase
             "no orphaned row may survive across the batch boundary");
         Assert.IsNotNull(await membershipRepo.Load(liveChannel.Id, "Peter#123"), "the live membership must survive untouched");
     }
+
+    // Fix round 1 (finding F7): the multi-batch test above only ever exercises the ORPHAN half of the
+    // per-page existence-check $in — every id in its batches is missing. This test crosses the SAME
+    // pagination boundary with EXISTING channels instead, so the existence check itself is proven
+    // correct at full OrphanSweepBatchSize width, not merely "an empty $in never matches".
+    [Test]
+    public async Task OrphanSweep_ExistingChannelsAtFullBatchWidth_AllSurvive_OnlyTheGenuineOrphanIsDeleted()
+    {
+        var db = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName);
+        var channelsCollection = db.GetCollection<ChatChannel>(ChatCollections.Channels);
+        var membershipsCollection = db.GetCollection<ChannelMembership>(ChatCollections.ChannelMemberships);
+        var membershipRepo = new MembershipRepository(MongoClient, new ChannelRepository(MongoClient));
+
+        // Strictly more than one batch's worth of EXISTING channels, each with exactly one membership —
+        // a discovery page's distinct-ChannelId batch composed ENTIRELY (or almost entirely) of ids that
+        // must all resolve "exists" via the existence-check $in, at full OrphanSweepBatchSize width.
+        var liveCount = CleanupJobs.OrphanSweepBatchSize + 1;
+        var liveChannels = Enumerable.Range(0, liveCount)
+            .Select(i => new ChatChannel { Type = ChannelType.SemiPublic, Name = $"room-{i}", NormalizedName = $"room-{i}" })
+            .ToList();
+        await channelsCollection.InsertManyAsync(liveChannels);
+        var liveMemberships = liveChannels
+            .Select((c, i) => new ChannelMembership { ChannelId = c.Id, BattleTag = $"liveuser{i}#1", JoinedAt = DateTime.UtcNow })
+            .ToList();
+        await membershipsCollection.InsertManyAsync(liveMemberships);
+
+        // One genuine orphan alongside the live set, so the sweep still does REAL work in the same run —
+        // not merely a no-op pass over an all-live dataset.
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = "gone-channel", BattleTag = "orphan#1", JoinedAt = DateTime.UtcNow });
+
+        var deleted = await new CleanupJobs(MongoClient).SweepOrphanedMemberships();
+
+        Assert.AreEqual(1, deleted, "only the single genuine orphan is deleted — none of the live channels' memberships");
+        var liveChannelIds = liveChannels.Select(c => c.Id).ToList();
+        Assert.AreEqual((long)liveCount, await membershipsCollection.CountDocumentsAsync(
+            Builders<ChannelMembership>.Filter.In(m => m.ChannelId, liveChannelIds)),
+            "every live channel's membership must survive — the existence check must resolve all of them correctly even at full batch width");
+        Assert.IsNull(await membershipRepo.Load("gone-channel", "orphan#1"), "the genuine orphan must still be reaped");
+    }
+
+    // Fix round 1 (finding F3): RunOnce's wiring of the orphan sweep was untested — deleting the
+    // SweepOrphanedMemberships() call from RunOnce would survive the full suite (only the method in
+    // isolation was pinned). This proves RunOnce itself reaps an orphan, not just the method directly.
+    [Test]
+    public async Task RunOnce_AlsoSweepsOrphanedMemberships()
+    {
+        var channelRepo = new ChannelRepository(MongoClient);
+        var membershipRepo = new MembershipRepository(MongoClient, channelRepo);
+        var now = DateTime.UtcNow;
+
+        var liveChannel = new ChatChannel { Type = ChannelType.Public, Name = "W3C Lounge", NormalizedName = "w3c lounge" };
+        await channelRepo.Insert(liveChannel);
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = liveChannel.Id, BattleTag = "Peter#123", JoinedAt = now });
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = "gone-channel", BattleTag = "Peter#123", JoinedAt = now });
+
+        await new CleanupJobs(MongoClient).RunOnce(now);
+
+        Assert.IsNull(await membershipRepo.Load("gone-channel", "Peter#123"),
+            "RunOnce must invoke the orphan sweep — an undeleted orphaned row here means the wiring, not just the method, regressed");
+        Assert.IsNotNull(await membershipRepo.Load(liveChannel.Id, "Peter#123"), "the live membership must survive RunOnce");
+    }
 }

--- a/W3ChampionsChatService.Tests/CleanupJobsTests.cs
+++ b/W3ChampionsChatService.Tests/CleanupJobsTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using MongoDB.Driver;
 using NUnit.Framework;
 using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Domain;
@@ -88,5 +90,74 @@ public class CleanupJobsTests : IntegrationTestBase
 
         Assert.IsNull(await prefsRepo.Load("Idle#1", "chan1"), "the idle user's persisted preference must be pruned too");
         Assert.IsNotNull(await prefsRepo.Load("Active#2", "chan1"), "the active user's preference must survive");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Match-channel-hygiene brief (2026-08-05), Part 2 — orphan sweep: membership rows referencing a
+    // channel id that no longer exists in the channels collection (TTL'd System match channel, or a lost
+    // mm→chat member-removal) are DB-hygiene GC'd on the same weekly cadence, catching users who never
+    // reconnect (the connect-time self-heal, Part 1, only fires for someone who DOES reconnect).
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task OrphanSweep_DeletesOnlyMembershipsOfMissingChannels_AcrossUsersAndTypes()
+    {
+        var channelRepo = new ChannelRepository(MongoClient);
+        var membershipRepo = new MembershipRepository(MongoClient, channelRepo);
+
+        var publicChannel = new ChatChannel { Type = ChannelType.Public, Name = "W3C Lounge", NormalizedName = "w3c lounge" };
+        var systemChannel = new ChatChannel { Type = ChannelType.System, SystemKind = SystemChannelKind.Match, SystemRef = "match-1", Name = "Match 1" };
+        await channelRepo.Insert(publicChannel);
+        await channelRepo.Insert(systemChannel);
+
+        // Live memberships — their channel docs exist, must survive the sweep untouched.
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = publicChannel.Id, BattleTag = "Peter#123", JoinedAt = DateTime.UtcNow });
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = systemChannel.Id, BattleTag = "Peter#123", JoinedAt = DateTime.UtcNow });
+
+        // Orphaned memberships — channel ids with NO matching channel document at all (TTL'd/deleted),
+        // spanning two different users, one of the ids shared by both (mirrors a stale System match
+        // channel two participants were both still a member of).
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = "gone-match-channel", BattleTag = "Peter#123", JoinedAt = DateTime.UtcNow });
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = "gone-match-channel", BattleTag = "Wolf#456", JoinedAt = DateTime.UtcNow });
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = "gone-public-channel", BattleTag = "Wolf#456", JoinedAt = DateTime.UtcNow });
+
+        var deleted = await new CleanupJobs(MongoClient).SweepOrphanedMemberships();
+
+        Assert.AreEqual(3, deleted);
+        var peterChannelIds = (await membershipRepo.LoadForUser("Peter#123")).Select(m => m.ChannelId).ToList();
+        CollectionAssert.AreEquivalent(new[] { publicChannel.Id, systemChannel.Id }, peterChannelIds,
+            "Peter keeps only the two memberships whose channels still exist");
+        Assert.AreEqual(0, (await membershipRepo.LoadForUser("Wolf#456")).Count,
+            "Wolf's only two memberships were both orphaned");
+    }
+
+    [Test]
+    public async Task OrphanSweep_ProcessesMoreThanOneBatch_AndDeletesAllOrphansAcrossBatches()
+    {
+        var channelRepo = new ChannelRepository(MongoClient);
+        var membershipRepo = new MembershipRepository(MongoClient, channelRepo);
+        var db = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName);
+        var membershipsCollection = db.GetCollection<ChannelMembership>(ChatCollections.ChannelMemberships);
+
+        var liveChannel = new ChatChannel { Type = ChannelType.Public, Name = "W3C Lounge", NormalizedName = "w3c lounge" };
+        await channelRepo.Insert(liveChannel);
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = liveChannel.Id, BattleTag = "Peter#123", JoinedAt = DateTime.UtcNow });
+
+        // Strictly more distinct orphaned channel ids than a single OrphanSweepBatchSize round, so the
+        // sweep must loop across at least two batches to reap every one of them — one membership row per
+        // distinct (nonexistent) channel id, each for a different user so ux_channelId_battleTag never
+        // collides.
+        var orphanCount = CleanupJobs.OrphanSweepBatchSize + 1;
+        var orphanRows = Enumerable.Range(0, orphanCount)
+            .Select(i => new ChannelMembership { ChannelId = $"gone-{i}", BattleTag = $"orphan{i}#1", JoinedAt = DateTime.UtcNow })
+            .ToList();
+        await membershipsCollection.InsertManyAsync(orphanRows);
+
+        var deleted = await new CleanupJobs(MongoClient).SweepOrphanedMemberships();
+
+        Assert.AreEqual(orphanCount, deleted, "every orphan must be reaped, not just the first batch's worth");
+        Assert.AreEqual(0L, await membershipsCollection.CountDocumentsAsync(m => m.ChannelId != liveChannel.Id),
+            "no orphaned row may survive across the batch boundary");
+        Assert.IsNotNull(await membershipRepo.Load(liveChannel.Id, "Peter#123"), "the live membership must survive untouched");
     }
 }

--- a/W3ChampionsChatService.Tests/CountingChannelRepository.cs
+++ b/W3ChampionsChatService.Tests/CountingChannelRepository.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using W3ChampionsChatService.Channels;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// A <see cref="ChannelRepository"/> spy (subclass over the real Mongo-backed repository — mirrors
+/// <see cref="CountingMembershipRepository"/>'s spy-over-real-repo idiom) that counts
+/// <see cref="LoadAnyByNormalizedName"/> calls.
+/// <para>
+/// Fix round 1 (finding F2b): backs the <c>JoinChannel(null)</c>/<c>JoinChannel(whitespace)</c> tests
+/// proving the new early null/whitespace-name guard issues ZERO channel-collection reads —
+/// <see cref="LoadAnyByNormalizedName"/> is the FIRST channel-collection read <c>JoinChannel</c>
+/// performs, so a zero call count here proves the guard pre-empted the entire DB-read path, not
+/// merely that one specific downstream call didn't happen to fire.
+/// </para>
+/// </summary>
+internal sealed class CountingChannelRepository(MongoClient client) : ChannelRepository(client)
+{
+    public int LoadAnyByNormalizedNameCallCount { get; private set; }
+
+    public override Task<ChatChannel> LoadAnyByNormalizedName(string normalizedName)
+    {
+        LoadAnyByNormalizedNameCallCount++;
+        return base.LoadAnyByNormalizedName(normalizedName);
+    }
+}

--- a/W3ChampionsChatService.Tests/CountingMembershipRepository.cs
+++ b/W3ChampionsChatService.Tests/CountingMembershipRepository.cs
@@ -20,12 +20,18 @@ namespace W3ChampionsChatService.Tests;
 /// the Public lane — the ONLY channel type that must never perform ANY membership-scoping read at all —
 /// genuinely performs zero, not merely zero of the full-room variant.
 /// </para>
+/// <para>
+/// Match-channel-hygiene brief (2026-08-05), Part 1: also counts <see cref="DeleteOrphanedForUser"/>
+/// calls, so a test can assert SessionStateAssembler.AssembleAndSeed's zero-orphans common case issues
+/// no extra delete query, and that a second (already-healed) connect doesn't call it again.
+/// </para>
 /// </summary>
 internal sealed class CountingMembershipRepository(MongoClient client, ChannelRepository channelRepository)
     : MembershipRepository(client, channelRepository)
 {
     public int LoadForChannelCallCount { get; private set; }
     public int LoadMemberBattleTagsCallCount { get; private set; }
+    public int DeleteOrphanedForUserCallCount { get; private set; }
 
     public override Task<List<ChannelMembership>> LoadForChannel(string channelId)
     {
@@ -37,5 +43,11 @@ internal sealed class CountingMembershipRepository(MongoClient client, ChannelRe
     {
         LoadMemberBattleTagsCallCount++;
         return base.LoadMemberBattleTags(channelId, battleTags);
+    }
+
+    public override Task<long> DeleteOrphanedForUser(string battleTag, IReadOnlyCollection<string> channelIds)
+    {
+        DeleteOrphanedForUserCallCount++;
+        return base.DeleteOrphanedForUser(battleTag, channelIds);
     }
 }

--- a/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
+++ b/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
@@ -959,6 +959,27 @@ public class SessionStateAssemblerTests : IntegrationTestBase
             "an already-healed, orphan-free connect must not invoke the delete path again");
     }
 
+    // Fix round 1 (finding F4): the self-heal delete's BattleTag scoping was untested — replacing the
+    // filter with a bare In(ChannelId) (deleting EVERY user's rows on that channel id, not just the
+    // connecting user's) would have survived the full suite. A second user's membership on the SAME
+    // gone channel must survive this connect untouched.
+    [Test]
+    public async Task Connect_OrphanSelfHeal_ScopedToConnectingUser_OtherUsersMembershipOnSameGoneChannelSurvives()
+    {
+        var identity = Identity("peter#123");
+        const string goneChannelId = "gone-channel-id";
+        const string otherBattleTag = "otheruser#456";
+        await InsertMembership(goneChannelId, identity.BattleTag, lastReadSeq: 0);
+        await InsertMembership(goneChannelId, otherBattleTag, lastReadSeq: 0);
+
+        await _assembler.AssembleAndSeed(identity, "conn-1", DateTime.UtcNow, ChatUserFor(identity));
+
+        Assert.IsNull(await _membershipRepository.Load(goneChannelId, identity.BattleTag),
+            "the connecting user's own orphaned row must be deleted");
+        Assert.IsNotNull(await _membershipRepository.Load(goneChannelId, otherBattleTag),
+            "another user's membership on the SAME gone channel must survive — the delete filter is scoped by BattleTag, not a bare ChannelId $in");
+    }
+
     [Test]
     public async Task Connect_WithZeroOrphans_IssuesNoOrphanDeleteCall()
     {

--- a/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
+++ b/W3ChampionsChatService.Tests/SessionStateAssemblerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MongoDB.Driver;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Channels;
@@ -917,5 +918,100 @@ public class SessionStateAssemblerTests : IntegrationTestBase
             new[] { chanC.Id, chanA.Id, chanB.Id },
             dto.Channels.Select(c => c.Channel.Id).ToList(),
             "Channels must come back in membership JoinedAt-ascending order, not Mongo insertion/natural order");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Match-channel-hygiene brief (2026-08-05), Part 1 — connect-time orphan self-heal: a membership row
+    // whose channel doc is gone (TTL'd System match channel, or a lost mm→chat member-removal) is
+    // excluded from the snapshot exactly as before (pre-existing behavior — see channelBackedMemberships'
+    // doc comment), AND its row is now best-effort deleted so it doesn't linger until CleanupJobs' weekly
+    // orphan sweep (Part 2) or the 365-day idle-membership prune.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Connect_WithOrphanedMembership_ExcludesFromSnapshot_AndDeletesTheRow_AndSecondConnectIsNoOp()
+    {
+        var identity = Identity("peter#123");
+        var liveChannel = await InsertChannel(ChannelType.Public, "General", lastSeq: 0);
+        await InsertMembership(liveChannel.Id, identity.BattleTag, lastReadSeq: 0);
+
+        // A membership row whose channel was deleted/TTL'd out from under it — inserted directly (the
+        // repository has no channel-existence check on Insert), exactly reproducing a genuine orphan.
+        const string goneChannelId = "gone-channel-id";
+        await InsertMembership(goneChannelId, identity.BattleTag, lastReadSeq: 0);
+
+        var spy = new CountingMembershipRepository(MongoClient, _channelRepository);
+        var assembler = BuildAssembler(spy);
+
+        var (dto, _) = await assembler.AssembleAndSeed(identity, "conn-1", DateTime.UtcNow, ChatUserFor(identity));
+
+        Assert.AreEqual(1, dto.Channels.Count, "the orphaned membership must not reach the snapshot");
+        Assert.AreEqual(liveChannel.Id, dto.Channels.Single().Channel.Id);
+        Assert.AreEqual(1, spy.DeleteOrphanedForUserCallCount);
+        Assert.IsNull(await spy.Load(goneChannelId, identity.BattleTag), "the orphaned row must be deleted");
+        Assert.IsNotNull(await spy.Load(liveChannel.Id, identity.BattleTag), "the live membership must survive untouched");
+
+        // Second connect: the orphan is already gone, so nothing is left to self-heal.
+        var (dto2, _) = await assembler.AssembleAndSeed(identity, "conn-2", DateTime.UtcNow, ChatUserFor(identity));
+
+        Assert.AreEqual(1, dto2.Channels.Count);
+        Assert.AreEqual(1, spy.DeleteOrphanedForUserCallCount,
+            "an already-healed, orphan-free connect must not invoke the delete path again");
+    }
+
+    [Test]
+    public async Task Connect_WithZeroOrphans_IssuesNoOrphanDeleteCall()
+    {
+        var identity = Identity("peter#123");
+        var liveChannel = await InsertChannel(ChannelType.Public, "General", lastSeq: 0);
+        await InsertMembership(liveChannel.Id, identity.BattleTag, lastReadSeq: 0);
+
+        var spy = new CountingMembershipRepository(MongoClient, _channelRepository);
+        var assembler = BuildAssembler(spy);
+
+        await assembler.AssembleAndSeed(identity, "conn-1", DateTime.UtcNow, ChatUserFor(identity));
+
+        Assert.AreEqual(0, spy.DeleteOrphanedForUserCallCount,
+            "zero orphans is the common case — it must issue zero extra delete queries");
+    }
+
+    [Test]
+    public async Task Connect_WhenOrphanDeleteThrows_ConnectStillSucceeds_WithTheSameSnapshot()
+    {
+        var identity = Identity("peter#123");
+        var liveChannel = await InsertChannel(ChannelType.Public, "General", lastSeq: 0);
+        await InsertMembership(liveChannel.Id, identity.BattleTag, lastReadSeq: 0);
+        const string goneChannelId = "gone-channel-id";
+        await InsertMembership(goneChannelId, identity.BattleTag, lastReadSeq: 0);
+
+        var throwing = new ThrowingOrphanDeleteMembershipRepository(MongoClient, _channelRepository);
+        var assembler = BuildAssembler(throwing);
+
+        var (dto, muteStatus) = await assembler.AssembleAndSeed(identity, "conn-1", DateTime.UtcNow, ChatUserFor(identity));
+
+        Assert.AreEqual(1, dto.Channels.Count, "the snapshot must still exclude the orphan even though the delete failed");
+        Assert.AreEqual(liveChannel.Id, dto.Channels.Single().Channel.Id);
+        Assert.AreEqual(MuteStatus.None, muteStatus, "a failed best-effort delete must not fail (or otherwise alter) connect");
+        Assert.IsNotNull(await _membershipRepository.Load(goneChannelId, identity.BattleTag),
+            "a failed delete must leave the orphaned row in place — retried on a later connect or the weekly sweep");
+    }
+
+    private SessionStateAssembler BuildAssembler(MembershipRepository membershipRepository) => new(
+        membershipRepository,
+        _channelRepository,
+        _messageRepository,
+        _muteRepository,
+        _onlineMemberRegistry,
+        _connectionMapping,
+        _mentionInboxRepository);
+
+    // A MembershipRepository whose DeleteOrphanedForUser always throws — simulating a Mongo write
+    // failure on the connect-time self-heal's best-effort delete (mirrors ChatHubMembershipTests'
+    // ThrowingNotificationPreferenceRepository idiom).
+    private sealed class ThrowingOrphanDeleteMembershipRepository(MongoClient client, ChannelRepository channelRepository)
+        : MembershipRepository(client, channelRepository)
+    {
+        public override Task<long> DeleteOrphanedForUser(string battleTag, IReadOnlyCollection<string> channelIds) =>
+            Task.FromException<long>(new InvalidOperationException("simulated orphan-delete failure"));
     }
 }

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -53,8 +53,13 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
     /// ChannelType) — backs the join resolution order: a name match on an existing
     /// non-name-joinable type (e.g. System) must be distinguishable from "no match" so the
     /// caller can reject with PermissionDenied instead of falling through to implicit create.
+    /// Virtual: a test seam (fix round 1, finding F2b — mirrors <c>MembershipRepository</c>'s
+    /// virtual-method spy idiom) so a test can prove <c>ChatHub.Channels.JoinChannel</c>'s new
+    /// null/whitespace-name guard issues ZERO channel-collection reads — this is the FIRST such
+    /// read the method performs, so a zero call count here proves the whole DB-read path was
+    /// pre-empted.
     /// </summary>
-    public Task<ChatChannel> LoadAnyByNormalizedName(string normalizedName) =>
+    public virtual Task<ChatChannel> LoadAnyByNormalizedName(string normalizedName) =>
         Channels.Find(c => c.NormalizedName == normalizedName).FirstOrDefaultAsync();
 
     public Task<List<ChatChannel>> LoadAllOfType(ChannelType type) =>

--- a/W3ChampionsChatService/Chats/ChatHub.Channels.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Channels.cs
@@ -293,6 +293,14 @@ public partial class ChatHub
             {
                 // System / Dm / GroupDm — ACL-governed, not joinable by name. NOT an implicit-create
                 // case: a name collision with an existing ACL channel must be rejected outright.
+                //
+                // Match-channel-hygiene brief (2026-08-05), Part 3: LoadAnyByNormalizedName can only ever
+                // MATCH a System channel here if some future write path populates its NormalizedName —
+                // today ChannelRepository.FindOrCreateSystem (the sole System-channel creation path)
+                // never sets that field, so this branch is currently unreachable for Type == System (Dm/
+                // GroupDm are unreachable too, for the same reason — neither creation path sets it
+                // either). Kept deliberately: it is the guard that keeps the ACL namespace safe the
+                // moment anyone ever DOES populate NormalizedName on one of these types.
                 return new JoinChannelResult(ChatResultCode.PermissionDenied);
             }
 

--- a/W3ChampionsChatService/Chats/ChatHub.Channels.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Channels.cs
@@ -225,6 +225,10 @@ public partial class ChatHub
     /// <list type="number">
     /// <item>Fail-closed: an unregistered connection (never authenticated, or displaced/torn down) is
     /// denied outright — there is no identity to join a channel under.</item>
+    /// <item>Fix round 1 (finding F2b): a null/whitespace-only <paramref name="name"/> is rejected here,
+    /// BEFORE any DB read — <see cref="ChatResultCode.PermissionDenied"/>, zero channel-collection reads.
+    /// See the guard's own inline comment for the mechanism this pre-empts: a proven, reachable-today
+    /// path into the ACL-type denial branch below.</item>
     /// <item><see cref="Channels.ChannelRepository.LoadAnyByNormalizedName"/> resolves ANY channel
     /// with that normalized name, across every <see cref="ChannelType"/>:
     /// <list type="bullet">
@@ -272,6 +276,21 @@ public partial class ChatHub
             return new JoinChannelResult(ChatResultCode.PermissionDenied);
         }
 
+        // Fix round 1 (finding F2b): reject a null/whitespace-only name BEFORE any DB read. Proven:
+        // without this guard, ChannelNames.Normalize(null) -> null, and LoadAnyByNormalizedName(null)
+        // renders the Mongo filter {NormalizedName: null} — because ChatChannel.NormalizedName is
+        // [BsonIgnoreIfNull], that filter matches every document where the field is ABSENT, i.e. EVERY
+        // System/Dm/GroupDm document (none of their creation paths — FindOrCreateSystem, FindOrCreateDm,
+        // the GroupDm creation path — ever populate NormalizedName). So JoinChannel(null) matched the
+        // first such document and landed in the ACL-type denial branch below on EVERY call — a LIVE
+        // guard reached via a guaranteed COLLSCAN (the partial index ux_type_normalizedName can't serve
+        // a null match), not dead code. This guard pre-empts that path entirely, returning the SAME
+        // PermissionDenied the branch below would have yielded, with zero channel-collection reads.
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return new JoinChannelResult(ChatResultCode.PermissionDenied);
+        }
+
         var battleTag = session.Identity.BattleTag;
         var now = _timeProvider.GetUtcNow().UtcDateTime;
         var normalizedName = ChannelNames.Normalize(name);
@@ -294,13 +313,25 @@ public partial class ChatHub
                 // System / Dm / GroupDm — ACL-governed, not joinable by name. NOT an implicit-create
                 // case: a name collision with an existing ACL channel must be rejected outright.
                 //
-                // Match-channel-hygiene brief (2026-08-05), Part 3: LoadAnyByNormalizedName can only ever
-                // MATCH a System channel here if some future write path populates its NormalizedName —
-                // today ChannelRepository.FindOrCreateSystem (the sole System-channel creation path)
-                // never sets that field, so this branch is currently unreachable for Type == System (Dm/
-                // GroupDm are unreachable too, for the same reason — neither creation path sets it
-                // either). Kept deliberately: it is the guard that keeps the ACL namespace safe the
-                // moment anyone ever DOES populate NormalizedName on one of these types.
+                // Match-channel-hygiene brief (2026-08-05), Part 3 — CORRECTED, fix round 1 (finding F2):
+                // the original comment here claimed this branch was structurally unreachable. That claim
+                // was WRONG. Proven: ChannelNames.Normalize(null) -> null, and
+                // LoadAnyByNormalizedName(null) renders the Mongo filter {NormalizedName: null} — because
+                // ChatChannel.NormalizedName is [BsonIgnoreIfNull], that filter matches every document
+                // where the field is ABSENT, which is EVERY System/Dm/GroupDm document (none of their
+                // creation paths — FindOrCreateSystem, FindOrCreateDm, the GroupDm creation path — ever
+                // populate NormalizedName). So JoinChannel(null) matched the first such document and
+                // landed HERE on every call — a LIVE ACL guard, reached via a guaranteed COLLSCAN (the
+                // partial index ux_type_normalizedName can't serve a null match), not dead code.
+                //
+                // Fix round 1 (finding F2b) added an explicit null/whitespace-name guard at the top of
+                // JoinChannel that now pre-empts this exact path before any DB read — so for a
+                // null/whitespace name this branch is unreachable again TODAY. It stays as
+                // defense-in-depth for the ORIGINAL concern this comment used to (wrongly) dismiss: a
+                // real, non-blank name that collides with a System/Dm/GroupDm channel the moment any
+                // future write path ever populates NormalizedName on one of those types — and as a
+                // backstop if the F2b guard above is ever weakened or removed without re-reading this
+                // history.
                 return new JoinChannelResult(ChatResultCode.PermissionDenied);
             }
 

--- a/W3ChampionsChatService/Domain/CleanupJobs.cs
+++ b/W3ChampionsChatService/Domain/CleanupJobs.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;
+using Serilog;
 using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Memberships;
 using W3ChampionsChatService.Messages;
@@ -29,10 +30,22 @@ namespace W3ChampionsChatService.Domain;
 public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient)
 {
     /// <summary>
-    /// Part 2 batch size: distinct-channel-id cardinality behind <see cref="SweepOrphanedMemberships"/> is
-    /// bounded by total channels + orphans, which can grow large — this caps each existence-check/delete
-    /// round so the sweep never issues a single unbounded <c>$in</c> over the whole collection. Not spec
-    /// text; hard-coded, adjust here only (mirrors <c>ChatHub.Channels.MaxPresenceRegisterAttempts</c>'s
+    /// Part 2 batch size — fix round 1 (finding F5, aligned with the F1 fix): a DUAL-purpose bound for
+    /// <see cref="SweepOrphanedMemberships"/>, and BOTH halves are now bounded, unlike before this round:
+    /// <list type="bullet">
+    /// <item>(a) the PAGE SIZE of the range-paginated distinct-ChannelId discovery scan
+    /// (<see cref="LoadDistinctChannelIdsPage"/>). Before this round, discovery used a single
+    /// <c>DistinctAsync</c> call — the <c>distinct</c> command packs EVERY distinct value into one reply
+    /// document, capped at MongoDB's 16MB per-document limit, and was empirically PROVEN to throw
+    /// "distinct too big" at ≈450k distinct ids, after which the whole weekly job died forever (finding
+    /// F1). Range pagination over <c>ux_channelId_battleTag</c> keeps every individual round-trip's
+    /// result set bounded by this constant regardless of how large the true distinct-id cardinality
+    /// grows — the total scan is still proportional to the full membership collection, but no single
+    /// Mongo reply is ever unbounded again.</item>
+    /// <item>(b) the existence-check <c>$in</c> + delete batch size per page (unchanged in shape from the
+    /// original design — this was already bounded before F1).</item>
+    /// </list>
+    /// Not spec text; hard-coded, adjust here only (mirrors <c>ChatHub.Channels.MaxPresenceRegisterAttempts</c>'s
     /// local-const-not-ChatLimits precedent — this is an internal job-tuning knob, not a client-facing
     /// limit). Internal (assembly has InternalsVisibleTo, ChatHub.cs) so a test can pin the batching
     /// boundary without hardcoding a duplicate magic number.
@@ -110,11 +123,25 @@ public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoC
     /// connect-time self-heal (<see cref="Protocol.SessionStateAssembler.AssembleAndSeed"/>): it catches
     /// users who never reconnect, so an orphaned row doesn't linger until the 365-day idle sweep above.
     /// <para>
-    /// Mechanics: distinct ChannelIds across ALL memberships, processed <see cref="OrphanSweepBatchSize"/>
-    /// at a time (cardinality is bounded by total channels + orphans, which can be large) — per batch, an
-    /// existence check against the channels collection (<c>$in</c>) yields the missing subset, which is
-    /// then batch-deleted from memberships in one round-trip. A channel id with zero memberships never
-    /// enters the distinct set in the first place, so this never scans healthy channels.
+    /// Mechanics: distinct ChannelIds across ALL memberships are discovered via a RANGE-PAGINATED scan
+    /// (<see cref="LoadDistinctChannelIdsPage"/> — fix round 1, finding F1; see <see cref="OrphanSweepBatchSize"/>'s
+    /// doc for why the original single <c>DistinctAsync</c> call was replaced), <see cref="OrphanSweepBatchSize"/>
+    /// ids at a time. Per page, an existence check against the channels collection (<c>$in</c>) yields the
+    /// missing subset, which is then batch-deleted from memberships in one round-trip — this
+    /// existence-check/delete body is UNCHANGED from before the F1 fix, only the discovery step that
+    /// feeds it changed. A channel id with zero memberships never enters the discovery scan in the first
+    /// place, so this never scans healthy channels.
+    /// </para>
+    /// <para>
+    /// PRECONDITION (fix round 1, finding F8): the check-then-delete is safe from a TOCTOU standpoint
+    /// only because a channel's <c>_id</c> is ALWAYS a fresh, server-generated
+    /// <see cref="MongoDB.Bson.ObjectId"/> — every <c>FindOrCreate*</c> path (<see cref="Channels.ChannelRepository"/>)
+    /// stamps <c>ObjectId.GenerateNewId().ToString()</c> via <c>$setOnInsert</c>, so an id is NEVER
+    /// caller-supplied and NEVER reused across documents. That is what guarantees "no channel currently
+    /// has this id" can never flip to "a DIFFERENT, unrelated channel now has this id" in the gap between
+    /// this method's existence check and its delete. A future channel type keyed by a
+    /// deterministic/caller-supplied id (unlike every type today) would break that guarantee and must
+    /// re-derive its own safety argument before reusing this sweep unmodified.
     /// </para>
     /// </summary>
     public async Task<long> SweepOrphanedMemberships()
@@ -123,14 +150,19 @@ public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoC
         var channels = db.GetCollection<ChatChannel>(ChatCollections.Channels);
         var memberships = db.GetCollection<ChannelMembership>(ChatCollections.ChannelMemberships);
 
-        var distinctChannelIds = await memberships
-            .DistinctAsync(m => m.ChannelId, Builders<ChannelMembership>.Filter.Empty);
-        var allChannelIds = await distinctChannelIds.ToListAsync();
-        if (allChannelIds.Count == 0) return 0;
-
         long deleted = 0;
-        foreach (var batch in allChannelIds.Chunk(OrphanSweepBatchSize))
+        string cursorChannelId = null;
+        while (true)
         {
+            var page = await LoadDistinctChannelIdsPage(memberships, cursorChannelId, OrphanSweepBatchSize);
+            if (page.Count == 0) break;
+
+            // The Gt(cursor) filter on the NEXT page's query skips every remaining row of this page's
+            // last-seen ChannelId too (not just the ones fetched here), so advancing the cursor to the
+            // last row makes progress even when a single channel's membership count exceeds one page.
+            cursorChannelId = page[^1];
+
+            var batch = page.Distinct().ToList();
             var existingIds = await channels
                 .Find(Builders<ChatChannel>.Filter.In(c => c.Id, batch))
                 .Project(c => c.Id)
@@ -144,6 +176,40 @@ public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoC
             deleted += result.DeletedCount;
         }
 
+        // Fix round 1 (finding F9): one operator-visible info line naming the total, mirroring the
+        // connect-time self-heal's log convention (SessionStateAssembler.AssembleAndSeed) — logged only
+        // when > 0, since a clean sweep with nothing to reap is not worth a log line every week.
+        if (deleted > 0)
+        {
+            Log.Information("SweepOrphanedMemberships: deleted {Count} orphaned membership row(s)", deleted);
+        }
+
         return deleted;
+    }
+
+    /// <summary>
+    /// Fix round 1 (finding F1): the range-paginated distinct-ChannelId discovery cursor that replaces
+    /// the original unbounded <c>DistinctAsync</c> call (see <see cref="OrphanSweepBatchSize"/>'s doc for
+    /// the proven failure mode this fixes). Backed by <c>ux_channelId_battleTag</c> (ChannelId-leading
+    /// compound index): a plain <c>Find(ChannelId &gt; cursor).SortBy(ChannelId).Limit(N)</c> page, whose
+    /// documents cross the wire individually via the driver's own cursor/batch protocol — never packed
+    /// into a single reply document the way <c>distinct</c> is, so the TOTAL result size across pages is
+    /// genuinely unbounded while every INDIVIDUAL round-trip stays capped at <paramref name="limit"/>
+    /// rows. A page can contain duplicate ChannelIds (multiple members of the same channel) — the caller
+    /// dedupes. Termination: an empty page means every membership row has been visited (ChannelId is
+    /// never null, so <c>Gt</c> strictly-greater pagination cannot loop).
+    /// </summary>
+    private static async Task<List<string>> LoadDistinctChannelIdsPage(
+        IMongoCollection<ChannelMembership> memberships, string afterChannelId, int limit)
+    {
+        var filter = afterChannelId == null
+            ? Builders<ChannelMembership>.Filter.Empty
+            : Builders<ChannelMembership>.Filter.Gt(m => m.ChannelId, afterChannelId);
+
+        return await memberships.Find(filter)
+            .SortBy(m => m.ChannelId)
+            .Project(m => m.ChannelId)
+            .Limit(limit)
+            .ToListAsync();
     }
 }

--- a/W3ChampionsChatService/Domain/CleanupJobs.cs
+++ b/W3ChampionsChatService/Domain/CleanupJobs.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MongoDB.Driver;
@@ -18,14 +19,31 @@ namespace W3ChampionsChatService.Domain;
 ///     rows, so that carrier doesn't outlive the membership it was written to survive. The pref
 ///     collection has no TTL of its own (PR36 D2 — it must persist indefinitely across an ordinary
 ///     leave/rejoin), so this job is its ONLY GC path.
+/// (c) match-channel-hygiene brief (2026-08-05), Part 2 — orphaned-membership sweep: a channel doc can TTL
+///     out (e.g. a System match channel's ttl_expiresAt, 24h after creation) while its membership rows
+///     survive — normally self-healed at connect time (<see cref="Protocol.SessionStateAssembler.AssembleAndSeed"/>),
+///     but a user who never reconnects would otherwise leave those rows stranded until the 365-day idle
+///     sweep (b). This DB-hygiene pass catches them on the same weekly cadence instead.
 /// Group/DM shells need no job — their ExpiresAt TTL handles them.
 /// </summary>
 public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoClient)
 {
+    /// <summary>
+    /// Part 2 batch size: distinct-channel-id cardinality behind <see cref="SweepOrphanedMemberships"/> is
+    /// bounded by total channels + orphans, which can grow large — this caps each existence-check/delete
+    /// round so the sweep never issues a single unbounded <c>$in</c> over the whole collection. Not spec
+    /// text; hard-coded, adjust here only (mirrors <c>ChatHub.Channels.MaxPresenceRegisterAttempts</c>'s
+    /// local-const-not-ChatLimits precedent — this is an internal job-tuning knob, not a client-facing
+    /// limit). Internal (assembly has InternalsVisibleTo, ChatHub.cs) so a test can pin the batching
+    /// boundary without hardcoding a duplicate magic number.
+    /// </summary>
+    internal const int OrphanSweepBatchSize = 1000;
+
     public async Task RunOnce(DateTime now)
     {
         await DeleteEmptySemiPublicChannels();
         await PruneIdleMemberships(now);
+        await SweepOrphanedMemberships();
     }
 
     public async Task<long> DeleteEmptySemiPublicChannels()
@@ -84,5 +102,48 @@ public class CleanupJobs(MongoClient mongoClient) : MongoDbRepositoryBase(mongoC
             Builders<NotificationPreference>.Filter.In(p => p.BattleTag, idleMembershipKeys));
 
         return result.DeletedCount;
+    }
+
+    /// <summary>
+    /// Match-channel-hygiene brief (2026-08-05), Part 2 — DB-hygiene sweep for membership rows whose
+    /// channel no longer exists (see the class doc's item (c)). This is the slow-path complement to the
+    /// connect-time self-heal (<see cref="Protocol.SessionStateAssembler.AssembleAndSeed"/>): it catches
+    /// users who never reconnect, so an orphaned row doesn't linger until the 365-day idle sweep above.
+    /// <para>
+    /// Mechanics: distinct ChannelIds across ALL memberships, processed <see cref="OrphanSweepBatchSize"/>
+    /// at a time (cardinality is bounded by total channels + orphans, which can be large) — per batch, an
+    /// existence check against the channels collection (<c>$in</c>) yields the missing subset, which is
+    /// then batch-deleted from memberships in one round-trip. A channel id with zero memberships never
+    /// enters the distinct set in the first place, so this never scans healthy channels.
+    /// </para>
+    /// </summary>
+    public async Task<long> SweepOrphanedMemberships()
+    {
+        var db = CreateClient();
+        var channels = db.GetCollection<ChatChannel>(ChatCollections.Channels);
+        var memberships = db.GetCollection<ChannelMembership>(ChatCollections.ChannelMemberships);
+
+        var distinctChannelIds = await memberships
+            .DistinctAsync(m => m.ChannelId, Builders<ChannelMembership>.Filter.Empty);
+        var allChannelIds = await distinctChannelIds.ToListAsync();
+        if (allChannelIds.Count == 0) return 0;
+
+        long deleted = 0;
+        foreach (var batch in allChannelIds.Chunk(OrphanSweepBatchSize))
+        {
+            var existingIds = await channels
+                .Find(Builders<ChatChannel>.Filter.In(c => c.Id, batch))
+                .Project(c => c.Id)
+                .ToListAsync();
+            var existingSet = new HashSet<string>(existingIds);
+            var missingIds = batch.Where(id => !existingSet.Contains(id)).ToList();
+            if (missingIds.Count == 0) continue;
+
+            var result = await memberships.DeleteManyAsync(
+                Builders<ChannelMembership>.Filter.In(m => m.ChannelId, missingIds));
+            deleted += result.DeletedCount;
+        }
+
+        return deleted;
     }
 }

--- a/W3ChampionsChatService/Memberships/MembershipRepository.cs
+++ b/W3ChampionsChatService/Memberships/MembershipRepository.cs
@@ -95,6 +95,27 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
         return Memberships.DeleteOneAsync(m => m.ChannelId == channelId && m.BattleTag == tag);
     }
 
+    /// <summary>
+    /// Match-channel-hygiene brief (2026-08-05), Part 1 — connect-time orphan self-heal. Batched delete of
+    /// membership rows whose channel no longer exists (e.g. a lost mm→chat member-removal left the row
+    /// behind after the System channel's <c>ttl_expiresAt</c> TTL'd the doc). Called ONLY from
+    /// <see cref="Protocol.SessionStateAssembler.AssembleAndSeed"/> with the CONNECTING user's own
+    /// excluded (channel-less) <see cref="ChannelMembership.ChannelId"/> set — every row therefore shares
+    /// the SAME BattleTag, so a single equality ANDed with a ChannelId <c>$in</c> serves the whole batch
+    /// through the unique <c>ux_channelId_battleTag</c> index (one index seek per channel id, bounded by
+    /// the — typically tiny — orphan count, never a collection scan). Virtual: a test seam so a throwing
+    /// double can prove the caller's best-effort posture (a delete failure must never fail connect).
+    /// </summary>
+    public virtual async Task<long> DeleteOrphanedForUser(string battleTag, IReadOnlyCollection<string> channelIds)
+    {
+        var tag = NormalizeTag(battleTag);
+        var filter = Builders<ChannelMembership>.Filter.And(
+            Builders<ChannelMembership>.Filter.In(m => m.ChannelId, channelIds),
+            Builders<ChannelMembership>.Filter.Eq(m => m.BattleTag, tag));
+        var result = await Memberships.DeleteManyAsync(filter);
+        return result.DeletedCount;
+    }
+
     /// <summary>Monotonic read-state advance ($max) — a lower/stale seq from an out-of-order
     /// or duplicate MarkRead call never regresses LastReadSeq.</summary>
     public Task UpdateLastReadSeq(string channelId, string battleTag, long seq)

--- a/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
+++ b/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
@@ -121,11 +121,20 @@ public class SessionStateAssembler(
             // match-channel-hygiene brief Part 2) gets another chance to reap them.
             try
             {
-                await membershipRepository.DeleteOrphanedForUser(identity.BattleTag, orphanedChannelIds);
-                Log.Information(
-                    "AssembleAndSeed: self-healed {Count} orphaned membership row(s) for {BattleTag} — channel doc(s) gone, membership row(s) deleted",
-                    orphanedChannelIds.Count,
-                    identity.BattleTag);
+                // Fix round 1 (finding F6): log the ACTUAL DeletedCount the delete returned, not the
+                // requested orphanedChannelIds.Count — a concurrent healer (a second connection for the
+                // SAME user, or the weekly CleanupJobs sweep, Part 2) can race this delete and already
+                // remove some of these rows first, so the requested count can overstate what THIS call
+                // actually healed. Logged only when > 0 (mirrors the guard above — nothing to report on
+                // a fully-raced no-op delete).
+                var deletedCount = await membershipRepository.DeleteOrphanedForUser(identity.BattleTag, orphanedChannelIds);
+                if (deletedCount > 0)
+                {
+                    Log.Information(
+                        "AssembleAndSeed: self-healed {Count} orphaned membership row(s) for {BattleTag} — channel doc(s) gone, membership row(s) deleted",
+                        deletedCount,
+                        identity.BattleTag);
+                }
             }
             catch (Exception ex)
             {

--- a/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
+++ b/W3ChampionsChatService/Protocol/SessionStateAssembler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Serilog;
 using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Chats;
@@ -93,10 +94,48 @@ public class SessionStateAssembler(
         // Channel-backed memberships only (row exists AND the channel it points at still exists) —
         // the single filtered set both the DTO's Channels list and the OnlineMemberRegistry seed are
         // built from, so a membership orphaned by a deleted channel never fans out to a channel with
-        // no row even though it doesn't reach the client either.
+        // no row even though it doesn't reach the client either. An orphaned row (channel doc gone —
+        // e.g. a lost mm→chat member-removal that leaves the row behind after the System channel's
+        // ttl_expiresAt TTLs the doc, 2026-08-05 match-channel-hygiene incident) drops AND deletes
+        // (self-heal, 2026-08-05): it is excluded from this filtered set exactly as before, but the
+        // excluded set is ALSO collected and best-effort batch-deleted right below, so the connect path
+        // itself repairs the desync instead of waiting for CleanupJobs' weekly orphan sweep or the
+        // 365-day idle-membership prune to eventually catch it.
         var channelBackedMemberships = memberships
             .Where(m => channelsById.ContainsKey(m.ChannelId))
             .ToList();
+
+        // Self-heal (2026-08-05): the channel ids behind this connecting user's own orphaned rows — every
+        // row shares this user's BattleTag, which is what lets MembershipRepository.DeleteOrphanedForUser
+        // serve the whole batch off the unique ux_channelId_battleTag index. Guarded on non-empty so the
+        // common case (no orphans) issues zero extra queries.
+        var orphanedChannelIds = memberships
+            .Where(m => !channelsById.ContainsKey(m.ChannelId))
+            .Select(m => m.ChannelId)
+            .ToList();
+        if (orphanedChannelIds.Count > 0)
+        {
+            // Best-effort: a delete failure must never fail connect — the snapshot above already
+            // excludes these rows regardless of whether the delete below succeeds, so the client
+            // experience is unaffected either way; the next connect (or the weekly CleanupJobs sweep,
+            // match-channel-hygiene brief Part 2) gets another chance to reap them.
+            try
+            {
+                await membershipRepository.DeleteOrphanedForUser(identity.BattleTag, orphanedChannelIds);
+                Log.Information(
+                    "AssembleAndSeed: self-healed {Count} orphaned membership row(s) for {BattleTag} — channel doc(s) gone, membership row(s) deleted",
+                    orphanedChannelIds.Count,
+                    identity.BattleTag);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(
+                    ex,
+                    "AssembleAndSeed: failed to self-heal {Count} orphaned membership row(s) for {BattleTag} — snapshot proceeds with the dropped set regardless",
+                    orphanedChannelIds.Count,
+                    identity.BattleTag);
+            }
+        }
 
         // Follow-up spec §6: bound the 1:1-DM slice of the snapshot. The SELECTED set feeds the DTO's
         // Channels list, the pending tray, AND the OnlineMemberRegistry seed below — the registry set


### PR DESCRIPTION
Hygiene half of the 2026-08-05 stuck-lobby-chat incident fixes (launcher half rides launcher-e #839; the root-cause protocol fix — epoch/seq membership reconciliation with matchmaking — is spec'd separately and deferred to its own round).

## What's in here (1187/1187 tests)

### Connect-time orphan self-heal
Memberships whose channel doc no longer exists (TTL'd match channels, lost teardowns) were silently hidden from the snapshot but never deleted. Connect now batch-deletes them (best-effort — a delete failure can never fail connect; logs the actual deleted count as an operator desync signal). Zero extra queries when there are no orphans.

### Orphaned-membership sweep in CleanupJobs
Weekly job now also reaps membership rows referencing missing channels — covers users who never reconnect. Discovery is index-ordered range pagination (no `distinct` — the naive version was empirically proven to die at Mongo's 16MB cap around ~450k distinct ids); existence checks + deletes are batched. Safety precondition (channel ids are always fresh ObjectIds, never reused) documented at the site.

### JoinChannel hardening (review catch)
The System/Dm/GroupDm name-match denial branch was believed unreachable — review **proved the opposite**: `JoinChannel(null)` normalizes to a `{NormalizedName: null}` query that matches every ACL channel (the field is `[BsonIgnoreIfNull]` and never set for those types), making that branch a live ACL guard reached on every null-name call — via a guaranteed COLLSCAN. Now: null/whitespace names are rejected first thing (same `PermissionDenied`, zero DB reads — pinned by a counting-repository test), and the branch stays as documented defense-in-depth.

## Verification
`dotnet test` 1187/1187 (10 new), build 0 warnings, format clean. Opus review (deletion-safety focus: creation-ordering walked for every channel type — channel-doc-first everywhere; cross-user delete scoping mutation-tested) + fix round + scoped re-review with independent re-verification — CLEAN.

No wire changes; deploy in any order relative to the launcher.
