### PR TITLE
Match-channel reconciliation: authoritative roster assertions, epoch sync, detach freeze

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ Idempotent create-or-get of a match channel: `{ kind: "match", ref, name, member
 A duplicate call for the same `ref` is `200`, not a conflict — same channel, no duplicate memberships, no
 re-push for members already present, and the 24h creation-anchored expiry is never reset by a re-get.
 
+`name` is **normalized, never rejected**: trimmed, and clamped to 100 chars. An empty-after-trim name
+falls back to `ref` as a placeholder display name — a cosmetic field must never be able to block an
+otherwise-valid create.
+
 Optional additive fields (absent ⇒ today's behavior, byte-for-byte):
 
 - `epoch` (string) / `seq` (integer, >= 1) — must arrive **together**; a lone one is a `400`. When
@@ -319,6 +323,10 @@ lobby's complete member set; chat-service diffs it against stored membership and
   existing member.
 - `name` — optional; used **only** when the assertion must create the channel on demand (mm's boot-race
   healing, so a recreated room never displays its raw ref as its name). Ignored on an existing channel.
+  **Normalized, never rejected**: trimmed and clamped to 100 chars; an empty-after-trim name falls back
+  to the ref placeholder, exactly like create-on-demand above. `name` is cosmetic — mm applies no
+  length/trim/charset validation of its own to a custom-game lobby name before sending it, and a field
+  chat cannot store must never be able to reject the entire authoritative roster.
 - `detached` — see below.
 
 **Staleness — `(epoch, seq)` admission table**, persisted per channel:
@@ -370,6 +378,16 @@ Every non-frozen match channel is then resolved one of two ways:
 re-anchored — regardless of whether their ref appears in `liveLobbyRefs`. A live in-progress or
 just-finished game's chat must never be swept away by an mm restart; its 24h TTL is its only cleanup path.
 
+**Only assertion-stamped channels are ever sweep candidates.** A channel becomes eligible for an epoch
+sync only once it has participated in the assertion protocol at least once — created with `epoch`/`seq`,
+or asserted via the roster endpoint above. A channel that predates this protocol (created only through
+the deprecated delta endpoint, never asserted) carries no stamp at all and is **invisible to the sweep**:
+it survives regardless of `liveLobbyRefs` and falls to its own 24h creation-anchored TTL instead. This is
+what makes it safe to deploy mm's epoch-sync call against the match channels chat already holds from
+before mm's own deploy — the first sync after mm's release simply never sees them, so it cannot tear them
+down. No backfill, feature flag, or deploy-order choreography is required for this beyond "chat-service
+ships first" (see Deploy order below).
+
 ### `DELETE /internal/channels/{ref}`
 
 Explicit, unconditional teardown: messages purged, memberships deleted, the channel doc removed, and
@@ -384,3 +402,10 @@ not an explicit authoritative teardown mm chooses to send.
 shape simultaneously, so today's not-yet-deployed mm keeps working unchanged through its own release.
 Once mm's deploy to the assertion protocol is confirmed, the delta endpoint and its supporting code are
 removed in a follow-up chat-service PR.
+
+**Rollback is a one-way door once mm has deployed the assertion protocol.** After mm starts calling
+`PUT .../roster` and `POST .../epoch-sync`, rolling chat-service back below this version `404`s both
+routes. mm's assertion scheduler has no attempt cap, so every dirty lobby retries at a steady ~30s cadence
+forever and the boot-time epoch sync never converges — a silent, total desync whose only tell is a pegged
+`matchmaking_chat_dirty_channels` gauge on the mm side. **Never roll chat-service back below this version
+while assertion-era mm is live; if a rollback is ever needed, roll mm back first.**

--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ channel's own `POST` (create-on-demand, using the ref as a placeholder display n
 
 The **authoritative full-set membership assertion** — the replacement for the delta above. mm sends the
 lobby's complete member set; chat-service diffs it against stored membership and converges, idempotently.
+A user-initiated leave (`ChatHub.LeaveChannel`) on a live match channel is re-converged by the next
+assertion, by design (2026-08-05 reconciliation review, H4) — mm is authoritative for lobby membership.
 
 ```json
 { "epoch": "<opaque token>", "seq": 1, "members": ["Tag#1", "Tag#2"], "name": "My Lobby", "detached": false }

--- a/README.md
+++ b/README.md
@@ -293,22 +293,10 @@ Optional additive fields (absent ⇒ today's behavior, byte-for-byte):
   refs are never part of mm's live-lobby registry, so without birth-detach the first epoch sync after any
   mm restart would tear down every in-progress ladder game's chat.
 
-### `PUT /internal/channels/{ref}/members` — DEPRECATED
-
-> **This endpoint is scheduled for removal.** It exists only so chat-service can serve both mm's current
-> (delta-based) and upcoming (assertion-based) membership protocols during the deploy window described
-> below. Once mm's deploy to the assertion protocol is confirmed, this route, its request DTO, and the
-> corresponding legacy code paths are deleted in a follow-up chat-service PR — every site that must be
-> touched is marked in code with a grep-able `TRANSITION (2026-08-05 ...)` comment.
-
-The legacy membership delta: `{ add: string[], remove: string[], focus? }`. `add`/`remove` tolerate a
-missing array (treated as empty — "no change" for that half of the call). Tolerant of arriving before the
-channel's own `POST` (create-on-demand, using the ref as a placeholder display name).
-
 ### `PUT /internal/channels/{ref}/roster`
 
-The **authoritative full-set membership assertion** — the replacement for the delta above. mm sends the
-lobby's complete member set; chat-service diffs it against stored membership and converges, idempotently.
+The **authoritative full-set membership assertion** — the sole membership-mutation protocol mm drives. mm
+sends the lobby's complete member set; chat-service diffs it against stored membership and converges, idempotently.
 A user-initiated leave (`ChatHub.LeaveChannel`) on a live match channel is re-converged by the next
 assertion, by design (2026-08-05 reconciliation review, H4) — mm is authoritative for lobby membership.
 
@@ -320,9 +308,8 @@ assertion, by design (2026-08-05 reconciliation review, H4) — mm is authoritat
   generation, fresh per mm boot. Compared for equality only — never parsed or ordered.
 - `seq` — a positive integer (`>= 1`), mm's per-`(lobby, epoch)` monotonic counter. `0` is reserved
   server-side as "nothing applied yet under this epoch".
-- `members` — the **complete** roster. Unlike the delta's `add`/`remove`, this is **not** null-tolerant:
-  omitting it is a `400`, while `[]` is a legal, meaningful value (an empty lobby) and clears every
-  existing member.
+- `members` — the **complete** roster. **Not** null-tolerant: omitting it is a `400`, while `[]` is a
+  legal, meaningful value (an empty lobby) and clears every existing member.
 - `name` — optional; used **only** when the assertion must create the channel on demand (mm's boot-race
   healing, so a recreated room never displays its raw ref as its name). Ignored on an existing channel.
   **Normalized, never rejected**: trimmed and clamped to 100 chars; an empty-after-trim name falls back
@@ -347,7 +334,6 @@ A **discarded** assertion (stale, duplicate, or against a frozen channel — see
 applied first, then the channel **freezes**. Once frozen:
 
 - every later roster assertion for that ref is discarded;
-- the deprecated delta endpoint above is discarded too, regardless of which protocol asks;
 - `POST /internal/channels` still find-or-creates and backfills the name, but adds no members;
 - an explicit `DELETE` (below) still works — detach freezes assertions and sweeps, not an explicit
   teardown command.
@@ -382,28 +368,28 @@ just-finished game's chat must never be swept away by an mm restart; its 24h TTL
 
 **Only assertion-stamped channels are ever sweep candidates.** A channel becomes eligible for an epoch
 sync only once it has participated in the assertion protocol at least once — created with `epoch`/`seq`,
-or asserted via the roster endpoint above. A channel that predates this protocol (created only through
-the deprecated delta endpoint, never asserted) carries no stamp at all and is **invisible to the sweep**:
-it survives regardless of `liveLobbyRefs` and falls to its own 24h creation-anchored TTL instead. This is
+or asserted via the roster endpoint above. A channel created via `POST /internal/channels` without
+`epoch`/`seq` and never since asserted carries no stamp at all and is **invisible to the sweep**: it
+survives regardless of `liveLobbyRefs` and falls to its own 24h creation-anchored TTL instead. This is
 what makes it safe to deploy mm's epoch-sync call against the match channels chat already holds from
 before mm's own deploy — the first sync after mm's release simply never sees them, so it cannot tear them
-down. No backfill, feature flag, or deploy-order choreography is required for this beyond "chat-service
-ships first" (see Deploy order below).
+down. No backfill, feature flag, or deploy-order choreography is required for this beyond "chat deploys
+first" (see Deploy order below).
 
 ### `DELETE /internal/channels/{ref}`
 
 Explicit, unconditional teardown: messages purged, memberships deleted, the channel doc removed, and
 `ChannelRemoved` pushed to every member who was online. `200` even for an unknown `ref` (a `404` would
-only trigger a pointless mm retry), and — unlike the roster assertion and the deprecated delta — this
-still tears down an **already-frozen** channel: detach guards the automated paths (assertions, sweeps),
-not an explicit authoritative teardown mm chooses to send.
+only trigger a pointless mm retry), and — unlike the roster assertion — this still tears down an
+**already-frozen** channel: detach guards the automated paths (assertions, sweeps), not an explicit
+authoritative teardown mm chooses to send.
 
 ### Deploy order
 
-**chat-service ships first.** It accepts both the deprecated delta shape and the new roster-assertion
-shape simultaneously, so today's not-yet-deployed mm keeps working unchanged through its own release.
-Once mm's deploy to the assertion protocol is confirmed, the delta endpoint and its supporting code are
-removed in a follow-up chat-service PR.
+**chat-service deploys before (or with) mm.** Until mm's own deploy lands, its still-running deployment
+keeps calling the old membership-delta endpoint this service no longer serves — those calls `404`
+harmlessly (fail-soft: no chat functionality depends on them succeeding) until mm's own deploy switches it
+over to the roster-assertion protocol above.
 
 **Rollback is a one-way door once mm has deployed the assertion protocol.** After mm starts calling
 `PUT .../roster` and `POST .../epoch-sync`, rolling chat-service back below this version `404`s both

--- a/README.md
+++ b/README.md
@@ -251,3 +251,136 @@ of what it proxies for moderation.
 - **`DELETE api/loungeMute/{bTag}`** — `404 Not Found` if no mute exists for `bTag`; otherwise `200 OK`,
   and the target's live connections have their cached mute cleared immediately (the client's hidden
   rooms/ban banner still only refresh on reconnect — no live "ban lifted" event is sent, by design).
+
+## Internal API for the matchmaking service (HMAC realm)
+
+Every endpoint below lives under `/internal/channels` and is gated by a per-caller HMAC signature —
+**a disjoint auth realm from the JWT/ticket scheme above**, never `[UserHasPermission]`. mm signs the
+raw request body and presents two headers:
+
+- `X-W3C-Webhook-Timestamp` — unix seconds.
+- `X-W3C-Signature` — `"v1=" + hex(HMAC_SHA256(key = the caller's configured secret, msg = "v1." +
+  timestamp + "." + rawBodyBytes))`, taken over the **exact** raw body bytes (never a re-serialized
+  copy). Hex is verified case-insensitively.
+
+A request is rejected with a bare, body-free `401` when either header is missing, the body exceeds the
+internal size cap, the signature does not verify, the clock skew between `now` and the timestamp exceeds
+a **±300s freshness window**, or the caller the signature resolves to is not on the endpoint's allow-list
+(only mm may call this surface). Each caller (mm, website-backend) is provisioned its own secret out of
+band — this document intentionally carries no secret value, hostname, or environment name.
+
+Every `ref` (a lobby/match identifier) and `epoch` is re-validated server-side against the same character
+class regardless of what the caller sent, and every `400` returns a generic body that never echoes which
+rule failed — mm should treat any `4xx` as "fix the request", not parse the message.
+
+### `POST /internal/channels`
+
+Idempotent create-or-get of a match channel: `{ kind: "match", ref, name, members: string[], focus? }`.
+A duplicate call for the same `ref` is `200`, not a conflict — same channel, no duplicate memberships, no
+re-push for members already present, and the 24h creation-anchored expiry is never reset by a re-get.
+
+Optional additive fields (absent ⇒ today's behavior, byte-for-byte):
+
+- `epoch` (string) / `seq` (integer, >= 1) — must arrive **together**; a lone one is a `400`. When
+  present they stamp the same `(epoch, seq)` staleness state the roster assertion below uses, so a
+  late-landing create retry can never resurrect a member a newer assertion already removed.
+- `detached` (bool) — marks the channel born already frozen. **Ladder matches must send `detached: true`
+  on create**: chat-service uses one channel kind for both custom lobbies and ladder matches, and ladder
+  refs are never part of mm's live-lobby registry, so without birth-detach the first epoch sync after any
+  mm restart would tear down every in-progress ladder game's chat.
+
+### `PUT /internal/channels/{ref}/members` — DEPRECATED
+
+> **This endpoint is scheduled for removal.** It exists only so chat-service can serve both mm's current
+> (delta-based) and upcoming (assertion-based) membership protocols during the deploy window described
+> below. Once mm's deploy to the assertion protocol is confirmed, this route, its request DTO, and the
+> corresponding legacy code paths are deleted in a follow-up chat-service PR — every site that must be
+> touched is marked in code with a grep-able `TRANSITION (2026-08-05 ...)` comment.
+
+The legacy membership delta: `{ add: string[], remove: string[], focus? }`. `add`/`remove` tolerate a
+missing array (treated as empty — "no change" for that half of the call). Tolerant of arriving before the
+channel's own `POST` (create-on-demand, using the ref as a placeholder display name).
+
+### `PUT /internal/channels/{ref}/roster`
+
+The **authoritative full-set membership assertion** — the replacement for the delta above. mm sends the
+lobby's complete member set; chat-service diffs it against stored membership and converges, idempotently.
+
+```json
+{ "epoch": "<opaque token>", "seq": 1, "members": ["Tag#1", "Tag#2"], "name": "My Lobby", "detached": false }
+```
+
+- `epoch` — an **opaque string** (the same character class/length cap as `ref`), mm's authority
+  generation, fresh per mm boot. Compared for equality only — never parsed or ordered.
+- `seq` — a positive integer (`>= 1`), mm's per-`(lobby, epoch)` monotonic counter. `0` is reserved
+  server-side as "nothing applied yet under this epoch".
+- `members` — the **complete** roster. Unlike the delta's `add`/`remove`, this is **not** null-tolerant:
+  omitting it is a `400`, while `[]` is a legal, meaningful value (an empty lobby) and clears every
+  existing member.
+- `name` — optional; used **only** when the assertion must create the channel on demand (mm's boot-race
+  healing, so a recreated room never displays its raw ref as its name). Ignored on an existing channel.
+- `detached` — see below.
+
+**Staleness — `(epoch, seq)` admission table**, persisted per channel:
+
+| Stored state | Incoming | Result |
+|---|---|---|
+| no epoch stored yet | any | **accept**, stamp `(epoch, seq)` — covers channels that predate this protocol |
+| same epoch | `seq` strictly greater than stored | **accept**, advance the stamp |
+| same epoch | `seq` equal to or lower than stored | **discard** (duplicate/reordered delivery — a no-op) |
+| different epoch | any | **accept and re-anchor** to the incoming epoch (logged as an anomaly) — epochs are opaque and unordered, so a discard rule here would permanently wedge a channel that outlived an mm restart |
+
+A **discarded** assertion (stale, duplicate, or against a frozen channel — see below) still returns
+`200`: it is a successful no-op, not a failure, and mm must not retry a correctly-discarded assertion.
+
+`detached: true` marks mm's final assertion for a lobby (sent once, at game start): the member set is
+applied first, then the channel **freezes**. Once frozen:
+
+- every later roster assertion for that ref is discarded;
+- the deprecated delta endpoint above is discarded too, regardless of which protocol asks;
+- `POST /internal/channels` still find-or-creates and backfills the name, but adds no members;
+- an explicit `DELETE` (below) still works — detach freezes assertions and sweeps, not an explicit
+  teardown command.
+
+A frozen channel is excluded from every sweep, including the epoch sync below; the 24h creation-anchored
+TTL is its sole cleanup path from there.
+
+### `POST /internal/channels/epoch-sync`
+
+mm's boot-time convergence sweep, sent once per mm process start under a fresh `epoch`:
+
+```json
+{ "epoch": "<opaque token>", "liveLobbyRefs": ["abc123XYZ0", "..."] }
+```
+
+`liveLobbyRefs` is the **complete** set of lobby refs mm still knows about right now (the empty set after
+a crash, since lobbies are ephemeral state in mm) — like `members` above, it is **not** null-tolerant
+(omitting it is a `400`) but `[]` is honored as a legal, meaningful value. Every entry is re-validated
+against the ref character class and the array is capped at 512 entries; an over-cap body is a `400` (mm
+should retry rather than send a partial world).
+
+Every non-frozen match channel is then resolved one of two ways:
+
+- **absent** from `liveLobbyRefs` ⇒ torn down (same routine as the explicit `DELETE` below: messages and
+  memberships purged, channel doc removed, `ChannelRemoved` pushed to every member who was online).
+- **present** ⇒ spared, and re-anchored to the new epoch with its `seq` counter reset, so mm's first
+  assertion under the new epoch applies cleanly.
+
+**Frozen (`detached`) channels are never touched by an epoch sync** — not loaded, not torn down, not
+re-anchored — regardless of whether their ref appears in `liveLobbyRefs`. A live in-progress or
+just-finished game's chat must never be swept away by an mm restart; its 24h TTL is its only cleanup path.
+
+### `DELETE /internal/channels/{ref}`
+
+Explicit, unconditional teardown: messages purged, memberships deleted, the channel doc removed, and
+`ChannelRemoved` pushed to every member who was online. `200` even for an unknown `ref` (a `404` would
+only trigger a pointless mm retry), and — unlike the roster assertion and the deprecated delta — this
+still tears down an **already-frozen** channel: detach guards the automated paths (assertions, sweeps),
+not an explicit authoritative teardown mm chooses to send.
+
+### Deploy order
+
+**chat-service ships first.** It accepts both the deprecated delta shape and the new roster-assertion
+shape simultaneously, so today's not-yet-deployed mm keeps working unchanged through its own release.
+Once mm's deploy to the assertion protocol is confirmed, the delta endpoint and its supporting code are
+removed in a follow-up chat-service PR.

--- a/W3ChampionsChatService.Tests/ChannelRepositorySystemTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelRepositorySystemTests.cs
@@ -190,7 +190,9 @@ public class ChannelRepositorySystemTests : IntegrationTestBase
     [Test]
     public async Task TryAdvanceAssertion_SameEpochEqualSeq_Rejects_AndLeavesStampUnchanged()
     {
-        // Pins the ModifiedCount vs MatchedCount subtlety: a same-(epoch, seq) replay must be a no-op.
+        // Pins equal-seq REJECTION (the observable boolean/stamp), not the ModifiedCount vs MatchedCount
+        // choice — the strict Lt and the ModifiedCount check mutually mask each other here; neither is
+        // independently distinguished by this test alone (see ChannelRepository.TryAdvanceAssertion).
         var repo = new ChannelRepository(MongoClient);
         var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
         await repo.TryAdvanceAssertion(channel.Id, "e1", 3);
@@ -283,6 +285,10 @@ public class ChannelRepositorySystemTests : IntegrationTestBase
         await repo.FindOrCreateSystem(SystemChannelKind.Clan, "clan-1", "Clan Chat", Now);
         await repo.Insert(new ChatChannel { Type = ChannelType.Public, Name = "Pub", NormalizedName = "pub" });
         await repo.Insert(new ChatChannel { Type = ChannelType.Dm, PairKey = "alice#1|bob#2" });
+        // Pins the Type == System clause (Task 1 review r1, mutation M8): SystemKind == Match alone
+        // would otherwise admit this non-System doc. The unique ux_systemKind_systemRef index is
+        // partial on Type == System, so a Public doc with a SystemKind cannot collide with it.
+        await repo.Insert(new ChatChannel { Type = ChannelType.Public, Name = "Impostor", NormalizedName = "impostor", SystemKind = SystemChannelKind.Match, SystemRef = "match-impostor" });
 
         var result = await repo.LoadNonDetachedMatchChannels();
 

--- a/W3ChampionsChatService.Tests/ChannelRepositorySystemTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelRepositorySystemTests.cs
@@ -285,9 +285,9 @@ public class ChannelRepositorySystemTests : IntegrationTestBase
         await repo.TryAdvanceAssertion(detachedMatch.Id, "e1", 1);
         await repo.SetDetached(detachedMatch.Id);
         // 2026-08-05 fix wave (final review H1, plan D8 amendment): a match channel that has NEVER been
-        // stamped by the assertion protocol — exactly the shape of a channel minted only by the
-        // deprecated delta path during the transition window — must be excluded too, same as a detached
-        // one, not just left to chance alongside the non-match seeds below.
+        // stamped by the assertion protocol — exactly the shape of a channel created without epoch/seq
+        // and never since asserted — must be excluded too, same as a detached one, not just left to
+        // chance alongside the non-match seeds below.
         await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-unstamped", "Unstamped Match", Now);
         await repo.FindOrCreateSystem(SystemChannelKind.Clan, "clan-1", "Clan Chat", Now);
         await repo.Insert(new ChatChannel { Type = ChannelType.Public, Name = "Pub", NormalizedName = "pub" });
@@ -323,8 +323,8 @@ public class ChannelRepositorySystemTests : IntegrationTestBase
     [Test]
     public async Task LegacyChannelDocument_WithoutAssertionFields_Deserializes_AndIsAdmissible()
     {
-        // Backward-compatibility pin: a channel created via the legacy create/delta path never wrote
-        // the three new fields — every read must tolerate absence, and the CAS must still admit.
+        // Backward-compatibility pin: a channel created without epoch/seq never wrote the three new
+        // fields — every read must tolerate absence, and the CAS must still admit.
         var repo = new ChannelRepository(MongoClient);
         var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
 

--- a/W3ChampionsChatService.Tests/ChannelRepositorySystemTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelRepositorySystemTests.cs
@@ -276,12 +276,19 @@ public class ChannelRepositorySystemTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task LoadNonDetachedMatchChannels_ReturnsOnlyNonDetachedSystemMatch()
+    public async Task LoadNonDetachedMatchChannels_ReturnsOnlyNonDetachedAssertionStampedSystemMatch()
     {
         var repo = new ChannelRepository(MongoClient);
         var liveMatch = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-live", "Live Match", Now);
+        await repo.TryAdvanceAssertion(liveMatch.Id, "e1", 1);
         var detachedMatch = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-detached", "Detached Match", Now);
+        await repo.TryAdvanceAssertion(detachedMatch.Id, "e1", 1);
         await repo.SetDetached(detachedMatch.Id);
+        // 2026-08-05 fix wave (final review H1, plan D8 amendment): a match channel that has NEVER been
+        // stamped by the assertion protocol — exactly the shape of a channel minted only by the
+        // deprecated delta path during the transition window — must be excluded too, same as a detached
+        // one, not just left to chance alongside the non-match seeds below.
+        await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-unstamped", "Unstamped Match", Now);
         await repo.FindOrCreateSystem(SystemChannelKind.Clan, "clan-1", "Clan Chat", Now);
         await repo.Insert(new ChatChannel { Type = ChannelType.Public, Name = "Pub", NormalizedName = "pub" });
         await repo.Insert(new ChatChannel { Type = ChannelType.Dm, PairKey = "alice#1|bob#2" });

--- a/W3ChampionsChatService.Tests/ChannelRepositorySystemTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelRepositorySystemTests.cs
@@ -154,4 +154,172 @@ public class ChannelRepositorySystemTests : IntegrationTestBase
         Assert.That(index["key"]["SystemRef"].ToInt32(), Is.EqualTo(1));
         Assert.That(index["partialFilterExpression"]["Type"].AsString, Is.EqualTo("System"));
     }
+
+    // ── 2026-08-05 reconciliation plan Task 1 (D3/D4/D8) — (epoch, seq) assertion admission +
+    // detach latch + epoch-sync repository primitives ────────────────────────────────────────
+
+    [Test]
+    public async Task TryAdvanceAssertion_NoEpochStored_Accepts_AndStamps()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+
+        var accepted = await repo.TryAdvanceAssertion(channel.Id, "e1", 1);
+
+        Assert.That(accepted, Is.True, "a channel with no stored epoch must admit the first assertion");
+        var reloaded = await repo.Load(channel.Id);
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e1"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(1L));
+    }
+
+    [Test]
+    public async Task TryAdvanceAssertion_SameEpochHigherSeq_Accepts_AndAdvances()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+        await repo.TryAdvanceAssertion(channel.Id, "e1", 3);
+
+        var accepted = await repo.TryAdvanceAssertion(channel.Id, "e1", 4);
+
+        Assert.That(accepted, Is.True);
+        var reloaded = await repo.Load(channel.Id);
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e1"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(4L));
+    }
+
+    [Test]
+    public async Task TryAdvanceAssertion_SameEpochEqualSeq_Rejects_AndLeavesStampUnchanged()
+    {
+        // Pins the ModifiedCount vs MatchedCount subtlety: a same-(epoch, seq) replay must be a no-op.
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+        await repo.TryAdvanceAssertion(channel.Id, "e1", 3);
+
+        var accepted = await repo.TryAdvanceAssertion(channel.Id, "e1", 3);
+
+        Assert.That(accepted, Is.False);
+        var reloaded = await repo.Load(channel.Id);
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e1"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(3L));
+    }
+
+    [Test]
+    public async Task TryAdvanceAssertion_SameEpochLowerSeq_Rejects_AndLeavesStampUnchanged()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+        await repo.TryAdvanceAssertion(channel.Id, "e1", 5);
+
+        var accepted = await repo.TryAdvanceAssertion(channel.Id, "e1", 4);
+
+        Assert.That(accepted, Is.False);
+        var reloaded = await repo.Load(channel.Id);
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e1"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(5L));
+    }
+
+    [Test]
+    public async Task TryAdvanceAssertion_DifferentEpoch_Accepts_AndReAnchors()
+    {
+        // D3(c): epochs are opaque and unordered, so a mismatch is accepted and re-anchored rather
+        // than discarded (a discard rule could permanently wedge a channel after an mm restart).
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+        await repo.TryAdvanceAssertion(channel.Id, "e1", 9);
+
+        var accepted = await repo.TryAdvanceAssertion(channel.Id, "e2", 1);
+
+        Assert.That(accepted, Is.True);
+        var reloaded = await repo.Load(channel.Id);
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e2"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(1L));
+    }
+
+    [Test]
+    public async Task TryAdvanceAssertion_DetachedChannel_Rejects()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+        await repo.TryAdvanceAssertion(channel.Id, "e1", 1);
+        await repo.SetDetached(channel.Id);
+
+        var accepted = await repo.TryAdvanceAssertion(channel.Id, "e1", 99);
+
+        Assert.That(accepted, Is.False, "a detached channel must never re-admit an assertion, even with a strictly greater seq");
+        var reloaded = await repo.Load(channel.Id);
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(1L));
+    }
+
+    [Test]
+    public async Task TryAdvanceAssertion_UnknownChannelId_Rejects()
+    {
+        var repo = new ChannelRepository(MongoClient);
+
+        var accepted = await repo.TryAdvanceAssertion("does-not-exist", "e1", 1);
+
+        Assert.That(accepted, Is.False);
+    }
+
+    [Test]
+    public async Task SetDetached_IsIdempotent_AndPersists()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+
+        await repo.SetDetached(channel.Id);
+        await repo.SetDetached(channel.Id);
+
+        var reloaded = await repo.Load(channel.Id);
+        Assert.That(reloaded.Detached, Is.True);
+    }
+
+    [Test]
+    public async Task LoadNonDetachedMatchChannels_ReturnsOnlyNonDetachedSystemMatch()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var liveMatch = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-live", "Live Match", Now);
+        var detachedMatch = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-detached", "Detached Match", Now);
+        await repo.SetDetached(detachedMatch.Id);
+        await repo.FindOrCreateSystem(SystemChannelKind.Clan, "clan-1", "Clan Chat", Now);
+        await repo.Insert(new ChatChannel { Type = ChannelType.Public, Name = "Pub", NormalizedName = "pub" });
+        await repo.Insert(new ChatChannel { Type = ChannelType.Dm, PairKey = "alice#1|bob#2" });
+
+        var result = await repo.LoadNonDetachedMatchChannels();
+
+        Assert.That(result.Select(c => c.Id).ToList(), Is.EquivalentTo(new[] { liveMatch.Id }));
+    }
+
+    [Test]
+    public async Task StampAssertionEpoch_SetsEpoch_AndResetsSeqToZeroSentinel()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+        await repo.TryAdvanceAssertion(channel.Id, "e1", 9);
+
+        await repo.StampAssertionEpoch(channel.Id, "e2");
+
+        var reloaded = await repo.Load(channel.Id);
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e2"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(0L));
+
+        // proves the 0 sentinel (never $unset) does not wedge the channel against the new epoch.
+        var accepted = await repo.TryAdvanceAssertion(channel.Id, "e2", 1);
+        Assert.That(accepted, Is.True);
+    }
+
+    [Test]
+    public async Task LegacyChannelDocument_WithoutAssertionFields_Deserializes_AndIsAdmissible()
+    {
+        // Backward-compatibility pin: a channel created via the legacy create/delta path never wrote
+        // the three new fields — every read must tolerate absence, and the CAS must still admit.
+        var repo = new ChannelRepository(MongoClient);
+        var channel = await repo.FindOrCreateSystem(SystemChannelKind.Match, "match-1", "Match Chat", Now);
+
+        Assert.That(channel.Detached, Is.False);
+        Assert.That(channel.AssertSeq, Is.EqualTo(0L));
+        Assert.That(channel.AssertEpoch, Is.Null);
+
+        var accepted = await repo.TryAdvanceAssertion(channel.Id, "e1", 1);
+        Assert.That(accepted, Is.True);
+    }
 }

--- a/W3ChampionsChatService.Tests/ChatLimitsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatLimitsTests.cs
@@ -130,6 +130,27 @@ public class ChatLimitsTests
     }
 
     [Test]
+    public void InternalMaxLiveRefsPerSync_Is512()
+    {
+        // 2026-08-05 reconciliation spec §3 — plan decision, not spec-pinned text; hard-coded,
+        // adjust here only.
+        Assert.AreEqual(512, ChatLimits.InternalMaxLiveRefsPerSync);
+    }
+
+    [Test]
+    public void InternalMaxLiveRefsPerSync_StaysWithinInternalMaxBodyBytes()
+    {
+        // Pins the sizing argument documented on InternalMaxLiveRefsPerSync's declaration: a 64-char
+        // ref plus JSON quoting/comma is ≈68 bytes (InternalRefMaxLength + 4), so the whole array must
+        // stay comfortably inside InternalMaxBodyBytes. If either constant moves, this test catches the
+        // sizing argument going false at CI time instead of mm hitting an unexpected 400 in production.
+        Assert.Less(
+            ChatLimits.InternalMaxLiveRefsPerSync * (ChatLimits.InternalRefMaxLength + 4),
+            ChatLimits.InternalMaxBodyBytes,
+            "InternalMaxLiveRefsPerSync * (InternalRefMaxLength + 4) must stay under InternalMaxBodyBytes");
+    }
+
+    [Test]
     public void DefaultChatRooms_NormalizeToDistinctKeys()
     {
         // C3 Task 3: Guards the static SessionStateAssembler.CatalogOrder initialization invariant.

--- a/W3ChampionsChatService.Tests/CleanupJobsTests.cs
+++ b/W3ChampionsChatService.Tests/CleanupJobsTests.cs
@@ -200,6 +200,33 @@ public class CleanupJobsTests : IntegrationTestBase
         Assert.IsNull(await membershipRepo.Load("gone-channel", "orphan#1"), "the genuine orphan must still be reaped");
     }
 
+    // 2026-08-05 reconciliation (plan D4/D8, Task 4): a detached System+Match channel keeps its doc —
+    // detach freezes ASSERTIONS and SWEEPS, not the channel's existence — so its membership rows are
+    // NOT orphans and must survive this sweep untouched. Pins the composition the brief calls out
+    // (ApplyEpochSync's own exclusion filter is a separate, redundant guard against ever reaching here).
+    [Test]
+    public async Task SweepOrphanedMemberships_LeavesDetachedMatchChannelMembershipsAlone()
+    {
+        var channelRepo = new ChannelRepository(MongoClient);
+        var membershipRepo = new MembershipRepository(MongoClient, channelRepo);
+
+        var detachedChannel = new ChatChannel
+        {
+            Type = ChannelType.System,
+            SystemKind = SystemChannelKind.Match,
+            SystemRef = "match-detached",
+            Name = "Detached Match",
+            Detached = true,
+        };
+        await channelRepo.Insert(detachedChannel);
+        await membershipRepo.Insert(new ChannelMembership { ChannelId = detachedChannel.Id, BattleTag = "Peter#123", JoinedAt = DateTime.UtcNow });
+
+        var deleted = await new CleanupJobs(MongoClient).SweepOrphanedMemberships();
+
+        Assert.AreEqual(0, deleted, "the detached channel's doc still exists, so its membership rows are not orphans");
+        Assert.IsNotNull(await membershipRepo.Load(detachedChannel.Id, "Peter#123"), "the detached channel's membership row survives");
+    }
+
     // Fix round 1 (finding F3): RunOnce's wiring of the orphan sweep was untested — deleting the
     // SweepOrphanedMemberships() call from RunOnce would survive the full suite (only the method in
     // isolation was pinned). This proves RunOnce itself reaps an orphan, not just the method directly.

--- a/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
@@ -299,6 +299,35 @@ public class InternalApiIntegrationTests : IntegrationTestBase
         return await _channelsController.Delete(@ref);
     }
 
+    // 2026-08-05 reconciliation spec, Task 6 — the same hand-signed-through-the-real-filter idiom as the
+    // three helpers above, for the two ADDITIVE endpoints.
+
+    private async Task<IActionResult> PutChannelRoster(string @ref, string bodyJson, string secret, string timestamp, InternalCaller[] allowed = null)
+    {
+        var (passed, http) = await ThroughFilter("PUT", $"/internal/channels/{@ref}/roster", Utf8(bodyJson), secret, timestamp, allowed ?? MmOnlyAllowed);
+        if (!passed)
+        {
+            return new UnauthorizedResult();
+        }
+
+        var dto = await JsonSerializer.DeserializeAsync<InternalRosterAssertRequest>(http.Request.Body, JsonOptions);
+        _channelsController.ControllerContext.HttpContext = http;
+        return await _channelsController.AssertRoster(@ref, dto);
+    }
+
+    private async Task<IActionResult> PostEpochSync(string bodyJson, string secret, string timestamp, InternalCaller[] allowed = null)
+    {
+        var (passed, http) = await ThroughFilter("POST", "/internal/channels/epoch-sync", Utf8(bodyJson), secret, timestamp, allowed ?? MmOnlyAllowed);
+        if (!passed)
+        {
+            return new UnauthorizedResult();
+        }
+
+        var dto = await JsonSerializer.DeserializeAsync<InternalEpochSyncRequest>(http.Request.Body, JsonOptions);
+        _channelsController.ControllerContext.HttpContext = http;
+        return await _channelsController.EpochSync(dto);
+    }
+
     private async Task<IActionResult> PostRelationshipChange(string bodyJson, string secret, string timestamp, InternalCaller[] allowed = null)
     {
         var (passed, http) = await ThroughFilter("POST", "/internal/relationship-changes", Utf8(bodyJson), secret, timestamp, allowed ?? WbOnlyAllowed);
@@ -734,5 +763,213 @@ public class InternalApiIntegrationTests : IntegrationTestBase
         var finalChannel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, @ref);
         Assert.That(finalChannel, Is.Not.Null);
         Assert.That(finalChannel.Id, Is.EqualTo(healedDto.Id));
+    }
+
+    // ════════════════════════════════════════════════════════════════════════════════════════════
+    // 2026-08-05 RECONCILIATION — Task 6: the two ADDITIVE endpoints proved through the REAL HMAC
+    // byte-path (mirrors ACCEPTANCE 1's Hmac_PinnedVectors_AcceptedEndToEnd / CrossCaller shape), plus
+    // the transition-coexistence pins (spec §"Verification gates" — chat must accept BOTH the legacy
+    // delta shape and the new authoritative assertion shape until mm's own deploy).
+    // ════════════════════════════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task RosterAssert_SignedRequest_AcceptedEndToEnd()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        RegisterOnline("conn-alice", alice);
+        RegisterOnline("conn-bob", bob);
+
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-roster-1\",\"name\":\"Roster Match\",\"members\":[\"Alice#1\"]}";
+        var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp()) as OkObjectResult;
+        Assert.That(createResult, Is.Not.Null);
+        var channelDto = createResult.Value as InternalChannelDto;
+
+        // The full-set assertion drops Alice (absent from the asserted set) and adds Bob — through the
+        // REAL filter, then the REAL controller/domain/repository stack.
+        var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[\"Bob#2\"]}";
+        var rosterResult = await PutChannelRoster("match-roster-1", rosterBody, MmSecret, NowTimestamp());
+
+        Assert.That(rosterResult, Is.InstanceOf<OkResult>(), "a correctly signed roster assertion must be accepted end-to-end");
+        Assert.That(await _membershipRepository.Load(channelDto.Id, alice), Is.Null, "Alice, absent from the asserted set, converges away");
+        Assert.That(await _membershipRepository.Load(channelDto.Id, bob), Is.Not.Null, "Bob, present in the asserted set, is durably added");
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(1));
+        Assert.That(_harness.SignalCount("conn-bob", ChatEvents.ChannelAdded), Is.EqualTo(1));
+
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-roster-1");
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e1"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(1L));
+    }
+
+    [Test]
+    public async Task RosterAssert_WrongSecret_Rejected401_AndNoMembershipChange()
+    {
+        const string alice = "Alice#1";
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-roster-2\",\"name\":\"Roster Match 2\",\"members\":[\"Alice#1\"]}";
+        var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp()) as OkObjectResult;
+        Assert.That(createResult, Is.Not.Null);
+        var channelDto = createResult.Value as InternalChannelDto;
+
+        // A signature computed with the WRONG secret never verifies — the real filter must reject before
+        // model binding, so ApplyRosterAssertion (which would empty the membership below) never runs.
+        var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[]}";
+        var result = await PutChannelRoster("match-roster-2", rosterBody, "not-the-real-secret", NowTimestamp());
+
+        Assert.That(result, Is.InstanceOf<UnauthorizedResult>());
+        Assert.That(await _membershipRepository.Load(channelDto.Id, alice), Is.Not.Null,
+            "a rejected request must never reach the domain layer — the pre-existing membership is untouched");
+    }
+
+    [Test]
+    public async Task RosterAssert_WbCaller_Rejected401()
+    {
+        // Least privilege (mirror CrossCaller_WbSecretOnChannelsEndpoint_401): a cryptographically VALID
+        // wb signature is not enough — wb is not in InternalChannelsController's Mm-only allow-list.
+        var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[]}";
+
+        var result = await PutChannelRoster("cross-caller-roster", rosterBody, WbSecret, NowTimestamp(), MmOnlyAllowed);
+
+        Assert.That(result, Is.InstanceOf<UnauthorizedResult>());
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "cross-caller-roster"), Is.Null,
+            "a rejected request must never reach the controller/DB — not even a create-on-demand shell");
+    }
+
+    [Test]
+    public async Task EpochSync_SignedRequest_AcceptedEndToEnd()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-epoch-1\",\"name\":\"Epoch Match\",\"members\":[\"Alice#1\"]}";
+        var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp());
+        Assert.That(createResult, Is.InstanceOf<OkObjectResult>());
+
+        // mm rebooted under a fresh epoch and no longer knows this lobby — the sync tears it down.
+        var syncBody = "{\"epoch\":\"e2\",\"liveLobbyRefs\":[]}";
+        var result = await PostEpochSync(syncBody, MmSecret, NowTimestamp());
+
+        Assert.That(result, Is.InstanceOf<OkResult>(), "a correctly signed epoch sync must be accepted end-to-end");
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-epoch-1"), Is.Null,
+            "the channel absent from liveLobbyRefs is torn down");
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(1),
+            "ChannelRemoved reaches the online member's captured connection");
+    }
+
+    [Test]
+    public async Task EpochSync_WrongSecret_Rejected401_AndNothingTornDown()
+    {
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-epoch-2\",\"name\":\"Epoch Match 2\",\"members\":[]}";
+        var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp());
+        Assert.That(createResult, Is.InstanceOf<OkObjectResult>());
+
+        var syncBody = "{\"epoch\":\"e2\",\"liveLobbyRefs\":[]}";
+        var result = await PostEpochSync(syncBody, "not-the-real-secret", NowTimestamp());
+
+        Assert.That(result, Is.InstanceOf<UnauthorizedResult>());
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-epoch-2"), Is.Not.Null,
+            "a rejected epoch sync must never reach ApplyEpochSync — nothing is torn down");
+    }
+
+    [Test]
+    public async Task Transition_DeltaThenAssertion_Converges()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        RegisterOnline("conn-alice", alice);
+        RegisterOnline("conn-bob", bob);
+
+        // mm's legacy delta lands first — create-on-demand shell, no stored epoch yet (the pre-protocol state).
+        var deltaBody = "{\"add\":[\"Alice#1\"],\"remove\":[]}";
+        var deltaResult = await PutChannelMembers("match-transition-1", deltaBody, MmSecret, NowTimestamp());
+        Assert.That(deltaResult, Is.InstanceOf<OkResult>());
+        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-1");
+        Assert.That(shell.AssertEpoch, Is.Null, "a channel born via the legacy delta path carries no stored epoch");
+        Assert.That(await _membershipRepository.Load(shell.Id, alice), Is.Not.Null);
+
+        // The FIRST assertion converges to the asserted set, removing whoever the delta added who is absent.
+        var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[\"Bob#2\"]}";
+        var rosterResult = await PutChannelRoster("match-transition-1", rosterBody, MmSecret, NowTimestamp());
+
+        Assert.That(rosterResult, Is.InstanceOf<OkResult>());
+        Assert.That(await _membershipRepository.Load(shell.Id, alice), Is.Null,
+            "the assertion converges — Alice, added only by the delta, is absent from the asserted set");
+        Assert.That(await _membershipRepository.Load(shell.Id, bob), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task Transition_AssertionThenDelta_DeltaStillApplies()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        RegisterOnline("conn-alice", alice);
+        RegisterOnline("conn-bob", bob);
+
+        var rosterBody1 = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[\"Alice#1\"],\"name\":\"Transition Match\"}";
+        var rosterResult1 = await PutChannelRoster("match-transition-2", rosterBody1, MmSecret, NowTimestamp());
+        Assert.That(rosterResult1, Is.InstanceOf<OkResult>());
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-2");
+
+        // A straggler delta on a NON-detached channel during the overlap window still mutates membership —
+        // it bypasses the (epoch, seq) guard by design (it does not call TryAdvanceAssertion at all).
+        var deltaBody = "{\"add\":[\"Bob#2\"],\"remove\":[]}";
+        var deltaResult = await PutChannelMembers("match-transition-2", deltaBody, MmSecret, NowTimestamp());
+        Assert.That(deltaResult, Is.InstanceOf<OkResult>());
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null, "the straggler delta genuinely mutated membership");
+        var afterDelta = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-2");
+        Assert.That(afterDelta.AssertSeq, Is.EqualTo(1L), "the delta does NOT bump the stored (epoch, seq)");
+
+        // The NEXT assertion re-converges — a late delta can never permanently desync the room (the exact
+        // behavior the transition window relies on).
+        var rosterBody2 = "{\"epoch\":\"e1\",\"seq\":2,\"members\":[\"Alice#1\"]}";
+        var rosterResult2 = await PutChannelRoster("match-transition-2", rosterBody2, MmSecret, NowTimestamp());
+        Assert.That(rosterResult2, Is.InstanceOf<OkResult>());
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null,
+            "the next assertion re-converges, removing the straggler delta's member");
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task Transition_CreateThenAssertion_SharesOneChannel()
+    {
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-transition-3\",\"name\":\"Real Display Name\",\"members\":[]}";
+        var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp()) as OkObjectResult;
+        Assert.That(createResult, Is.Not.Null);
+        var createDto = createResult.Value as InternalChannelDto;
+
+        _time.Advance(TimeSpan.FromHours(1));
+
+        // name is provided but IGNORED — CreateOrGet already established the real name on an existing channel.
+        var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[],\"name\":\"Should Be Ignored\"}";
+        var rosterResult = await PutChannelRoster("match-transition-3", rosterBody, MmSecret, NowTimestamp());
+
+        Assert.That(rosterResult, Is.InstanceOf<OkResult>());
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-3");
+        Assert.That(channel.Id, Is.EqualTo(createDto.Id), "the create and the assertion resolve to the SAME channel doc");
+        Assert.That(channel.Name, Is.EqualTo("Real Display Name"), "the real display name is preserved — name is ignored on an existing channel");
+        Assert.That(channel.ExpiresAt, Is.EqualTo(createDto.ExpiresAt), "the 24h creation-anchored expiry is NOT reset by the assertion");
+    }
+
+    [Test]
+    public async Task Transition_AssertionBeforeCreate_ThenCreate_BackfillsNameWithoutResettingExpiry()
+    {
+        // The assertion arrives BEFORE mm's own create POST (the boot-race healing case) — create-on-demand
+        // shell, no name provided, so the ref itself is the placeholder.
+        var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[]}";
+        var rosterResult = await PutChannelRoster("match-transition-4", rosterBody, MmSecret, NowTimestamp());
+        Assert.That(rosterResult, Is.InstanceOf<OkResult>());
+        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-4");
+        Assert.That(shell.Name, Is.EqualTo("match-transition-4"), "no name was provided — the ref itself is the placeholder");
+        var shellExpiry = shell.ExpiresAt;
+
+        _time.Advance(TimeSpan.FromHours(1));
+
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-transition-4\",\"name\":\"Real Match Name\",\"members\":[]}";
+        var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp()) as OkObjectResult;
+
+        Assert.That(createResult, Is.Not.Null, "the late create must succeed against the assertion-created shell");
+        var createDto = createResult.Value as InternalChannelDto;
+        Assert.That(createDto.Id, Is.EqualTo(shell.Id), "the create resolves to the SAME shell channel");
+        Assert.That(createDto.Name, Is.EqualTo("Real Match Name"), "the real create backfills the placeholder name");
+        Assert.That(createDto.ExpiresAt, Is.EqualTo(shellExpiry), "the create does NOT reset the shell's own creation-anchored expiry");
     }
 }

--- a/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
@@ -840,7 +840,10 @@ public class InternalApiIntegrationTests : IntegrationTestBase
         const string alice = "Alice#1";
         RegisterOnline("conn-alice", alice);
 
-        var createBody = "{\"kind\":\"match\",\"ref\":\"match-epoch-1\",\"name\":\"Epoch Match\",\"members\":[\"Alice#1\"]}";
+        // 2026-08-05 fix wave (final review H1, plan D8 amendment): the sweep only considers channels
+        // already stamped by the assertion protocol, so the create carries epoch/seq — an unstamped
+        // channel would be invisible to the sweep and would survive regardless of liveLobbyRefs.
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-epoch-1\",\"name\":\"Epoch Match\",\"members\":[\"Alice#1\"],\"epoch\":\"e1\",\"seq\":1}";
         var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp());
         Assert.That(createResult, Is.InstanceOf<OkObjectResult>());
 

--- a/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
@@ -274,19 +274,6 @@ public class InternalApiIntegrationTests : IntegrationTestBase
         return await _channelsController.Create(dto);
     }
 
-    private async Task<IActionResult> PutChannelMembers(string @ref, string bodyJson, string secret, string timestamp, InternalCaller[] allowed = null)
-    {
-        var (passed, http) = await ThroughFilter("PUT", $"/internal/channels/{@ref}/members", Utf8(bodyJson), secret, timestamp, allowed ?? MmOnlyAllowed);
-        if (!passed)
-        {
-            return new UnauthorizedResult();
-        }
-
-        var dto = await JsonSerializer.DeserializeAsync<InternalMembersDeltaRequest>(http.Request.Body, JsonOptions);
-        _channelsController.ControllerContext.HttpContext = http;
-        return await _channelsController.UpdateMembers(@ref, dto);
-    }
-
     private async Task<IActionResult> DeleteChannelThroughFilter(string @ref, string secret, string timestamp, InternalCaller[] allowed = null)
     {
         var (passed, http) = await ThroughFilter("DELETE", $"/internal/channels/{@ref}", Array.Empty<byte>(), secret, timestamp, allowed ?? MmOnlyAllowed);
@@ -300,7 +287,7 @@ public class InternalApiIntegrationTests : IntegrationTestBase
     }
 
     // 2026-08-05 reconciliation spec, Task 6 — the same hand-signed-through-the-real-filter idiom as the
-    // three helpers above, for the two ADDITIVE endpoints.
+    // two helpers above, for the roster-assertion and epoch-sync endpoints.
 
     private async Task<IActionResult> PutChannelRoster(string @ref, string bodyJson, string secret, string timestamp, InternalCaller[] allowed = null)
     {
@@ -524,45 +511,6 @@ public class InternalApiIntegrationTests : IntegrationTestBase
     }
 
     // ════════════════════════════════════════════════════════════════════════════════════════════
-    // ACCEPTANCE 4 — member delta: add creates membership + pushes ChannelAdded; remove deletes +
-    // pushes ChannelRemoved + force-unfocuses the removed user's connection.
-    // ════════════════════════════════════════════════════════════════════════════════════════════
-
-    [Test]
-    public async Task MemberDelta_AddPushes_RemoveDeletesPushesAndForceUnfocuses()
-    {
-        const string bt = "Alice#1";
-        RegisterOnline("conn-alice", bt);
-
-        var createBody = "{\"kind\":\"match\",\"ref\":\"match-ac4\",\"name\":\"AC4 Match\",\"members\":[]}";
-        var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp()) as OkObjectResult;
-        var channelDto = createResult.Value as InternalChannelDto;
-
-        // ADD via PUT — through the real filter + real controller.
-        var addBody = "{\"add\":[\"Alice#1\"],\"remove\":[],\"focus\":true}";
-        var addResult = await PutChannelMembers("match-ac4", addBody, MmSecret, NowTimestamp());
-        Assert.That(addResult, Is.InstanceOf<OkResult>());
-        Assert.That(await _membershipRepository.Load(channelDto.Id, bt), Is.Not.Null, "the add creates a durable membership");
-        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1));
-
-        _focusRegistry.Focus("conn-alice", channelDto.Id, bt);
-        Assert.That(_focusRegistry.GetFocusedChannels("conn-alice"), Does.Contain(channelDto.Id),
-            "precondition: the connection genuinely has the channel focused before the removal");
-
-        // REMOVE via PUT — pushes ChannelRemoved and force-unfocuses the connection.
-        var removeBody = "{\"add\":[],\"remove\":[\"Alice#1\"]}";
-        var removeResult = await PutChannelMembers("match-ac4", removeBody, MmSecret, NowTimestamp());
-        Assert.That(removeResult, Is.InstanceOf<OkResult>());
-        Assert.That(await _membershipRepository.Load(channelDto.Id, bt), Is.Null, "the remove deletes the membership");
-        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(1));
-        var removedDto = _harness.PayloadFor("conn-alice", ChatEvents.ChannelRemoved) as ChannelRemovedDto;
-        Assert.That(removedDto, Is.Not.Null);
-        Assert.That(removedDto.ChannelId, Is.EqualTo(channelDto.Id));
-        Assert.That(_focusRegistry.GetFocusedChannels("conn-alice"), Does.Not.Contain(channelDto.Id),
-            "the removed user's connection is FORCE-UNFOCUSED from the channel");
-    }
-
-    // ════════════════════════════════════════════════════════════════════════════════════════════
     // ACCEPTANCE 5 — one-match-channel-per-user invariant: ChannelRemoved(A) STRICTLY before
     // ChannelAdded(B); exactly one System+Match membership remains.
     // ════════════════════════════════════════════════════════════════════════════════════════════
@@ -718,58 +666,9 @@ public class InternalApiIntegrationTests : IntegrationTestBase
     }
 
     // ════════════════════════════════════════════════════════════════════════════════════════════
-    // PLUS — the M1 fire-and-forget reordering story, end-to-end: a members-PUT can arrive before the
-    // create, a DELETE can then race ahead of the create too, and a LATE create POST must still heal
-    // idempotently (no exception, no orphaned/duplicate data) rather than resurrecting stale state.
-    // ════════════════════════════════════════════════════════════════════════════════════════════
-
-    [Test]
-    public async Task OutOfOrder_PutThenDelete_ThenLatePost_HealsIdempotently()
-    {
-        const string bt = "Alice#1";
-        const string @ref = "match-reorder";
-        RegisterOnline("conn-alice", bt);
-
-        // 1. The members-PUT arrives FIRST (mm's delta call raced ahead of its own create call) —
-        // create-on-demand shell (ref-as-placeholder-name), tolerant of delta-before-create (M1).
-        var putBody = "{\"add\":[\"Alice#1\"],\"remove\":[],\"focus\":true}";
-        var putResult = await PutChannelMembers(@ref, putBody, MmSecret, NowTimestamp());
-        Assert.That(putResult, Is.InstanceOf<OkResult>());
-        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, @ref);
-        Assert.That(shell, Is.Not.Null, "the shell is created on demand rather than a hard 404");
-        Assert.That(await _membershipRepository.Load(shell.Id, bt), Is.Not.Null);
-        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1));
-
-        // 2. The DELETE arrives NEXT (mm canceled the lobby before its own retried create POST landed) —
-        // hard teardown, tolerant of delete-before-(real)create.
-        var deleteResult = await DeleteChannelThroughFilter(@ref, MmSecret, NowTimestamp());
-        Assert.That(deleteResult, Is.InstanceOf<OkResult>());
-        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, @ref), Is.Null);
-        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(1));
-
-        // 3. The ORIGINAL create POST finally arrives LAST (after retries/reordering) — must heal
-        // idempotently: no exception, no orphaned/duplicate data. Since the prior shell was hard-deleted,
-        // this legitimately creates a BRAND-NEW channel (a fresh Id, a fresh 24h expiry) rather than
-        // resurrecting the torn-down one — there is nothing left to resurrect.
-        var postBody = $"{{\"kind\":\"match\",\"ref\":\"{@ref}\",\"name\":\"Reorder Match\",\"members\":[\"Alice#1\"],\"focus\":true}}";
-        var postResult = await PostChannelsCreate(postBody, MmSecret, NowTimestamp()) as OkObjectResult;
-        Assert.That(postResult, Is.Not.Null, "the late create must succeed, not error, even though its own channel was already torn down");
-        var healedDto = postResult.Value as InternalChannelDto;
-        Assert.That(healedDto.Id, Is.Not.EqualTo(shell.Id), "the healed channel is a brand-new document — the deleted one is gone for good");
-        Assert.That(await _membershipRepository.Load(healedDto.Id, bt), Is.Not.Null, "Alice is (re)added to the healed channel");
-        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(2), "a second ChannelAdded for the healed channel");
-
-        // Exactly ONE channel exists for this ref at the end — no duplicates, no orphans left behind.
-        var finalChannel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, @ref);
-        Assert.That(finalChannel, Is.Not.Null);
-        Assert.That(finalChannel.Id, Is.EqualTo(healedDto.Id));
-    }
-
-    // ════════════════════════════════════════════════════════════════════════════════════════════
-    // 2026-08-05 RECONCILIATION — Task 6: the two ADDITIVE endpoints proved through the REAL HMAC
-    // byte-path (mirrors ACCEPTANCE 1's Hmac_PinnedVectors_AcceptedEndToEnd / CrossCaller shape), plus
-    // the transition-coexistence pins (spec §"Verification gates" — chat must accept BOTH the legacy
-    // delta shape and the new authoritative assertion shape until mm's own deploy).
+    // 2026-08-05 RECONCILIATION — Task 6: the two roster-assertion/epoch-sync endpoints proved through
+    // the REAL HMAC byte-path (mirrors ACCEPTANCE 1's Hmac_PinnedVectors_AcceptedEndToEnd / CrossCaller
+    // shape), plus a handful of create/assertion interaction pins.
     // ════════════════════════════════════════════════════════════════════════════════════════════
 
     [Test]
@@ -874,67 +773,9 @@ public class InternalApiIntegrationTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task Transition_DeltaThenAssertion_Converges()
+    public async Task RosterAssert_CreateThenAssertion_SharesOneChannel()
     {
-        const string alice = "Alice#1";
-        const string bob = "Bob#2";
-        RegisterOnline("conn-alice", alice);
-        RegisterOnline("conn-bob", bob);
-
-        // mm's legacy delta lands first — create-on-demand shell, no stored epoch yet (the pre-protocol state).
-        var deltaBody = "{\"add\":[\"Alice#1\"],\"remove\":[]}";
-        var deltaResult = await PutChannelMembers("match-transition-1", deltaBody, MmSecret, NowTimestamp());
-        Assert.That(deltaResult, Is.InstanceOf<OkResult>());
-        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-1");
-        Assert.That(shell.AssertEpoch, Is.Null, "a channel born via the legacy delta path carries no stored epoch");
-        Assert.That(await _membershipRepository.Load(shell.Id, alice), Is.Not.Null);
-
-        // The FIRST assertion converges to the asserted set, removing whoever the delta added who is absent.
-        var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[\"Bob#2\"]}";
-        var rosterResult = await PutChannelRoster("match-transition-1", rosterBody, MmSecret, NowTimestamp());
-
-        Assert.That(rosterResult, Is.InstanceOf<OkResult>());
-        Assert.That(await _membershipRepository.Load(shell.Id, alice), Is.Null,
-            "the assertion converges — Alice, added only by the delta, is absent from the asserted set");
-        Assert.That(await _membershipRepository.Load(shell.Id, bob), Is.Not.Null);
-    }
-
-    [Test]
-    public async Task Transition_AssertionThenDelta_DeltaStillApplies()
-    {
-        const string alice = "Alice#1";
-        const string bob = "Bob#2";
-        RegisterOnline("conn-alice", alice);
-        RegisterOnline("conn-bob", bob);
-
-        var rosterBody1 = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[\"Alice#1\"],\"name\":\"Transition Match\"}";
-        var rosterResult1 = await PutChannelRoster("match-transition-2", rosterBody1, MmSecret, NowTimestamp());
-        Assert.That(rosterResult1, Is.InstanceOf<OkResult>());
-        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-2");
-
-        // A straggler delta on a NON-detached channel during the overlap window still mutates membership —
-        // it bypasses the (epoch, seq) guard by design (it does not call TryAdvanceAssertion at all).
-        var deltaBody = "{\"add\":[\"Bob#2\"],\"remove\":[]}";
-        var deltaResult = await PutChannelMembers("match-transition-2", deltaBody, MmSecret, NowTimestamp());
-        Assert.That(deltaResult, Is.InstanceOf<OkResult>());
-        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null, "the straggler delta genuinely mutated membership");
-        var afterDelta = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-2");
-        Assert.That(afterDelta.AssertSeq, Is.EqualTo(1L), "the delta does NOT bump the stored (epoch, seq)");
-
-        // The NEXT assertion re-converges — a late delta can never permanently desync the room (the exact
-        // behavior the transition window relies on).
-        var rosterBody2 = "{\"epoch\":\"e1\",\"seq\":2,\"members\":[\"Alice#1\"]}";
-        var rosterResult2 = await PutChannelRoster("match-transition-2", rosterBody2, MmSecret, NowTimestamp());
-        Assert.That(rosterResult2, Is.InstanceOf<OkResult>());
-        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null,
-            "the next assertion re-converges, removing the straggler delta's member");
-        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null);
-    }
-
-    [Test]
-    public async Task Transition_CreateThenAssertion_SharesOneChannel()
-    {
-        var createBody = "{\"kind\":\"match\",\"ref\":\"match-transition-3\",\"name\":\"Real Display Name\",\"members\":[]}";
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-roster-3\",\"name\":\"Real Display Name\",\"members\":[]}";
         var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp()) as OkObjectResult;
         Assert.That(createResult, Is.Not.Null);
         var createDto = createResult.Value as InternalChannelDto;
@@ -943,30 +784,30 @@ public class InternalApiIntegrationTests : IntegrationTestBase
 
         // name is provided but IGNORED — CreateOrGet already established the real name on an existing channel.
         var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[],\"name\":\"Should Be Ignored\"}";
-        var rosterResult = await PutChannelRoster("match-transition-3", rosterBody, MmSecret, NowTimestamp());
+        var rosterResult = await PutChannelRoster("match-roster-3", rosterBody, MmSecret, NowTimestamp());
 
         Assert.That(rosterResult, Is.InstanceOf<OkResult>());
-        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-3");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-roster-3");
         Assert.That(channel.Id, Is.EqualTo(createDto.Id), "the create and the assertion resolve to the SAME channel doc");
         Assert.That(channel.Name, Is.EqualTo("Real Display Name"), "the real display name is preserved — name is ignored on an existing channel");
         Assert.That(channel.ExpiresAt, Is.EqualTo(createDto.ExpiresAt), "the 24h creation-anchored expiry is NOT reset by the assertion");
     }
 
     [Test]
-    public async Task Transition_AssertionBeforeCreate_ThenCreate_BackfillsNameWithoutResettingExpiry()
+    public async Task RosterAssert_AssertionBeforeCreate_ThenCreate_BackfillsNameWithoutResettingExpiry()
     {
         // The assertion arrives BEFORE mm's own create POST (the boot-race healing case) — create-on-demand
         // shell, no name provided, so the ref itself is the placeholder.
         var rosterBody = "{\"epoch\":\"e1\",\"seq\":1,\"members\":[]}";
-        var rosterResult = await PutChannelRoster("match-transition-4", rosterBody, MmSecret, NowTimestamp());
+        var rosterResult = await PutChannelRoster("match-roster-4", rosterBody, MmSecret, NowTimestamp());
         Assert.That(rosterResult, Is.InstanceOf<OkResult>());
-        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-transition-4");
-        Assert.That(shell.Name, Is.EqualTo("match-transition-4"), "no name was provided — the ref itself is the placeholder");
+        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-roster-4");
+        Assert.That(shell.Name, Is.EqualTo("match-roster-4"), "no name was provided — the ref itself is the placeholder");
         var shellExpiry = shell.ExpiresAt;
 
         _time.Advance(TimeSpan.FromHours(1));
 
-        var createBody = "{\"kind\":\"match\",\"ref\":\"match-transition-4\",\"name\":\"Real Match Name\",\"members\":[]}";
+        var createBody = "{\"kind\":\"match\",\"ref\":\"match-roster-4\",\"name\":\"Real Match Name\",\"members\":[]}";
         var createResult = await PostChannelsCreate(createBody, MmSecret, NowTimestamp()) as OkObjectResult;
 
         Assert.That(createResult, Is.Not.Null, "the late create must succeed against the assertion-created shell");

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -224,6 +224,10 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         AssertBadRequest(result);
     }
 
+    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): this whole region covers the
+    // DELTA path. mm keeps sending deltas until its own deploy; DELETE THIS ENTIRE REGION in the
+    // mm-deploy-confirmed cleanup PR alongside UpdateMembers/InternalMembersDeltaRequest — see docs
+    // plan Task 6.
     // ── PUT /internal/channels/{ref}/members ────────────────────────────────────────────────────
 
     [Test]

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -83,6 +83,13 @@ public class InternalChannelsControllerTests : IntegrationTestBase
     private static InternalChannelCreateRequest ValidCreateRequest(string @ref = "match-1", string name = "Match One", params string[] members) =>
         new() { Kind = "match", Ref = @ref, Name = name, Members = members.ToList() };
 
+    private static InternalRosterAssertRequest ValidRosterRequest(
+        string epoch = "e1", long seq = 1, string name = null, bool? detached = null, params string[] members) =>
+        new() { Epoch = epoch, Seq = seq, Members = members.ToList(), Name = name, Detached = detached };
+
+    private static InternalEpochSyncRequest ValidEpochSyncRequest(string epoch = "e1", params string[] liveLobbyRefs) =>
+        new() { Epoch = epoch, LiveLobbyRefs = liveLobbyRefs.ToList() };
+
     private static void AssertBadRequest(IActionResult result)
     {
         var badRequest = result as BadRequestObjectResult;
@@ -265,6 +272,340 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         var result = await _controller.UpdateMembers("match-1", new InternalMembersDeltaRequest { Add = tooMany });
 
         AssertBadRequest(result);
+    }
+
+    // ── PUT /internal/channels/{ref}/roster ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task PutRoster_ValidBody_Returns200_AndAppliesMembership()
+    {
+        var request = ValidRosterRequest(members: "Peter#123");
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        var membership = await _membershipRepository.LoadForUser("Peter#123");
+        Assert.That(membership, Is.Not.Empty, "the assertion must have applied the member");
+    }
+
+    [TestCaseSource(nameof(InvalidRefs))]
+    public async Task PutRoster_InvalidRef_400(string badRef)
+    {
+        var result = await _controller.AssertRoster(badRef, ValidRosterRequest());
+
+        AssertBadRequest(result);
+    }
+
+    [TestCaseSource(nameof(InvalidRefs))]
+    public async Task PutRoster_InvalidEpoch_400(string badEpoch)
+    {
+        var request = ValidRosterRequest();
+        request.Epoch = badEpoch;
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PutRoster_NullMembers_400()
+    {
+        var request = ValidRosterRequest();
+        request.Members = null;
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PutRoster_EmptyMembers_200_AndClearsMembership()
+    {
+        await _controller.Create(ValidCreateRequest(@ref: "match-1", members: "Peter#123"));
+
+        var result = await _controller.AssertRoster("match-1", ValidRosterRequest());
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        var membership = await _membershipRepository.LoadForUser("Peter#123");
+        Assert.That(membership, Is.Empty, "an empty asserted set is legal and must clear existing membership (D7)");
+    }
+
+    [Test]
+    public async Task PutRoster_TooManyMembers_400()
+    {
+        var request = ValidRosterRequest();
+        request.Members = Enumerable.Range(0, ChatLimits.InternalMaxMembersPerCall + 1)
+            .Select(i => $"Player{i}#123")
+            .ToList();
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PutRoster_BlankMemberEntry_400()
+    {
+        var request = ValidRosterRequest();
+        request.Members = new List<string> { "Peter#123", "   " };
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        AssertBadRequest(result);
+    }
+
+    [TestCase(0L)]
+    [TestCase(-1L)]
+    public async Task PutRoster_SeqBelowOne_400(long badSeq)
+    {
+        var request = ValidRosterRequest();
+        request.Seq = badSeq;
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PutRoster_UnknownRef_200_CreatesOnDemand()
+    {
+        var request = ValidRosterRequest(name: "Boot-Race Lobby", members: "Peter#123");
+
+        var result = await _controller.AssertRoster("does-not-exist-ref", request);
+
+        Assert.That(result, Is.InstanceOf<OkResult>(), "an assertion for an unknown ref must never 404");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "does-not-exist-ref");
+        Assert.That(channel, Is.Not.Null);
+        Assert.That(channel.Name, Is.EqualTo("Boot-Race Lobby"));
+    }
+
+    [Test]
+    public async Task PutRoster_StaleAssertion_Returns200()
+    {
+        await _controller.AssertRoster("match-1", ValidRosterRequest(epoch: "e1", seq: 5, members: "Peter#123"));
+
+        var result = await _controller.AssertRoster("match-1", ValidRosterRequest(epoch: "e1", seq: 1, members: "Wanda#456"));
+
+        Assert.That(result, Is.InstanceOf<OkResult>(), "a discarded stale assertion is still a 200, not an error");
+        var membership = await _membershipRepository.LoadForUser("Wanda#456");
+        Assert.That(membership, Is.Empty, "the stale assertion's membership must NOT have been applied");
+    }
+
+    [Test]
+    public async Task PutRoster_NullBody_400()
+    {
+        var result = await _controller.AssertRoster("match-1", null);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PutRoster_NullName_200()
+    {
+        var request = ValidRosterRequest(members: "Peter#123");
+        request.Name = null;
+
+        var result = await _controller.AssertRoster("brand-new-ref", request);
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "brand-new-ref");
+        Assert.That(channel.Name, Is.EqualTo("brand-new-ref"), "a null name falls back to the ref placeholder on create-on-demand");
+    }
+
+    [Test]
+    public async Task PutRoster_WhitespaceOnlyName_400()
+    {
+        var request = ValidRosterRequest();
+        request.Name = "   ";
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PutRoster_OverlongName_400()
+    {
+        var request = ValidRosterRequest();
+        request.Name = new string('a', 101);
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        AssertBadRequest(result);
+    }
+
+    // ── POST /internal/channels (D10 epoch/seq/detached) ────────────────────────────────────────
+
+    [Test]
+    public async Task PostCreate_WithEpochSeqDetached_200_AndChannelIsBornDetached()
+    {
+        var request = ValidCreateRequest(@ref: "ladder-1", members: "Peter#123");
+        request.Epoch = "e1";
+        request.Seq = 1;
+        request.Detached = true;
+
+        var result = await _controller.Create(request) as OkObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "ladder-1");
+        Assert.That(channel.Detached, Is.True, "a ladder-match create with detached:true must be born frozen");
+        var membership = await _membershipRepository.Load(channel.Id, "Peter#123");
+        Assert.That(membership, Is.Not.Null, "birth members are still added before the freeze");
+    }
+
+    [Test]
+    public async Task PostCreate_EpochWithoutSeq_400()
+    {
+        var request = ValidCreateRequest();
+        request.Epoch = "e1";
+
+        var result = await _controller.Create(request);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PostCreate_SeqWithoutEpoch_400()
+    {
+        var request = ValidCreateRequest();
+        request.Seq = 1;
+
+        var result = await _controller.Create(request);
+
+        AssertBadRequest(result);
+    }
+
+    [TestCase(0L)]
+    [TestCase(-1L)]
+    public async Task PostCreate_SeqBelowOne_400(long badSeq)
+    {
+        var request = ValidCreateRequest();
+        request.Epoch = "e1";
+        request.Seq = badSeq;
+
+        var result = await _controller.Create(request);
+
+        AssertBadRequest(result);
+    }
+
+    [TestCaseSource(nameof(InvalidRefs))]
+    public async Task PostCreate_InvalidEpoch_400(string badEpoch)
+    {
+        var request = ValidCreateRequest();
+        request.Epoch = badEpoch;
+        request.Seq = 1;
+
+        var result = await _controller.Create(request);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PostCreate_WithoutNewFields_200_UnchangedBehavior()
+    {
+        var request = ValidCreateRequest(@ref: "match-legacy", members: "Peter#123");
+
+        var result = await _controller.Create(request) as OkObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-legacy");
+        Assert.That(channel.AssertEpoch, Is.Null, "no stamp is written when epoch/seq are omitted — the back-compat pin for today's mm");
+        Assert.That(channel.Detached, Is.False);
+    }
+
+    // ── POST /internal/channels/epoch-sync ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task PostEpochSync_ValidBody_Returns200_AndTearsDownUnlistedChannels()
+    {
+        await _controller.Create(ValidCreateRequest(@ref: "match-live", members: "Peter#123"));
+        await _controller.Create(ValidCreateRequest(@ref: "match-dead", members: "Wanda#456"));
+
+        var result = await _controller.EpochSync(ValidEpochSyncRequest(liveLobbyRefs: "match-live"));
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-live"), Is.Not.Null);
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-dead"), Is.Null);
+    }
+
+    [Test]
+    public async Task PostEpochSync_EmptyLiveRefs_Returns200_AndTearsDownEverythingNonDetached()
+    {
+        await _controller.Create(ValidCreateRequest(@ref: "match-1", members: "Peter#123"));
+
+        var result = await _controller.EpochSync(ValidEpochSyncRequest());
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1"), Is.Null,
+            "an empty live list (the post-crash case) tears down every non-detached match channel");
+    }
+
+    [Test]
+    public async Task PostEpochSync_NullLiveRefs_400()
+    {
+        var result = await _controller.EpochSync(new InternalEpochSyncRequest { Epoch = "e1", LiveLobbyRefs = null });
+
+        AssertBadRequest(result);
+    }
+
+    [TestCaseSource(nameof(InvalidRefs))]
+    public async Task PostEpochSync_InvalidRefInLiveList_400(string badRef)
+    {
+        await _controller.Create(ValidCreateRequest(@ref: "match-1", members: "Peter#123"));
+
+        var result = await _controller.EpochSync(new InternalEpochSyncRequest { Epoch = "e1", LiveLobbyRefs = new List<string> { badRef } });
+
+        AssertBadRequest(result);
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1"), Is.Not.Null,
+            "validation must run BEFORE any domain call — an invalid entry must not trigger a partial teardown");
+    }
+
+    [TestCaseSource(nameof(InvalidRefs))]
+    public async Task PostEpochSync_InvalidEpoch_400(string badEpoch)
+    {
+        var result = await _controller.EpochSync(new InternalEpochSyncRequest { Epoch = badEpoch, LiveLobbyRefs = new List<string>() });
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PostEpochSync_TooManyLiveRefs_400()
+    {
+        var tooMany = Enumerable.Range(0, ChatLimits.InternalMaxLiveRefsPerSync + 1)
+            .Select(i => $"ref{i}")
+            .ToList();
+
+        var result = await _controller.EpochSync(new InternalEpochSyncRequest { Epoch = "e1", LiveLobbyRefs = tooMany });
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PostEpochSync_NullBody_400()
+    {
+        var result = await _controller.EpochSync(null);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public void PostEpochSync_RouteDoesNotShadowCreateOrDelete()
+    {
+        // Cheap regression guard (Task 5): proves the three actions carry distinct [Http*] route
+        // templates rather than reasoning about ASP.NET's routing table by inspection alone.
+        var createRoute = typeof(InternalChannelsController)
+            .GetMethod(nameof(InternalChannelsController.Create))
+            .GetCustomAttribute<HttpPostAttribute>()?.Template;
+        var deleteRoute = typeof(InternalChannelsController)
+            .GetMethod(nameof(InternalChannelsController.Delete))
+            .GetCustomAttribute<HttpDeleteAttribute>()?.Template;
+        var epochSyncRoute = typeof(InternalChannelsController)
+            .GetMethod(nameof(InternalChannelsController.EpochSync))
+            .GetCustomAttribute<HttpPostAttribute>()?.Template;
+
+        Assert.That(createRoute, Is.Null.Or.Empty, "Create is the root POST — no template, distinct from epoch-sync");
+        Assert.That(deleteRoute, Is.EqualTo("{ref}"), "Delete's template is a different verb+template from EpochSync's POST epoch-sync");
+        Assert.That(epochSyncRoute, Is.EqualTo("epoch-sync"));
     }
 
     // ── DELETE /internal/channels/{ref} ─────────────────────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -181,25 +181,31 @@ public class InternalChannelsControllerTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task Post_BlankName_400()
+    public async Task Post_BlankName_200_UsesRefPlaceholder()
     {
+        // 2026-08-05 fix wave (final review C1): name is cosmetic and must never reject an otherwise-valid
+        // create — mm applies no trim/length validation of its own before sending it.
         var request = ValidCreateRequest();
         request.Name = "   ";
 
-        var result = await _controller.Create(request);
+        var result = await _controller.Create(request) as OkObjectResult;
 
-        AssertBadRequest(result);
+        Assert.That(result, Is.Not.Null, "a whitespace-only name must normalize, never 400");
+        var dto = result.Value as InternalChannelDto;
+        Assert.That(dto.Name, Is.EqualTo("match-1"), "empty-after-trim falls back to the ref placeholder");
     }
 
     [Test]
-    public async Task Post_NameOver100Chars_400()
+    public async Task Post_NameOver100Chars_200_TruncatesName()
     {
         var request = ValidCreateRequest();
         request.Name = new string('a', 101);
 
-        var result = await _controller.Create(request);
+        var result = await _controller.Create(request) as OkObjectResult;
 
-        AssertBadRequest(result);
+        Assert.That(result, Is.Not.Null, "an overlong name must normalize (truncate), never 400");
+        var dto = result.Value as InternalChannelDto;
+        Assert.That(dto.Name, Is.EqualTo(new string('a', 100)), "clamped to the 100-char cap, not rejected");
     }
 
     [Test]
@@ -417,25 +423,31 @@ public class InternalChannelsControllerTests : IntegrationTestBase
     }
 
     [Test]
-    public async Task PutRoster_WhitespaceOnlyName_400()
+    public async Task PutRoster_WhitespaceOnlyName_200_UsesRefPlaceholder()
     {
+        // 2026-08-05 fix wave (final review C1): a name mm sends that chat cannot store must never
+        // permanently wedge a lobby's chat — normalize, never reject.
         var request = ValidRosterRequest();
         request.Name = "   ";
 
         var result = await _controller.AssertRoster("match-1", request);
 
-        AssertBadRequest(result);
+        Assert.That(result, Is.InstanceOf<OkResult>(), "a whitespace-only name must normalize, never 400");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(channel.Name, Is.EqualTo("match-1"), "empty-after-trim falls back to the ref placeholder");
     }
 
     [Test]
-    public async Task PutRoster_OverlongName_400()
+    public async Task PutRoster_OverlongName_200_TruncatesName()
     {
         var request = ValidRosterRequest();
         request.Name = new string('a', 101);
 
         var result = await _controller.AssertRoster("match-1", request);
 
-        AssertBadRequest(result);
+        Assert.That(result, Is.InstanceOf<OkResult>(), "an overlong name must normalize (truncate), never 400");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(channel.Name, Is.EqualTo(new string('a', 100)), "clamped to the 100-char cap, not rejected");
     }
 
     // ── POST /internal/channels (D10 epoch/seq/detached) ────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -243,60 +243,6 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         AssertBadRequest(result);
     }
 
-    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): this whole region covers the
-    // DELTA path. mm keeps sending deltas until its own deploy; DELETE THIS ENTIRE REGION in the
-    // mm-deploy-confirmed cleanup PR alongside UpdateMembers/InternalMembersDeltaRequest — see docs
-    // plan Task 6.
-    // ── PUT /internal/channels/{ref}/members ────────────────────────────────────────────────────
-
-    [Test]
-    public async Task Put_NullArrays_TreatedAsEmpty()
-    {
-        var request = new InternalMembersDeltaRequest { Add = null, Remove = null };
-
-        var result = await _controller.UpdateMembers("match-null-arrays", request);
-
-        Assert.That(result, Is.InstanceOf<OkResult>(), "null add/remove must be coerced to empty lists, not throw or 400");
-    }
-
-    [Test]
-    public async Task Put_AddsAndRemoves_AppliesDelta()
-    {
-        await _controller.Create(ValidCreateRequest(@ref: "match-2", members: "Peter#123"));
-
-        var result = await _controller.UpdateMembers("match-2", new InternalMembersDeltaRequest
-        {
-            Add = new List<string> { "Wanda#456" },
-            Remove = new List<string> { "Peter#123" },
-        });
-
-        Assert.That(result, Is.InstanceOf<OkResult>());
-        var membership = await _membershipRepository.LoadForUser("Wanda#456");
-        Assert.That(membership, Is.Not.Empty, "the add must have been applied");
-        var removed = await _membershipRepository.LoadForUser("Peter#123");
-        Assert.That(removed, Is.Empty, "the remove must have been applied");
-    }
-
-    [TestCaseSource(nameof(InvalidRefs))]
-    public async Task Put_RefWithDotSegments_400(string badRef)
-    {
-        var result = await _controller.UpdateMembers(badRef, new InternalMembersDeltaRequest());
-
-        AssertBadRequest(result);
-    }
-
-    [Test]
-    public async Task Put_TooManyMembers_400()
-    {
-        var tooMany = Enumerable.Range(0, ChatLimits.InternalMaxMembersPerCall + 1)
-            .Select(i => $"Player{i}#123")
-            .ToList();
-
-        var result = await _controller.UpdateMembers("match-1", new InternalMembersDeltaRequest { Add = tooMany });
-
-        AssertBadRequest(result);
-    }
-
     // ── PUT /internal/channels/{ref}/roster ─────────────────────────────────────────────────────
 
     [Test]
@@ -598,8 +544,7 @@ public class InternalChannelsControllerTests : IntegrationTestBase
     [Test]
     public async Task PostEpochSync_UnstampedChannel_Returns200_AndSurvives_FallsToTtl()
     {
-        // A channel created WITHOUT epoch/seq — exactly the shape of a channel minted only by the
-        // deprecated delta protocol (or today's not-yet-deployed mm) — must be invisible to the sweep.
+        // A channel created WITHOUT epoch/seq and never since asserted must be invisible to the sweep.
         await _controller.Create(ValidCreateRequest(@ref: "match-unstamped", members: "Peter#123"));
 
         var result = await _controller.EpochSync(ValidEpochSyncRequest());
@@ -660,8 +605,8 @@ public class InternalChannelsControllerTests : IntegrationTestBase
     [Test]
     public void PostEpochSync_RouteDoesNotShadowCreateOrDelete()
     {
-        // Cheap regression guard (Task 5): proves the three actions carry distinct [Http*] route
-        // templates rather than reasoning about ASP.NET's routing table by inspection alone.
+        // Cheap regression guard (Task 5): proves the actions carry distinct [Http*] route templates
+        // rather than reasoning about ASP.NET's routing table by inspection alone.
         var createRoute = typeof(InternalChannelsController)
             .GetMethod(nameof(InternalChannelsController.Create))
             .GetCustomAttribute<HttpPostAttribute>()?.Template;
@@ -674,16 +619,11 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         var assertRosterRoute = typeof(InternalChannelsController)
             .GetMethod(nameof(InternalChannelsController.AssertRoster))
             .GetCustomAttribute<HttpPutAttribute>()?.Template;
-        var updateMembersRoute = typeof(InternalChannelsController)
-            .GetMethod(nameof(InternalChannelsController.UpdateMembers))
-            .GetCustomAttribute<HttpPutAttribute>()?.Template;
 
         Assert.That(createRoute, Is.Null.Or.Empty, "Create is the root POST — no template, distinct from epoch-sync");
         Assert.That(deleteRoute, Is.EqualTo("{ref}"), "Delete's template is a different verb+template from EpochSync's POST epoch-sync");
         Assert.That(epochSyncRoute, Is.EqualTo("epoch-sync"));
         Assert.That(assertRosterRoute, Is.EqualTo("{ref}/roster"));
-        Assert.That(updateMembersRoute, Is.EqualTo("{ref}/members"));
-        Assert.That(assertRosterRoute, Is.Not.EqualTo(updateMembersRoute), "the two PUT routes must not collide (§2.3 one-character hazard)");
     }
 
     // ── DELETE /internal/channels/{ref} ─────────────────────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -449,6 +449,8 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         Assert.That(result, Is.Not.Null);
         var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "ladder-1");
         Assert.That(channel.Detached, Is.True, "a ladder-match create with detached:true must be born frozen");
+        Assert.That(channel.AssertEpoch, Is.EqualTo("e1"), "the request's epoch must be stamped through to the channel");
+        Assert.That(channel.AssertSeq, Is.EqualTo(1), "the request's seq must be stamped through to the channel");
         var membership = await _membershipRepository.Load(channel.Id, "Peter#123");
         Assert.That(membership, Is.Not.Null, "birth members are still added before the freeze");
     }
@@ -602,10 +604,19 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         var epochSyncRoute = typeof(InternalChannelsController)
             .GetMethod(nameof(InternalChannelsController.EpochSync))
             .GetCustomAttribute<HttpPostAttribute>()?.Template;
+        var assertRosterRoute = typeof(InternalChannelsController)
+            .GetMethod(nameof(InternalChannelsController.AssertRoster))
+            .GetCustomAttribute<HttpPutAttribute>()?.Template;
+        var updateMembersRoute = typeof(InternalChannelsController)
+            .GetMethod(nameof(InternalChannelsController.UpdateMembers))
+            .GetCustomAttribute<HttpPutAttribute>()?.Template;
 
         Assert.That(createRoute, Is.Null.Or.Empty, "Create is the root POST — no template, distinct from epoch-sync");
         Assert.That(deleteRoute, Is.EqualTo("{ref}"), "Delete's template is a different verb+template from EpochSync's POST epoch-sync");
         Assert.That(epochSyncRoute, Is.EqualTo("epoch-sync"));
+        Assert.That(assertRosterRoute, Is.EqualTo("{ref}/roster"));
+        Assert.That(updateMembersRoute, Is.EqualTo("{ref}/members"));
+        Assert.That(assertRosterRoute, Is.Not.EqualTo(updateMembersRoute), "the two PUT routes must not collide (§2.3 one-character hazard)");
     }
 
     // ── DELETE /internal/channels/{ref} ─────────────────────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -533,11 +533,23 @@ public class InternalChannelsControllerTests : IntegrationTestBase
 
     // ── POST /internal/channels/epoch-sync ──────────────────────────────────────────────────────
 
+    // 2026-08-05 fix wave (final review H1, plan D8 amendment): the sweep only considers channels
+    // already stamped by the assertion protocol (AssertEpoch exists), so every seed below that must be
+    // torn down carries epoch/seq on its create — an unstamped channel would be invisible to the sweep
+    // entirely and would survive regardless of liveLobbyRefs (see the dedicated survives-test below).
+    private static InternalChannelCreateRequest StampedCreateRequest(string @ref, params string[] members)
+    {
+        var request = ValidCreateRequest(@ref: @ref, members: members);
+        request.Epoch = "e1";
+        request.Seq = 1;
+        return request;
+    }
+
     [Test]
     public async Task PostEpochSync_ValidBody_Returns200_AndTearsDownUnlistedChannels()
     {
-        await _controller.Create(ValidCreateRequest(@ref: "match-live", members: "Peter#123"));
-        await _controller.Create(ValidCreateRequest(@ref: "match-dead", members: "Wanda#456"));
+        await _controller.Create(StampedCreateRequest("match-live", "Peter#123"));
+        await _controller.Create(StampedCreateRequest("match-dead", "Wanda#456"));
 
         var result = await _controller.EpochSync(ValidEpochSyncRequest(liveLobbyRefs: "match-live"));
 
@@ -549,13 +561,27 @@ public class InternalChannelsControllerTests : IntegrationTestBase
     [Test]
     public async Task PostEpochSync_EmptyLiveRefs_Returns200_AndTearsDownEverythingNonDetached()
     {
-        await _controller.Create(ValidCreateRequest(@ref: "match-1", members: "Peter#123"));
+        await _controller.Create(StampedCreateRequest("match-1", "Peter#123"));
 
         var result = await _controller.EpochSync(ValidEpochSyncRequest());
 
         Assert.That(result, Is.InstanceOf<OkResult>());
         Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1"), Is.Null,
-            "an empty live list (the post-crash case) tears down every non-detached match channel");
+            "an empty live list (the post-crash case) tears down every non-detached, assertion-stamped match channel");
+    }
+
+    [Test]
+    public async Task PostEpochSync_UnstampedChannel_Returns200_AndSurvives_FallsToTtl()
+    {
+        // A channel created WITHOUT epoch/seq — exactly the shape of a channel minted only by the
+        // deprecated delta protocol (or today's not-yet-deployed mm) — must be invisible to the sweep.
+        await _controller.Create(ValidCreateRequest(@ref: "match-unstamped", members: "Peter#123"));
+
+        var result = await _controller.EpochSync(ValidEpochSyncRequest());
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-unstamped"), Is.Not.Null,
+            "an unstamped channel survives an epoch sync even when absent from liveLobbyRefs — it falls to its own 24h TTL instead");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -230,6 +230,19 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         AssertBadRequest(result);
     }
 
+    [Test]
+    public async Task Post_MemberEntryWithControlChar_400()
+    {
+        // 2026-08-05 fix wave (final review M5): mirrors PutRoster_MemberEntryWithControlChar_400 —
+        // IsValidMembers must reject a control-char member entry, not just a blank one.
+        var request = ValidCreateRequest();
+        request.Members = new List<string> { "Peter#123", "Wanda\n#456" };
+
+        var result = await _controller.Create(request);
+
+        AssertBadRequest(result);
+    }
+
     // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): this whole region covers the
     // DELTA path. mm keeps sending deltas until its own deploy; DELETE THIS ENTIRE REGION in the
     // mm-deploy-confirmed cleanup PR alongside UpdateMembers/InternalMembersDeltaRequest — see docs
@@ -358,6 +371,18 @@ public class InternalChannelsControllerTests : IntegrationTestBase
     {
         var request = ValidRosterRequest();
         request.Members = new List<string> { "Peter#123", "   " };
+
+        var result = await _controller.AssertRoster("match-1", request);
+
+        AssertBadRequest(result);
+    }
+
+    [Test]
+    public async Task PutRoster_MemberEntryWithControlChar_400()
+    {
+        // 2026-08-05 fix wave (final review M5): IsValidMembers is shared across routes — pin it here too.
+        var request = ValidRosterRequest();
+        request.Members = new List<string> { "Peter#123", "Wanda\r#456" };
 
         var result = await _controller.AssertRoster("match-1", request);
 

--- a/W3ChampionsChatService.Tests/MatchChannelRefGateTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelRefGateTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3ChampionsChatService.Internal;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="MatchChannelRefGate"/> — the per-<c>systemRef</c> keyed async mutex that
+/// plan D5 requires every mutating match-channel path to hold for its whole operation (2026-08-05
+/// reconciliation spec, Task 2). Plain in-memory logic, deliberately **not** an
+/// <c>IntegrationTestBase</c> suite (no Mongo, no channel/membership state) — mirrors
+/// <see cref="ReadRateLimiterTests"/>'s shape: no <c>Thread.Sleep</c>, every interleaving proven
+/// deterministically via <see cref="TaskCompletionSource"/> and awaited tasks with generous timeouts.
+/// </summary>
+public class MatchChannelRefGateTests
+{
+    // Long enough that a correctly-blocked task never accidentally completes within it, short enough
+    // that a genuinely wedged gate fails the test promptly instead of hanging the run.
+    private static readonly TimeSpan ShortWait = TimeSpan.FromMilliseconds(200);
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    private MatchChannelRefGate _gate;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _gate = new MatchChannelRefGate();
+    }
+
+    [Test]
+    public async Task SameRef_SecondAcquire_BlocksUntilFirstReleases()
+    {
+        var first = await _gate.AcquireAsync("a");
+
+        var secondTask = _gate.AcquireAsync("a");
+
+        // The second acquire for the SAME ref must not complete while the first holder is still live —
+        // proven deterministically by racing it against a short delay rather than sleeping and hoping.
+        var completedFirst = await Task.WhenAny(secondTask, Task.Delay(ShortWait));
+        Assert.AreNotSame(secondTask, completedFirst, "the second acquire must still be blocked");
+        Assert.IsFalse(secondTask.IsCompleted, "the second acquire must not have completed yet");
+
+        first.Dispose();
+
+        var second = await secondTask.WaitAsync(Timeout);
+        Assert.IsNotNull(second, "the second acquire must complete once the first holder releases");
+        second.Dispose();
+    }
+
+    [Test]
+    public async Task DifferentRefs_DoNotBlockEachOther()
+    {
+        using var first = await _gate.AcquireAsync("a");
+
+        var secondTask = _gate.AcquireAsync("b");
+        var second = await secondTask.WaitAsync(Timeout);
+
+        Assert.IsTrue(secondTask.IsCompletedSuccessfully, "a distinct ref must never be blocked by another ref's holder");
+        second.Dispose();
+    }
+
+    [Test]
+    public async Task Entries_AreEvictedWhenAllHoldersRelease()
+    {
+        using (await _gate.AcquireAsync("a"))
+        {
+        }
+        using (await _gate.AcquireAsync("b"))
+        {
+        }
+
+        // A contended ref too: two sequential holders on the same key still end up fully released.
+        var first = await _gate.AcquireAsync("c");
+        var secondTask = _gate.AcquireAsync("c");
+        first.Dispose();
+        var second = await secondTask.WaitAsync(Timeout);
+        second.Dispose();
+
+        Assert.AreEqual(0, _gate.TrackedRefCount, "every entry must be evicted once its holders all release");
+    }
+
+    [Test]
+    public async Task ContendedEntry_IsNotEvictedWhileAWaiterIsPending()
+    {
+        var first = await _gate.AcquireAsync("a");
+        var secondTask = _gate.AcquireAsync("a");
+
+        // Give the second acquire a chance to register as a waiter before asserting the entry survives.
+        await Task.WhenAny(secondTask, Task.Delay(ShortWait));
+
+        Assert.AreEqual(1, _gate.TrackedRefCount, "an entry with a queued waiter must not be evicted early");
+
+        first.Dispose();
+        var second = await secondTask.WaitAsync(Timeout);
+        second.Dispose();
+    }
+
+    [Test]
+    public async Task Release_IsIdempotent()
+    {
+        var first = await _gate.AcquireAsync("a");
+        first.Dispose();
+        first.Dispose(); // A second Dispose must be a no-op, not a spurious extra Release.
+
+        var second = await _gate.AcquireAsync("a").WaitAsync(Timeout);
+
+        var thirdTask = _gate.AcquireAsync("a");
+        var completedThird = await Task.WhenAny(thirdTask, Task.Delay(ShortWait));
+
+        Assert.AreNotSame(thirdTask, completedThird, "the gate must still be exclusive after a double-Dispose");
+        Assert.IsFalse(thirdTask.IsCompleted, "a double-released holder must not have let two holders in");
+
+        second.Dispose();
+        var third = await thirdTask.WaitAsync(Timeout);
+        third.Dispose();
+    }
+
+    [Test]
+    public async Task BodyThrows_StillReleases()
+    {
+        Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            using var _ = await _gate.AcquireAsync("a");
+            throw new InvalidOperationException("boom");
+        });
+
+        var reacquired = await _gate.AcquireAsync("a").WaitAsync(Timeout);
+        Assert.IsNotNull(reacquired, "a throwing body must still release the gate via using/Dispose");
+        reacquired.Dispose();
+    }
+
+    [Test]
+    public async Task ManyConcurrentAcquires_SameRef_NeverOverlap()
+    {
+        const int concurrency = 50;
+        var sharedCounter = 0;
+        var overlapDetected = false;
+        var tasks = new List<Task>(concurrency);
+
+        for (var i = 0; i < concurrency; i++)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                using var _ = await _gate.AcquireAsync("shared");
+                var value = System.Threading.Interlocked.Increment(ref sharedCounter);
+                if (value != 1)
+                {
+                    overlapDetected = true;
+                }
+                await Task.Yield();
+                System.Threading.Interlocked.Decrement(ref sharedCounter);
+            }));
+        }
+
+        await Task.WhenAll(tasks).WaitAsync(Timeout);
+
+        Assert.IsFalse(overlapDetected, "no two concurrent acquires of the SAME ref may ever overlap");
+        Assert.AreEqual(0, _gate.TrackedRefCount, "every entry must be evicted once all 50 holders release");
+    }
+}

--- a/W3ChampionsChatService.Tests/MatchChannelRefGateTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelRefGateTests.cs
@@ -12,7 +12,8 @@ namespace W3ChampionsChatService.Tests;
 /// reconciliation spec, Task 2). Plain in-memory logic, deliberately **not** an
 /// <c>IntegrationTestBase</c> suite (no Mongo, no channel/membership state) — mirrors
 /// <see cref="ReadRateLimiterTests"/>'s shape: no <c>Thread.Sleep</c>, every interleaving proven
-/// deterministically via <see cref="TaskCompletionSource"/> and awaited tasks with generous timeouts.
+/// deterministically by racing the pending acquire against a bounded <see cref="Task.Delay(TimeSpan)"/>
+/// (a correctly-blocked acquire can only LOSE that race) and awaiting every task with a generous timeout.
 /// </summary>
 public class MatchChannelRefGateTests
 {
@@ -59,6 +60,17 @@ public class MatchChannelRefGateTests
 
         Assert.IsTrue(secondTask.IsCompletedSuccessfully, "a distinct ref must never be blocked by another ref's holder");
         second.Dispose();
+    }
+
+    [Test]
+    public async Task RefsAreCaseSensitive_OrdinalKeys_DoNotShareAGate()
+    {
+        // systemRefs are EXACT Mongo keys ([A-Za-z0-9_-]) — unlike battleTags they are never case-folded,
+        // so "Ab3" and "aB3" are two different channels and must never serialize against each other.
+        using var upper = await _gate.AcquireAsync("Ab3");
+        var lower = await _gate.AcquireAsync("aB3").WaitAsync(Timeout);
+        Assert.AreEqual(2, _gate.TrackedRefCount, "case-differing refs must be tracked as distinct gates");
+        lower.Dispose();
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -1248,6 +1248,31 @@ public class MatchChannelServiceTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task EpochSync_StampsSparedChannelThatHasNoStoredEpoch()
+    {
+        const string bob = "Bob#2";
+        // Created via the legacy CreateOrGet path and NEVER asserted — AssertEpoch is genuinely ABSENT
+        // on the stored document (not merely a different value from a prior assertion, as the sibling
+        // ReStampsSparedChannels test above exercises via ApplyRosterAssertion("e1", ...) first). This is
+        // the $exists:false disjunct of StampAssertionEpoch's filter — a legacy/transition channel spared
+        // by an epoch sync that has no AssertEpoch to compare against at all.
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+
+        await _service.ApplyEpochSync("e2", Members("match-1"));
+
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e2"),
+            "a spared channel with NO stored epoch at all must still be re-anchored to the new epoch — "
+            + "proves the absent-epoch disjunct in StampAssertionEpoch's filter, not just its Ne branch");
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(0), "the seq counter is reset to the 0 sentinel");
+
+        await _service.ApplyRosterAssertion("match-1", "e2", 1, Members(bob), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null,
+            "seq 1 under the new epoch applies cleanly after the re-anchor, confirming the stamp actually landed");
+    }
+
+    [Test]
     public async Task EpochSync_LeavesNonMatchChannelsUntouched()
     {
         const string alice = "Alice#1";

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -593,8 +593,11 @@ public class MatchChannelServiceTests : IntegrationTestBase
         RegisterOnline("conn-alice", alice);
         var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
 
-        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: false);
+        var outcome = await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: false);
 
+        // 2026-08-05 fix wave (final review M2): the outcome the controller now logs instead of an
+        // unconditional "succeeded" line.
+        Assert.That(outcome, Is.EqualTo(RosterAssertionOutcome.Applied));
         Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "the missing member is added");
         Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1));
         var dto = _harness.PayloadFor("conn-alice", ChatEvents.ChannelAdded) as ChannelAddedDto;
@@ -771,8 +774,10 @@ public class MatchChannelServiceTests : IntegrationTestBase
         var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
         await _service.ApplyRosterAssertion("match-1", "e1", 5, Members(alice), name: null, detached: false);
 
-        await _service.ApplyRosterAssertion("match-1", "e1", 4, Members(bob), name: null, detached: false);
+        var outcome = await _service.ApplyRosterAssertion("match-1", "e1", 4, Members(bob), name: null, detached: false);
 
+        // 2026-08-05 fix wave (final review M2).
+        Assert.That(outcome, Is.EqualTo(RosterAssertionOutcome.DiscardedStale));
         Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "membership unchanged");
         Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null, "the stale assertion never applied");
         var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
@@ -905,8 +910,10 @@ public class MatchChannelServiceTests : IntegrationTestBase
         var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
         await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: true);
 
-        await _service.ApplyRosterAssertion("match-1", "e2", 99, Members(bob), name: null, detached: false);
+        var outcome = await _service.ApplyRosterAssertion("match-1", "e2", 99, Members(bob), name: null, detached: false);
 
+        // 2026-08-05 fix wave (final review M2).
+        Assert.That(outcome, Is.EqualTo(RosterAssertionOutcome.DiscardedFrozen));
         Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "the frozen set is untouched");
         Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null, "a post-detach assertion never applies, even with a higher seq and a different epoch");
     }

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -1135,4 +1135,197 @@ public class MatchChannelServiceTests : IntegrationTestBase
         Assert.That(reloaded.AssertEpoch, Is.Null, "no (epoch, seq) stamp is written when the fields are omitted — the transition pin");
         Assert.That(reloaded.Detached, Is.False);
     }
+
+    // ============================================================================================
+    // 2026-08-05 reconciliation — ApplyEpochSync: startup teardown of orphaned lobby channels
+    // (plan D8, Task 4)
+    // ============================================================================================
+
+    [Test]
+    public async Task EpochSync_TearsDownChannelsNotInLiveList()
+    {
+        const string alice = "Alice#1";
+        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false);
+        var kept = await _service.CreateOrGet("match-kept", "Kept Match", Members(alice), focus: false);
+        var message = NewMessage(gone.Id, 1, alice);
+        await _messageRepository.Insert(message);
+
+        await _service.ApplyEpochSync("e2", Members("match-kept"));
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-gone"), Is.Null,
+            "the unlisted channel doc is torn down");
+        Assert.That(await _membershipRepository.LoadForChannel(gone.Id), Is.Empty, "its memberships are gone");
+        Assert.That(await _messageRepository.Load(message.Id), Is.Null, "its messages are purged");
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-kept"), Is.Not.Null,
+            "the listed channel is fully intact");
+        Assert.That(await _membershipRepository.Load(kept.Id, alice), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task EpochSync_PushesChannelRemovedToOnlineMembersOfTornDownChannels()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        RegisterOnline("conn-alice", alice);
+        RegisterOnline("conn-bob", bob);
+
+        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false);
+        var kept = await _service.CreateOrGet("match-kept", "Kept Match", Members(bob), focus: false);
+        var detachedRef = "match-detached";
+        await _service.CreateOrGet(detachedRef, "Detached Match", Members(), focus: false, detached: true);
+
+        await _service.ApplyEpochSync("e2", Members("match-kept"));
+
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(1),
+            "the torn-down channel's online member receives ChannelRemoved");
+        var dto = _harness.PayloadFor("conn-alice", ChatEvents.ChannelRemoved) as ChannelRemovedDto;
+        Assert.That(dto, Is.Not.Null);
+        Assert.That(dto.ChannelId, Is.EqualTo(gone.Id));
+
+        Assert.That(_harness.SignalCount("conn-bob", ChatEvents.ChannelRemoved), Is.EqualTo(0),
+            "the spared channel's member receives nothing");
+        Assert.That(kept.Id, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task EpochSync_SparesDetachedChannels()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+        var detached = await _service.CreateOrGet("match-detached", "Ladder", Members(alice), focus: false, detached: true);
+        var message = NewMessage(detached.Id, 1, alice);
+        await _messageRepository.Insert(message);
+
+        // The detached channel's ref is NOT in the live list — the empty live set is the post-crash case.
+        await _service.ApplyEpochSync("e2", Members());
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-detached"), Is.Not.Null,
+            "a detached channel survives an epoch sync even when absent from liveLobbyRefs");
+        Assert.That(await _membershipRepository.Load(detached.Id, alice), Is.Not.Null, "its memberships survive");
+        Assert.That(await _messageRepository.Load(message.Id), Is.Not.Null, "its messages survive");
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(0),
+            "a spared detached channel's member receives no push");
+    }
+
+    [Test]
+    public async Task EpochSync_EmptyLiveList_TearsDownEveryNonDetachedMatchChannel_ButNotDetachedOnes()
+    {
+        const string alice = "Alice#1";
+        var matchA = await _service.CreateOrGet("match-a", "Match A", Members(alice), focus: false);
+        var matchB = await _service.CreateOrGet("match-b", "Match B", Members(alice), focus: false);
+        var detached = await _service.CreateOrGet("match-detached", "Ladder", Members(alice), focus: false, detached: true);
+
+        await _service.ApplyEpochSync("e2", Members());
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-a"), Is.Null);
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-b"), Is.Null);
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-detached"), Is.Not.Null,
+            "the post-crash empty live list still spares detached channels");
+        Assert.That(matchA.Id, Is.Not.Null);
+        Assert.That(matchB.Id, Is.Not.Null);
+        Assert.That(detached.Id, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task EpochSync_ReStampsSparedChannels_SoNewEpochSeq1Applies()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 9, Members(alice), name: null, detached: false);
+
+        await _service.ApplyEpochSync("e2", Members("match-1"));
+
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e2"), "the spared channel is re-anchored to the new epoch");
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(0), "the seq counter is reset to the 0 sentinel");
+
+        await _service.ApplyRosterAssertion("match-1", "e2", 1, Members(bob), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null,
+            "seq 1 under the new epoch applies cleanly after the re-anchor");
+    }
+
+    [Test]
+    public async Task EpochSync_LeavesNonMatchChannelsUntouched()
+    {
+        const string alice = "Alice#1";
+
+        var publicChannel = new ChatChannel { Type = ChannelType.Public, Name = "W3C Lounge", NormalizedName = ChannelNames.Normalize("W3C Lounge") };
+        await _channelRepository.Insert(publicChannel);
+        await _membershipRepository.Insert(new ChannelMembership { ChannelId = publicChannel.Id, BattleTag = alice, JoinedAt = Now });
+
+        var dm = new ChatChannel { Type = ChannelType.Dm, PairKey = DmPairKey.For(alice, "Bob#2") };
+        await _channelRepository.Insert(dm);
+        await _membershipRepository.Insert(new ChannelMembership { ChannelId = dm.Id, BattleTag = alice, JoinedAt = Now });
+
+        var group = new ChatChannel { Type = ChannelType.GroupDm, Name = "squad", LastMessageAt = Now, ExpiresAt = Now.AddDays(365) };
+        await _channelRepository.Insert(group);
+        await _membershipRepository.Insert(new ChannelMembership { ChannelId = group.Id, BattleTag = alice, JoinedAt = Now });
+
+        var clan = await _channelRepository.FindOrCreateSystem(SystemChannelKind.Clan, "clan-1", "Clan Chat", Now);
+        await _membershipRepository.Insert(new ChannelMembership { ChannelId = clan.Id, BattleTag = alice, JoinedAt = Now });
+
+        await _service.ApplyEpochSync("e2", Members());
+
+        Assert.That(await _channelRepository.Load(publicChannel.Id), Is.Not.Null, "Public channels are untouched");
+        Assert.That(await _channelRepository.Load(dm.Id), Is.Not.Null, "Dm channels are untouched");
+        Assert.That(await _channelRepository.Load(group.Id), Is.Not.Null, "GroupDm channels are untouched");
+        Assert.That(await _channelRepository.Load(clan.Id), Is.Not.Null, "System+Clan channels are untouched");
+        Assert.That(await _membershipRepository.Load(publicChannel.Id, alice), Is.Not.Null);
+        Assert.That(await _membershipRepository.Load(dm.Id, alice), Is.Not.Null);
+        Assert.That(await _membershipRepository.Load(group.Id, alice), Is.Not.Null);
+        Assert.That(await _membershipRepository.Load(clan.Id, alice), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task EpochSync_UnknownRefInLiveList_IsANoOp()
+    {
+        Assert.DoesNotThrowAsync(async () => await _service.ApplyEpochSync("e2", Members("never-existed")));
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "never-existed"), Is.Null,
+            "listing a ref with no channel neither creates one nor throws");
+    }
+
+    [Test]
+    public async Task EpochSync_IsIdempotent()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false);
+        await _service.CreateOrGet("match-kept", "Kept Match", Members(), focus: false);
+
+        await _service.ApplyEpochSync("e2", Members("match-kept"));
+        var pushCountAfterFirst = _harness.AllSignals.Count;
+        var keptAfterFirst = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-kept");
+
+        await _service.ApplyEpochSync("e2", Members("match-kept"));
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-gone"), Is.Null,
+            "the torn-down channel stays torn down");
+        var keptAfterSecond = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-kept");
+        Assert.That(keptAfterSecond.AssertEpoch, Is.EqualTo(keptAfterFirst.AssertEpoch), "same end state on the spared channel");
+        Assert.That(keptAfterSecond.AssertSeq, Is.EqualTo(keptAfterFirst.AssertSeq));
+        Assert.That(_harness.AllSignals.Count, Is.EqualTo(pushCountAfterFirst), "no additional pushes on the second run");
+        Assert.That(gone.Id, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task EpochSync_LeavesNoOrphanedMembershipRows()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        await _service.CreateOrGet("match-gone-1", "Gone 1", Members(alice), focus: false);
+        await _service.CreateOrGet("match-gone-2", "Gone 2", Members(alice, bob), focus: false);
+        await _service.CreateOrGet("match-kept", "Kept", Members(bob), focus: false);
+
+        await _service.ApplyEpochSync("e2", Members("match-kept"));
+
+        var orphansDeleted = await new CleanupJobs(MongoClient).SweepOrphanedMemberships();
+
+        Assert.That(orphansDeleted, Is.EqualTo(0),
+            "the shared TearDownChannel routine deletes messages, memberships AND the channel doc together — "
+            + "so no orphaned membership row is left behind for CleanupJobs to find");
+    }
 }

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -1145,8 +1145,12 @@ public class MatchChannelServiceTests : IntegrationTestBase
     public async Task EpochSync_TearsDownChannelsNotInLiveList()
     {
         const string alice = "Alice#1";
-        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false);
-        var kept = await _service.CreateOrGet("match-kept", "Kept Match", Members(alice), focus: false);
+        // 2026-08-05 fix wave (final review H1, plan D8 amendment): stamped via epoch/seq on create — an
+        // UNSTAMPED channel is invisible to the sweep entirely (see the dedicated survives-test below),
+        // so a meaningful "gets torn down" test needs a channel that has participated in the assertion
+        // protocol at least once.
+        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false, epoch: "e1", seq: 1);
+        var kept = await _service.CreateOrGet("match-kept", "Kept Match", Members(alice), focus: false, epoch: "e1", seq: 1);
         var message = NewMessage(gone.Id, 1, alice);
         await _messageRepository.Insert(message);
 
@@ -1170,8 +1174,8 @@ public class MatchChannelServiceTests : IntegrationTestBase
         RegisterOnline("conn-alice", alice);
         RegisterOnline("conn-bob", bob);
 
-        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false);
-        var kept = await _service.CreateOrGet("match-kept", "Kept Match", Members(bob), focus: false);
+        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false, epoch: "e1", seq: 1);
+        var kept = await _service.CreateOrGet("match-kept", "Kept Match", Members(bob), focus: false, epoch: "e1", seq: 1);
         var detachedRef = "match-detached";
         await _service.CreateOrGet(detachedRef, "Detached Match", Members(), focus: false, detached: true);
 
@@ -1212,8 +1216,8 @@ public class MatchChannelServiceTests : IntegrationTestBase
     public async Task EpochSync_EmptyLiveList_TearsDownEveryNonDetachedMatchChannel_ButNotDetachedOnes()
     {
         const string alice = "Alice#1";
-        var matchA = await _service.CreateOrGet("match-a", "Match A", Members(alice), focus: false);
-        var matchB = await _service.CreateOrGet("match-b", "Match B", Members(alice), focus: false);
+        var matchA = await _service.CreateOrGet("match-a", "Match A", Members(alice), focus: false, epoch: "e1", seq: 1);
+        var matchB = await _service.CreateOrGet("match-b", "Match B", Members(alice), focus: false, epoch: "e1", seq: 1);
         var detached = await _service.CreateOrGet("match-detached", "Ladder", Members(alice), focus: false, detached: true);
 
         await _service.ApplyEpochSync("e2", Members());
@@ -1251,25 +1255,46 @@ public class MatchChannelServiceTests : IntegrationTestBase
     public async Task EpochSync_StampsSparedChannelThatHasNoStoredEpoch()
     {
         const string bob = "Bob#2";
-        // Created via the legacy CreateOrGet path and NEVER asserted — AssertEpoch is genuinely ABSENT
-        // on the stored document (not merely a different value from a prior assertion, as the sibling
-        // ReStampsSparedChannels test above exercises via ApplyRosterAssertion("e1", ...) first). This is
-        // the $exists:false disjunct of StampAssertionEpoch's filter — a legacy/transition channel spared
-        // by an epoch sync that has no AssertEpoch to compare against at all.
-        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        // Created via CreateOrGet WITH an epoch/seq stamp (unlike the sibling survives-test below) but
+        // never asserted since — AssertEpoch is set directly by the create's own D10 stamp, so this is
+        // the $exists:false-turned-true disjunct of StampAssertionEpoch's filter: a channel stamped
+        // exactly once, at create time, is still spared and re-anchored like any other candidate.
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false, epoch: "e1", seq: 1);
 
         await _service.ApplyEpochSync("e2", Members("match-1"));
 
         var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
         Assert.That(reloaded.AssertEpoch, Is.EqualTo("e2"),
-            "a spared channel with NO stored epoch at all must still be re-anchored to the new epoch — "
-            + "proves the absent-epoch disjunct in StampAssertionEpoch's filter, not just its Ne branch");
+            "a spared channel stamped only once, at create time, must still be re-anchored to the new epoch");
         Assert.That(reloaded.AssertSeq, Is.EqualTo(0), "the seq counter is reset to the 0 sentinel");
 
         await _service.ApplyRosterAssertion("match-1", "e2", 1, Members(bob), name: null, detached: false);
 
         Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null,
             "seq 1 under the new epoch applies cleanly after the re-anchor, confirming the stamp actually landed");
+    }
+
+    [Test]
+    public async Task EpochSync_UnstampedChannel_SurvivesEvenWhenAbsentFromLiveList_FallsToTtl()
+    {
+        const string alice = "Alice#1";
+        // Created via the legacy CreateOrGet path and NEVER stamped by the assertion protocol at all —
+        // AssertEpoch is genuinely ABSENT on the stored document, exactly the shape of a channel minted
+        // by the pre-reconciliation mm via the deprecated delta path during the transition window.
+        // 2026-08-05 fix wave (final review H1, plan D8 amendment): such a channel must NOT be swept by
+        // an epoch sync — LoadNonDetachedMatchChannels's AssertEpoch-exists filter makes it invisible to
+        // the sweep entirely, so it survives regardless of liveLobbyRefs and falls to its own 24h TTL.
+        var channel = await _service.CreateOrGet("match-legacy", "Legacy Match", Members(alice), focus: false);
+
+        // Absent from BOTH the live list AND ever having been stamped — the worst case, and exactly the
+        // shape of the mm-deploy cutover: mm boots with an empty liveLobbyRefs and a fresh epoch, and
+        // every pre-deploy channel in the database looks exactly like this.
+        await _service.ApplyEpochSync("e2", Members());
+
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-legacy");
+        Assert.That(reloaded, Is.Not.Null, "an unstamped channel must survive an epoch sync even when absent from liveLobbyRefs");
+        Assert.That(reloaded.AssertEpoch, Is.Null, "it is left completely untouched — not re-stamped either, since it was never a candidate");
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "its memberships survive");
     }
 
     [Test]
@@ -1318,8 +1343,8 @@ public class MatchChannelServiceTests : IntegrationTestBase
     {
         const string alice = "Alice#1";
         RegisterOnline("conn-alice", alice);
-        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false);
-        await _service.CreateOrGet("match-kept", "Kept Match", Members(), focus: false);
+        var gone = await _service.CreateOrGet("match-gone", "Gone Match", Members(alice), focus: false, epoch: "e1", seq: 1);
+        await _service.CreateOrGet("match-kept", "Kept Match", Members(), focus: false, epoch: "e1", seq: 1);
 
         await _service.ApplyEpochSync("e2", Members("match-kept"));
         var pushCountAfterFirst = _harness.AllSignals.Count;
@@ -1341,8 +1366,8 @@ public class MatchChannelServiceTests : IntegrationTestBase
     {
         const string alice = "Alice#1";
         const string bob = "Bob#2";
-        await _service.CreateOrGet("match-gone-1", "Gone 1", Members(alice), focus: false);
-        await _service.CreateOrGet("match-gone-2", "Gone 2", Members(alice, bob), focus: false);
+        await _service.CreateOrGet("match-gone-1", "Gone 1", Members(alice), focus: false, epoch: "e1", seq: 1);
+        await _service.CreateOrGet("match-gone-2", "Gone 2", Members(alice, bob), focus: false, epoch: "e1", seq: 1);
         await _service.CreateOrGet("match-kept", "Kept", Members(bob), focus: false);
 
         await _service.ApplyEpochSync("e2", Members("match-kept"));
@@ -1357,7 +1382,7 @@ public class MatchChannelServiceTests : IntegrationTestBase
     [Test]
     public async Task EpochSync_LiveRefMatching_IsCaseSensitive()
     {
-        await _service.CreateOrGet("match-A", "Upper", Members("Alice#1"), focus: false);
+        await _service.CreateOrGet("match-A", "Upper", Members("Alice#1"), focus: false, epoch: "e1", seq: 1);
 
         // A ref differing only in case is a DIFFERENT lobby — refs are exact Mongo keys drawn from
         // [A-Za-z0-9_-] (mm's nanoids use a mixed-case alphabet), unlike battleTags.
@@ -1433,8 +1458,8 @@ public class MatchChannelServiceTests : IntegrationTestBase
             MongoClient, channelRepo, async tornDownId => await channelRepo.SetDetached(tornDownId == idA ? idB : idA));
         var service = new MatchChannelService(channelRepo, memberships, _messageRepository, _fanOutEngine, _time);
 
-        var a = await service.CreateOrGet("match-a", "A", Members("Alice#1"), focus: false);
-        var b = await service.CreateOrGet("match-b", "B", Members("Bob#2"), focus: false);
+        var a = await service.CreateOrGet("match-a", "A", Members("Alice#1"), focus: false, epoch: "e1", seq: 1);
+        var b = await service.CreateOrGet("match-b", "B", Members("Bob#2"), focus: false, epoch: "e1", seq: 1);
         idA = a.Id;
         idB = b.Id;
 
@@ -1468,8 +1493,8 @@ public class MatchChannelServiceTests : IntegrationTestBase
             MongoClient, channelRepo, async tornDownId => await channelRepo.Delete(tornDownId == idA ? idB : idA));
         var service = new MatchChannelService(channelRepo, memberships, _messageRepository, _fanOutEngine, _time);
 
-        var a = await service.CreateOrGet("match-a", "A", Members("Alice#1"), focus: false);
-        var b = await service.CreateOrGet("match-b", "B", Members("Bob#2"), focus: false);
+        var a = await service.CreateOrGet("match-a", "A", Members("Alice#1"), focus: false, epoch: "e1", seq: 1);
+        var b = await service.CreateOrGet("match-b", "B", Members("Bob#2"), focus: false, epoch: "e1", seq: 1);
         idA = a.Id;
         idB = b.Id;
         var pushesBefore = _harness.AllSignals.Count;

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using MongoDB.Driver;
 using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
@@ -575,5 +577,485 @@ public class MatchChannelServiceTests : IntegrationTestBase
 
         Assert.That(_harness.AllSignals, Is.Empty, "an offline member receives zero live signals, and no error is thrown");
         Assert.That(await _membershipRepository.LoadForChannel(channel.Id), Is.Empty, "the teardown still completes for an offline-only channel");
+    }
+
+    // ============================================================================================
+    // 2026-08-05 reconciliation — ApplyRosterAssertion: diff + idempotency (plan D3, D4, D10)
+    // ============================================================================================
+
+    [Test]
+    public async Task Assert_AddsMissingMembers_PushesChannelAdded_NeverFocused()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "the missing member is added");
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1));
+        var dto = _harness.PayloadFor("conn-alice", ChatEvents.ChannelAdded) as ChannelAddedDto;
+        Assert.That(dto, Is.Not.Null);
+        Assert.That(dto.Focus, Is.False, "the roster assertion contract carries no focus field — adds are always focus:false");
+    }
+
+    [Test]
+    public async Task Assert_RemovesExtraMembers_DeletesRow_PushesChannelRemoved_AndUnfocuses()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(alice), focus: true);
+        _focusRegistry.Focus("conn-alice", channel.Id, alice);
+        Assert.That(_focusRegistry.GetFocusedChannels("conn-alice"), Does.Contain(channel.Id), "precondition: focused");
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Null, "the extra member is removed");
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(1));
+        var dto = _harness.PayloadFor("conn-alice", ChatEvents.ChannelRemoved) as ChannelRemovedDto;
+        Assert.That(dto, Is.Not.Null);
+        Assert.That(dto.ChannelId, Is.EqualTo(channel.Id));
+        Assert.That(_focusRegistry.GetFocusedChannels("conn-alice"), Does.Not.Contain(channel.Id),
+            "the removed member's connection is force-unfocused");
+    }
+
+    [Test]
+    public async Task Assert_ReAssertingIdenticalSet_IsIdempotent_ZeroPushes()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        RegisterOnline("conn-alice", alice);
+        RegisterOnline("conn-bob", bob);
+        await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice, bob), name: null, detached: false);
+        var pushCountAfterFirst = _harness.AllSignals.Count;
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 2, Members(alice, bob), name: null, detached: false);
+
+        Assert.That(_harness.AllSignals.Count, Is.EqualTo(pushCountAfterFirst), "an identical re-assertion pushes nothing new");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(await _membershipRepository.LoadForChannel(channel.Id), Has.Count.EqualTo(2), "membership rows are unchanged");
+    }
+
+    [Test]
+    public async Task Assert_MixedAddAndRemove_ConvergesInOneCall()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        RegisterOnline("conn-alice", alice);
+        RegisterOnline("conn-bob", bob);
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(alice), focus: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(bob), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Null, "alice is removed");
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null, "bob is added");
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(1));
+        Assert.That(_harness.SignalCount("conn-bob", ChatEvents.ChannelAdded), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Assert_EmptyMemberSet_RemovesEveryMember()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(alice, bob), focus: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.LoadForChannel(channel.Id), Is.Empty,
+            "D7: an empty member set is meaningful and removes every member — it is NOT a no-op");
+    }
+
+    [Test]
+    public async Task Assert_CaseOnlyDifference_DoesNotChurnMembership()
+    {
+        const string alice = "Alice#1";
+        await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: false);
+        var pushCountAfterFirst = _harness.AllSignals.Count;
+
+        // Re-assert with a DIFFERENT casing of the same tag.
+        await _service.ApplyRosterAssertion("match-1", "e1", 2, Members("alice#1"), name: null, detached: false);
+
+        Assert.That(_harness.AllSignals.Count, Is.EqualTo(pushCountAfterFirst),
+            "a case-only difference between stored (lowercased) and asserted (JWT-cased) battleTags must not churn membership");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(await _membershipRepository.LoadForChannel(channel.Id), Has.Count.EqualTo(1), "exactly one membership row — no delete+re-add");
+    }
+
+    [Test]
+    public async Task Assert_HonorsOneMatchChannelInvariant_RemovedBeforeAdded()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+        var matchA = await _service.CreateOrGet("match-A", "Match A", Members(alice), focus: true);
+        await _service.CreateOrGet("match-B", "Match B", Members(), focus: false);
+
+        await _service.ApplyRosterAssertion("match-B", "e1", 1, Members(alice), name: null, detached: false);
+
+        var matchB = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-B");
+        Assert.That(await _membershipRepository.Load(matchA.Id, alice), Is.Null, "the stale match-A membership is evicted");
+        Assert.That(await _membershipRepository.Load(matchB.Id, alice), Is.Not.Null);
+
+        var signals = _harness.AllSignals.Where(s => s.ConnectionId == "conn-alice").ToList();
+        var removedAIndex = signals.FindIndex(s =>
+            s.Method == ChatEvents.ChannelRemoved && ((ChannelRemovedDto)s.Payload).ChannelId == matchA.Id);
+        var addedBIndex = signals.FindIndex(s =>
+            s.Method == ChatEvents.ChannelAdded && ((ChannelAddedDto)s.Payload).Channel.Id == matchB.Id);
+        Assert.That(removedAIndex, Is.GreaterThanOrEqualTo(0), "ChannelRemoved(A) was emitted");
+        Assert.That(addedBIndex, Is.GreaterThanOrEqualTo(0), "ChannelAdded(B) was emitted");
+        Assert.That(removedAIndex, Is.LessThan(addedBIndex),
+            "ChannelRemoved(A) is emitted STRICTLY BEFORE ChannelAdded(B) on the assertion path too");
+    }
+
+    [Test]
+    public async Task Assert_BeforeCreate_CreatesShell_WithProvidedName_And24hExpiry()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: "My Lobby", detached: false);
+
+        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(shell, Is.Not.Null, "the shell is created on-demand rather than a hard 404");
+        Assert.That(shell.Name, Is.EqualTo("My Lobby"));
+        Assert.That(shell.ExpiresAt, Is.Not.Null);
+        Assert.That((shell.ExpiresAt.Value - Now.AddHours(24)).Duration(), Is.LessThan(TimeSpan.FromSeconds(1)),
+            "the shell's 24h expiry is anchored to its OWN creation time");
+        Assert.That(await _membershipRepository.Load(shell.Id, alice), Is.Not.Null);
+
+        var shellExpiry = shell.ExpiresAt;
+        _time.Advance(TimeSpan.FromHours(1));
+        var real = await _service.CreateOrGet("match-1", "Real Match Name", Members(), focus: false);
+        Assert.That(real.ExpiresAt, Is.EqualTo(shellExpiry), "a later real CreateOrGet does not reset the shell's expiry");
+    }
+
+    [Test]
+    public async Task Assert_BeforeCreate_NullName_UsesRefPlaceholder()
+    {
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(), name: null, detached: false);
+
+        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(shell.Name, Is.EqualTo("match-1"), "a null name falls back to the ref placeholder");
+
+        var real = await _service.CreateOrGet("match-1", "Real Match Name", Members(), focus: false);
+        Assert.That(real.Name, Is.EqualTo("Real Match Name"), "a later real CreateOrGet backfills the real name");
+    }
+
+    [Test]
+    public async Task Assert_OnExistingChannel_IgnoresName()
+    {
+        await _service.CreateOrGet("match-1", "Real Name", Members(), focus: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(), name: "Different Name", detached: false);
+
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.Name, Is.EqualTo("Real Name"), "an assertion never renames an EXISTING channel — CreateOrGet remains the name authority");
+    }
+
+    // ============================================================================================
+    // ApplyRosterAssertion — staleness (plan D3)
+    // ============================================================================================
+
+    [Test]
+    public async Task Assert_SameEpochLowerSeq_IsDiscarded_MembershipUnchanged()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 5, Members(alice), name: null, detached: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 4, Members(bob), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "membership unchanged");
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null, "the stale assertion never applied");
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(5), "the stamp is not regressed");
+    }
+
+    [Test]
+    public async Task Assert_SameEpochEqualSeq_IsDiscarded_MembershipUnchanged()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 5, Members(alice), name: null, detached: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 5, Members(bob), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "membership unchanged");
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null, "a same-(epoch,seq) replay is a no-op");
+    }
+
+    [Test]
+    public async Task Assert_SameEpochHigherSeq_Applies()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 2, Members(bob), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Null);
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null);
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task Assert_DifferentEpoch_IsAccepted_AndReAnchors()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        const string carol = "Carol#3";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 9, Members(alice), name: null, detached: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e2", 1, Members(bob), name: null, detached: false);
+
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e2"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(1));
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null, "the different-epoch assertion is accepted and applies");
+
+        // A follow-up under the SAME new epoch — proves the re-anchor stuck (a higher seq is now required).
+        await _service.ApplyRosterAssertion("match-1", "e2", 2, Members(carol), name: null, detached: false);
+
+        var reloadedAgain = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloadedAgain.AssertSeq, Is.EqualTo(2));
+        Assert.That(await _membershipRepository.Load(channel.Id, carol), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task Assert_OnChannelWithNoStoredEpoch_Applies()
+    {
+        const string alice = "Alice#1";
+        // Created via the legacy CreateOrGet path — no assertion state stored yet (the transition pin).
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null);
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e1"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(1));
+    }
+
+    // ============================================================================================
+    // Detach freeze (plan D4)
+    // ============================================================================================
+
+    [Test]
+    public async Task Assert_WithDetachedTrue_AppliesFinalSet_ThenFreezes()
+    {
+        const string alice = "Alice#1";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: true);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "the final set converges FIRST");
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.Detached, Is.True, "then the channel is frozen");
+    }
+
+    [Test]
+    public async Task Assert_AfterDetach_IsDiscarded_EvenWithHigherSeq_AndNewEpoch()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: true);
+
+        await _service.ApplyRosterAssertion("match-1", "e2", 99, Members(bob), name: null, detached: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "the frozen set is untouched");
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null, "a post-detach assertion never applies, even with a higher seq and a different epoch");
+    }
+
+    [Test]
+    public async Task Delta_AfterDetach_IsDiscarded()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: true);
+
+        await _service.ApplyMembersDelta("match-1", add: Members(bob), remove: Members(alice), focus: false);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "the legacy delta path is frozen too");
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null);
+    }
+
+    [Test]
+    public async Task CreateOrGet_AfterDetach_BackfillsName_ButAddsNoMembers()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Placeholder", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: true);
+
+        var result = await _service.CreateOrGet("match-1", "Real Name", Members(bob), focus: false);
+
+        Assert.That(result.Name, Is.EqualTo("Real Name"), "the name backfill still runs on a detached channel");
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "the frozen membership is untouched");
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null, "no new members are added to a detached channel");
+    }
+
+    [Test]
+    public async Task Delete_AfterDetach_StillTearsDownChannel()
+    {
+        const string alice = "Alice#1";
+        await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: true);
+
+        await _service.DeleteChannel("match-1");
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1"), Is.Null,
+            "an explicit DELETE still tears down a detached channel — detach guards assertions/sweeps, not an explicit teardown");
+    }
+
+    // ============================================================================================
+    // Concurrency (plan D5) — the per-ref gate serializes the whole "admit, diff, converge" operation
+    // ============================================================================================
+
+    // Blocks the FIRST TryAdvanceAssertion call it sees, signalling `Entered` on entry and awaiting
+    // `Release` before delegating to the real implementation — lets a test prove a second concurrent
+    // caller cannot reach this call until the first one (and hence the per-ref gate) releases.
+    private sealed class BlockingAssertionChannelRepository(MongoClient mongoClient) : ChannelRepository(mongoClient)
+    {
+        public readonly TaskCompletionSource Entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly TaskCompletionSource Release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _callCount;
+
+        public int CallCount => Volatile.Read(ref _callCount);
+
+        public override async Task<bool> TryAdvanceAssertion(string channelId, string epoch, long seq)
+        {
+            if (Interlocked.Increment(ref _callCount) == 1)
+            {
+                Entered.SetResult();
+                await Release.Task;
+            }
+
+            return await base.TryAdvanceAssertion(channelId, epoch, seq);
+        }
+    }
+
+    [Test]
+    public async Task ConcurrentAssertions_SameRef_DoNotInterleave()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+
+        var blockingRepo = new BlockingAssertionChannelRepository(MongoClient);
+        var membershipRepo = new MembershipRepository(MongoClient, blockingRepo);
+        var messageRepo = new MessageRepository(MongoClient);
+        var service = new MatchChannelService(blockingRepo, membershipRepo, messageRepo, _fanOutEngine, _time);
+
+        await service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+
+        var taskA = service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: false);
+        await blockingRepo.Entered.Task; // A is confirmed inside TryAdvanceAssertion, holding the per-ref gate.
+
+        var taskB = service.ApplyRosterAssertion("match-1", "e1", 2, Members(bob), name: null, detached: false);
+
+        // Give B every opportunity to (incorrectly) race past the gate while A is still inside its CAS call.
+        await Task.WhenAny(taskB, Task.Delay(TimeSpan.FromMilliseconds(300)));
+        Assert.That(blockingRepo.CallCount, Is.EqualTo(1), "B must not have entered TryAdvanceAssertion while A still holds the per-ref gate");
+        Assert.That(taskB.IsCompleted, Is.False, "B is blocked on the per-ref gate, not merely slow");
+
+        blockingRepo.Release.SetResult();
+        await taskA;
+        await taskB;
+
+        Assert.That(blockingRepo.CallCount, Is.EqualTo(2));
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(channel.AssertSeq, Is.EqualTo(2), "B's assertion (the later, higher seq) is the final stamped state");
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Null, "B's full-set assertion supersedes A's — alice is not in B's set");
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null);
+    }
+
+    // ============================================================================================
+    // Create-route stamping (plan D10)
+    // ============================================================================================
+
+    [Test]
+    public async Task CreateOrGet_WithDetached_AppliesMembers_ThenFreezes()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        RegisterOnline("conn-alice", alice);
+
+        var channel = await _service.CreateOrGet("match-1", "Ladder Match", Members(alice), focus: false, detached: true);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "members are added at birth");
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1));
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.Detached, Is.True, "a ladder-match channel is born detached");
+
+        // A follow-up assertion must be discarded — the channel is frozen from birth.
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(bob), name: null, detached: false);
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null);
+    }
+
+    [Test]
+    public async Task CreateOrGet_DetachedRetry_OnAlreadyDetachedChannel_IsIdempotent()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+        var first = await _service.CreateOrGet("match-1", "Ladder Match", Members(alice), focus: false, detached: true);
+        var pushCountAfterFirst = _harness.AllSignals.Count;
+
+        var second = await _service.CreateOrGet("match-1", "Ladder Match", Members(alice), focus: false, detached: true);
+
+        Assert.That(second.Id, Is.EqualTo(first.Id));
+        Assert.That(_harness.AllSignals.Count, Is.EqualTo(pushCountAfterFirst), "the retried detached create pushes nothing new");
+        Assert.That(await _membershipRepository.LoadForChannel(first.Id), Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task CreateOrGet_WithEpochSeq_StaleAgainstNewerAssertion_DoesNotResurrectMembers()
+    {
+        const string alice = "Alice#1";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(alice), focus: false, epoch: "e1", seq: 1);
+        await _service.ApplyRosterAssertion("match-1", "e1", 5, Members(), name: null, detached: false); // removes alice
+
+        await _service.CreateOrGet("match-1", "Match 1", Members(alice), focus: false, epoch: "e1", seq: 4);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Null,
+            "a late create carrying a STALE (epoch, seq) must not resurrect a member a newer assertion already removed");
+    }
+
+    [Test]
+    public async Task CreateOrGet_WithEqualSeq_StillAddsMembers()
+    {
+        const string alice = "Alice#1";
+        // Simulates the crashed-first-attempt case: the (epoch, seq) stamp landed, but the process crashed
+        // before the member add — so the retry below arrives with the SAME (epoch, seq) and alice missing.
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false, epoch: "e1", seq: 4);
+
+        await _service.CreateOrGet("match-1", "Match 1", Members(alice), focus: false, epoch: "e1", seq: 4);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null,
+            "an EQUAL stored seq still proceeds with adds — they are idempotent, so a crash between stamp and add never loses the member");
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(4));
+    }
+
+    [Test]
+    public async Task CreateOrGet_WithoutNewFields_BehavesExactlyAsToday()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(alice), focus: true);
+
+        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null);
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1));
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertEpoch, Is.Null, "no (epoch, seq) stamp is written when the fields are omitted — the transition pin");
+        Assert.That(reloaded.Detached, Is.False);
     }
 }

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -297,182 +297,6 @@ public class MatchChannelServiceTests : IntegrationTestBase
         Assert.That(reloaded.Name, Is.EqualTo("Real Match Name"), "the backfilled name is durably persisted");
     }
 
-    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): this whole region covers the
-    // DELTA path. mm keeps sending deltas until its own deploy; DELETE THIS ENTIRE REGION in the
-    // mm-deploy-confirmed cleanup PR alongside ApplyMembersDelta itself — see docs plan Task 6.
-    // ============================================================================================
-    // C7 Task 7 — ApplyMembersDelta: add creates membership + pushes ChannelAdded
-    // ============================================================================================
-
-    [Test]
-    public async Task Delta_AddCreatesMembership_AndPushesChannelAdded()
-    {
-        const string bt = "Alice#1";
-        RegisterOnline("conn-alice", bt);
-
-        // The channel already exists (mm's initial CreateOrGet POST already landed) before the delta arrives.
-        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
-
-        await _service.ApplyMembersDelta("match-1", add: Members(bt), remove: Members(), focus: true);
-
-        var membership = await _membershipRepository.Load(channel.Id, bt);
-        Assert.That(membership, Is.Not.Null, "the add creates a durable membership");
-        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1),
-            "ChannelAdded is pushed for the added member");
-    }
-
-    // ============================================================================================
-    // ApplyMembersDelta — remove deletes membership + pushes ChannelRemoved + force-unfocuses the
-    // removed user's connection (acceptance 4)
-    // ============================================================================================
-
-    [Test]
-    public async Task Delta_RemoveDeletesMembership_PushesChannelRemoved_AndUnfocusesRemovedUsersConnection()
-    {
-        const string bt = "Alice#1";
-        RegisterOnline("conn-alice", bt);
-
-        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(bt), focus: true);
-        _focusRegistry.Focus("conn-alice", channel.Id, bt);
-        Assert.That(_focusRegistry.GetFocusedChannels("conn-alice"), Does.Contain(channel.Id),
-            "precondition: the connection has the channel focused before the removal");
-
-        await _service.ApplyMembersDelta("match-1", add: Members(), remove: Members(bt), focus: false);
-
-        Assert.That(await _membershipRepository.Load(channel.Id, bt), Is.Null, "the membership is deleted");
-        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelRemoved), Is.EqualTo(1),
-            "ChannelRemoved is pushed to the removed user's live connection");
-        var dto = _harness.PayloadFor("conn-alice", ChatEvents.ChannelRemoved) as ChannelRemovedDto;
-        Assert.That(dto, Is.Not.Null);
-        Assert.That(dto.ChannelId, Is.EqualTo(channel.Id));
-
-        // Acceptance 4: the removed user's connection is FORCE-UNFOCUSED from the channel — the
-        // FocusRegistry.Unfocus tail of FanOutEngine.PushChannelRemoved (Task 5) IS this force-unfocus.
-        Assert.That(_focusRegistry.GetFocusedChannels("conn-alice"), Does.Not.Contain(channel.Id),
-            "the connection is no longer focused on the removed channel");
-    }
-
-    // ============================================================================================
-    // ApplyMembersDelta — delta-before-create: create-on-demand shell (ref-as-name, 24h expiry from
-    // its OWN creation), and a LATER real CreateOrGet backfills the name WITHOUT resetting expiry (M1)
-    // ============================================================================================
-
-    [Test]
-    public async Task Delta_BeforeCreate_CreatesShell_WithRefAsName_And24hExpiryFromShellCreation()
-    {
-        const string bt = "Alice#1";
-        RegisterOnline("conn-alice", bt);
-
-        // The delta arrives BEFORE mm's CreateOrGet POST — create-on-demand, never a hard 404 (§3.3, M1).
-        await _service.ApplyMembersDelta("match-1", add: Members(bt), remove: Members(), focus: true);
-
-        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
-        Assert.That(shell, Is.Not.Null, "the shell is created on-demand rather than a hard 404");
-        Assert.That(shell.Name, Is.EqualTo("match-1"), "the placeholder name is the ref itself");
-        Assert.That(shell.ExpiresAt, Is.Not.Null);
-        Assert.That((shell.ExpiresAt.Value - Now.AddHours(24)).Duration(), Is.LessThan(TimeSpan.FromSeconds(1)),
-            "the shell's 24h expiry is anchored to its OWN creation time");
-        Assert.That(await _membershipRepository.Load(shell.Id, bt), Is.Not.Null, "the add still applies to the newly-created shell");
-        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1));
-
-        var shellExpiry = shell.ExpiresAt;
-
-        // The clock moves before the LATER real mm CreateOrGet POST arrives.
-        _time.Advance(TimeSpan.FromHours(1));
-
-        var real = await _service.CreateOrGet("match-1", "Real Match Name", Members(), focus: false);
-
-        Assert.That(real.Id, Is.EqualTo(shell.Id), "the same channel (same ref)");
-        Assert.That(real.Name, Is.EqualTo("Real Match Name"), "the later create backfills the placeholder name");
-        Assert.That(real.ExpiresAt, Is.EqualTo(shellExpiry),
-            "the name backfill does NOT reset the shell's original creation-anchored expiry");
-    }
-
-    // ============================================================================================
-    // ApplyMembersDelta — removing an unknown member is a silent no-op, no push
-    // ============================================================================================
-
-    [Test]
-    public async Task Delta_RemoveUnknownMember_SilentNoOp_NoPush()
-    {
-        const string bt = "Ghost#1";
-        RegisterOnline("conn-ghost", bt);
-
-        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
-
-        // bt was never added to this channel — removing them must be a silent no-op.
-        await _service.ApplyMembersDelta("match-1", add: Members(), remove: Members(bt), focus: false);
-
-        Assert.That(_harness.AllSignals, Is.Empty, "no push is emitted for removing a member who was never present");
-        Assert.That(await _membershipRepository.Load(channel.Id, bt), Is.Null);
-    }
-
-    // ============================================================================================
-    // ApplyMembersDelta — add honors the one-match-channel-per-user invariant (acceptance 5, delta path)
-    // ============================================================================================
-
-    [Test]
-    public async Task Delta_AddHonorsOneMatchChannelInvariant()
-    {
-        const string bt = "Alice#1";
-        RegisterOnline("conn-alice", bt);
-
-        var matchA = await _service.CreateOrGet("match-A", "Match A", Members(bt), focus: true);
-
-        await _service.ApplyMembersDelta("match-B", add: Members(bt), remove: Members(), focus: true);
-
-        var matchB = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-B");
-        Assert.That(await _membershipRepository.Load(matchA.Id, bt), Is.Null,
-            "the stale match-A membership is swapped out on the delta path too");
-        Assert.That(await _membershipRepository.Load(matchB.Id, bt), Is.Not.Null);
-
-        var signals = _harness.AllSignals.Where(s => s.ConnectionId == "conn-alice").ToList();
-        var removedAIndex = signals.FindIndex(s =>
-            s.Method == ChatEvents.ChannelRemoved && ((ChannelRemovedDto)s.Payload).ChannelId == matchA.Id);
-        var addedBIndex = signals.FindIndex(s =>
-            s.Method == ChatEvents.ChannelAdded && ((ChannelAddedDto)s.Payload).Channel.Id == matchB.Id);
-        Assert.That(removedAIndex, Is.GreaterThanOrEqualTo(0), "ChannelRemoved(A) was emitted");
-        Assert.That(addedBIndex, Is.GreaterThanOrEqualTo(0), "ChannelAdded(B) was emitted");
-        Assert.That(removedAIndex, Is.LessThan(addedBIndex), "the swap fires on the delta path too");
-    }
-
-    // ============================================================================================
-    // ApplyMembersDelta — the focus flag is applied to adds
-    // ============================================================================================
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task Delta_FocusFlagAppliedToAdds(bool focus)
-    {
-        const string bt = "Alice#1";
-        RegisterOnline("conn-alice", bt);
-        await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
-
-        await _service.ApplyMembersDelta("match-1", add: Members(bt), remove: Members(), focus);
-
-        var dto = _harness.PayloadFor("conn-alice", ChatEvents.ChannelAdded) as ChannelAddedDto;
-        Assert.That(dto, Is.Not.Null);
-        Assert.That(dto.Focus, Is.EqualTo(focus), "the focus directive is applied to adds on the delta path");
-    }
-
-    // ============================================================================================
-    // ApplyMembersDelta — a battleTag in BOTH lists ends up REMOVED (adds-then-removes, deterministic;
-    // mm never sends this, but the behavior must be well-defined per §3.4)
-    // ============================================================================================
-
-    [Test]
-    public async Task Delta_BattleTagInBothLists_EndsUpRemoved()
-    {
-        const string bt = "Alice#1";
-        RegisterOnline("conn-alice", bt);
-        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
-
-        await _service.ApplyMembersDelta("match-1", add: Members(bt), remove: Members(bt), focus: true);
-
-        Assert.That(await _membershipRepository.Load(channel.Id, bt), Is.Null,
-            "adds run first, then removes — a battleTag in both lists ends up removed");
-    }
-
     // ============================================================================================
     // C7 Task 8 — DeleteChannel: hard-delete teardown (messages + memberships + channel), including
     // physically-present soft-deleted/shadow rows; another channel's data is untouched (acceptance 6a)
@@ -941,23 +765,6 @@ public class MatchChannelServiceTests : IntegrationTestBase
         Assert.That(await memberships.Load(channel.Id, "Alice#1"), Is.Not.Null);
     }
 
-    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): delta-path-only — pins
-    // ApplyMembersDelta's detach guard specifically. DELETE alongside ApplyMembersDelta itself in the
-    // mm-deploy-confirmed cleanup PR — see docs plan Task 6.
-    [Test]
-    public async Task Delta_AfterDetach_IsDiscarded()
-    {
-        const string alice = "Alice#1";
-        const string bob = "Bob#2";
-        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
-        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: true);
-
-        await _service.ApplyMembersDelta("match-1", add: Members(bob), remove: Members(alice), focus: false);
-
-        Assert.That(await _membershipRepository.Load(channel.Id, alice), Is.Not.Null, "the legacy delta path is frozen too");
-        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null);
-    }
-
     [Test]
     public async Task CreateOrGet_AfterDetach_BackfillsName_ButAddsNoMembers()
     {
@@ -1285,9 +1092,9 @@ public class MatchChannelServiceTests : IntegrationTestBase
     public async Task EpochSync_UnstampedChannel_SurvivesEvenWhenAbsentFromLiveList_FallsToTtl()
     {
         const string alice = "Alice#1";
-        // Created via the legacy CreateOrGet path and NEVER stamped by the assertion protocol at all —
+        // Created via CreateOrGet without epoch/seq and NEVER stamped by the assertion protocol at all —
         // AssertEpoch is genuinely ABSENT on the stored document, exactly the shape of a channel minted
-        // by the pre-reconciliation mm via the deprecated delta path during the transition window.
+        // by an mm that has not yet started sending epoch/seq or asserting a roster for this lobby.
         // 2026-08-05 fix wave (final review H1, plan D8 amendment): such a channel must NOT be swept by
         // an epoch sync — LoadNonDetachedMatchChannels's AssertEpoch-exists filter makes it invisible to
         // the sweep entirely, so it survives regardless of liveLobbyRefs and falls to its own 24h TTL.

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -951,6 +951,70 @@ public class MatchChannelServiceTests : IntegrationTestBase
     }
 
     // ============================================================================================
+    // Out-of-order heal — assert creates a shell, delete tears it down, a late create heals it
+    // idempotently. Narrower unit-level replacement for the delta-path
+    // OutOfOrder_PutThenDelete_ThenLatePost_HealsIdempotently test removed in the 2026-08-05
+    // delta-deletion round (task-7-report.md, "Judgment calls"), rewritten onto the surviving
+    // roster-assertion + D10 create-stamping protocol instead of the retired delta endpoint.
+    // ============================================================================================
+
+    [Test]
+    public async Task OutOfOrder_AssertThenDelete_ThenLateCreate_HealsWithFreshChannel()
+    {
+        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", alice);
+
+        // (1) An assertion for an UNKNOWN ref arrives before mm's create POST — the create-on-demand
+        // path stamps (e1, 1) and creates the shell.
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(), name: "My Lobby", detached: false);
+        var shell = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(shell, Is.Not.Null, "precondition: the out-of-order assertion created the shell on demand");
+        var shellId = shell.Id;
+        var shellExpiry = shell.ExpiresAt;
+
+        // The clock moves before the delete+late-create below, so a fresh 24h expiry is distinguishable
+        // from the shell's own creation-anchored one.
+        _time.Advance(TimeSpan.FromHours(3));
+
+        // (2) A hard DELETE tears the shell down completely — doc, memberships, messages all gone.
+        await _service.DeleteChannel("match-1");
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1"), Is.Null,
+            "the channel doc is torn down");
+        Assert.That(await _membershipRepository.LoadForChannel(shellId), Is.Empty, "its memberships are torn down");
+
+        // (3) A LATE create for the same ref now arrives, carrying the (epoch, seq) pair from BEFORE the
+        // delete (e1, 1) — stale coordinates relative to the vanished channel, but there is no live document
+        // at all for TryAdvanceAssertion to compare against, so it must heal idempotently rather than throw.
+        ChatChannel healed = null;
+        Assert.DoesNotThrowAsync(
+            async () => healed = await _service.CreateOrGet("match-1", "My Lobby", Members(alice), focus: false, epoch: "e1", seq: 1),
+            "the late create must heal idempotently — never throw on a stale (epoch, seq) against a fresh doc");
+
+        Assert.That(healed, Is.Not.Null);
+        Assert.That(healed.Id, Is.Not.EqualTo(shellId), "the heal produces a BRAND-NEW channel doc, not the deleted one");
+
+        // Exactly one physical doc for the ref — the heal does not leave a duplicate/orphaned row behind.
+        var db = MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName);
+        var docCount = await db.GetCollection<ChatChannel>(ChatCollections.Channels).CountDocumentsAsync(c =>
+            c.Type == ChannelType.System && c.SystemKind == SystemChannelKind.Match && c.SystemRef == "match-1");
+        Assert.That(docCount, Is.EqualTo(1), "exactly one channel doc exists for the ref after the heal");
+
+        // The fresh doc carries NO stored stamp going in, so the D10 member-add gate admits (CreateOrGetLocked's
+        // skipAdds reads AssertEpoch off the FRESH doc, which is null) and alice's membership is applied.
+        Assert.That(await _membershipRepository.Load(healed.Id, alice), Is.Not.Null,
+            "the fresh doc's D10 gate admits — members are applied on the healed channel");
+        Assert.That(_harness.SignalCount("conn-alice", ChatEvents.ChannelAdded), Is.EqualTo(1),
+            "alice's live connection receives ChannelAdded for the healed channel");
+
+        // A fresh 24h expiry, anchored to the heal's OWN creation time — not a reuse of the deleted shell's
+        // now-stale expiry.
+        Assert.That((healed.ExpiresAt.Value - Now.AddHours(24)).Duration(), Is.LessThan(TimeSpan.FromSeconds(1)),
+            "the healed channel's expiry is freshly anchored to ITS OWN creation time");
+        Assert.That(healed.ExpiresAt, Is.Not.EqualTo(shellExpiry),
+            "the healed channel's expiry is NOT the stale, deleted shell's expiry");
+    }
+
+    // ============================================================================================
     // 2026-08-05 reconciliation — ApplyEpochSync: startup teardown of orphaned lobby channels
     // (plan D8, Task 4)
     // ============================================================================================

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -1328,4 +1328,132 @@ public class MatchChannelServiceTests : IntegrationTestBase
             "the shared TearDownChannel routine deletes messages, memberships AND the channel doc together — "
             + "so no orphaned membership row is left behind for CleanupJobs to find");
     }
+
+    [Test]
+    public async Task EpochSync_LiveRefMatching_IsCaseSensitive()
+    {
+        await _service.CreateOrGet("match-A", "Upper", Members("Alice#1"), focus: false);
+
+        // A ref differing only in case is a DIFFERENT lobby — refs are exact Mongo keys drawn from
+        // [A-Za-z0-9_-] (mm's nanoids use a mixed-case alphabet), unlike battleTags.
+        await _service.ApplyEpochSync("e2", Members("match-a"));
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-A"), Is.Null,
+            "liveLobbyRefs is matched ORDINALLY — case folding would SPARE an orphaned channel whose ref "
+            + "differs only in case from a live one");
+    }
+
+    [Test]
+    public async Task EpochSync_DoesNotResetAChannelAlreadyAnchoredToTheSyncsOwnEpoch()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        var channel = await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+        // Anchor the channel to "e2" DURING what will be treated as "this same boot" — mirrors a lobby
+        // created/asserted while an epoch sync under "e2" was still retrying.
+        await _service.ApplyRosterAssertion("match-1", "e2", 5, Members(alice), name: null, detached: false);
+
+        await _service.ApplyEpochSync("e2", Members("match-1"));
+
+        var reloaded = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
+        Assert.That(reloaded.AssertEpoch, Is.EqualTo("e2"));
+        Assert.That(reloaded.AssertSeq, Is.EqualTo(5),
+            "a channel already anchored to the sync's OWN epoch must be left entirely untouched — "
+            + "resetting AssertSeq to 0 here would re-open the duplicate-replay window for assertions "
+            + "already applied under this epoch (plan D8 refinement, Task-4 review INFO-1)");
+
+        // If the reset had wrongly landed (AssertSeq -> 0), this duplicate/stale seq-3 assertion would be
+        // wrongly re-admitted (3 > 0) instead of discarded (3 <= the real stored seq, 5).
+        await _service.ApplyRosterAssertion("match-1", "e2", 3, Members(bob), name: null, detached: false);
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null,
+            "a duplicate (e2, 3) assertion is STILL discarded after the sync — proves AssertSeq was not reset");
+
+        // seq 6 — genuinely newer than the untouched stored seq 5 — still applies normally.
+        await _service.ApplyRosterAssertion("match-1", "e2", 6, Members(bob), name: null, detached: false);
+        Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Not.Null,
+            "(e2, 6) still applies — the untouched counter continues advancing normally post-sync");
+    }
+
+    // Fires a one-shot hook the first time a teardown reads a channel's member list — TearDownChannel's
+    // very first statement, and the ONLY caller of LoadForChannel on this path. That instant is inside
+    // ApplyEpochSync's loop but strictly AFTER its discovery scan, i.e. exactly the TOCTOU window the
+    // in-gate re-load exists to cover. (LoadForChannel is already a documented test seam.)
+    private sealed class TeardownHookMembershipRepository(
+        MongoClient client, ChannelRepository channelRepository, Func<string, Task> onFirstTeardown)
+        : MembershipRepository(client, channelRepository)
+    {
+        private int _calls;
+
+        public override async Task<List<ChannelMembership>> LoadForChannel(string channelId)
+        {
+            if (Interlocked.Increment(ref _calls) == 1)
+            {
+                await onFirstTeardown(channelId);
+            }
+
+            return await base.LoadForChannel(channelId);
+        }
+    }
+
+    [Test]
+    public async Task EpochSync_ReLoadsInsideTheGate_SoAChannelDetachedAfterTheScanIsSpared()
+    {
+        var channelRepo = new ChannelRepository(MongoClient);
+        string idA = null;
+        string idB = null;
+
+        // Detach the OTHER orphan while the first one is being torn down — order-independent, so this
+        // does not depend on the natural order LoadNonDetachedMatchChannels returns.
+        var memberships = new TeardownHookMembershipRepository(
+            MongoClient, channelRepo, async tornDownId => await channelRepo.SetDetached(tornDownId == idA ? idB : idA));
+        var service = new MatchChannelService(channelRepo, memberships, _messageRepository, _fanOutEngine, _time);
+
+        var a = await service.CreateOrGet("match-a", "A", Members("Alice#1"), focus: false);
+        var b = await service.CreateOrGet("match-b", "B", Members("Bob#2"), focus: false);
+        idA = a.Id;
+        idB = b.Id;
+
+        // Empty live list: BOTH refs are orphans at scan time, so both are teardown candidates.
+        await service.ApplyEpochSync("e2", Members());
+
+        var survivors = new[]
+        {
+            await channelRepo.LoadBySystemRef(SystemChannelKind.Match, "match-a"),
+            await channelRepo.LoadBySystemRef(SystemChannelKind.Match, "match-b"),
+        }.Where(c => c != null).ToList();
+
+        Assert.That(survivors.Count, Is.EqualTo(1),
+            "a channel DETACHED between the discovery scan and its own turn must be re-loaded inside the "
+            + "per-ref gate and SPARED — acting on the stale scan-time candidate tears down a live room");
+        Assert.That(survivors[0].Detached, Is.True, "the survivor is the one that was detached mid-sync");
+        Assert.That(await memberships.Load(survivors[0].Id, survivors[0].SystemRef == "match-a" ? "Alice#1" : "Bob#2"),
+            Is.Not.Null, "the spared channel keeps its membership rows");
+    }
+
+    [Test]
+    public async Task EpochSync_ReLoadsInsideTheGate_SoAChannelDeletedAfterTheScanIsSkipped()
+    {
+        RegisterOnline("conn-alice", "Alice#1");
+        RegisterOnline("conn-bob", "Bob#2");
+        var channelRepo = new ChannelRepository(MongoClient);
+        string idA = null;
+        string idB = null;
+
+        var memberships = new TeardownHookMembershipRepository(
+            MongoClient, channelRepo, async tornDownId => await channelRepo.Delete(tornDownId == idA ? idB : idA));
+        var service = new MatchChannelService(channelRepo, memberships, _messageRepository, _fanOutEngine, _time);
+
+        var a = await service.CreateOrGet("match-a", "A", Members("Alice#1"), focus: false);
+        var b = await service.CreateOrGet("match-b", "B", Members("Bob#2"), focus: false);
+        idA = a.Id;
+        idB = b.Id;
+        var pushesBefore = _harness.AllSignals.Count;
+
+        await service.ApplyEpochSync("e2", Members());
+
+        // The concurrently-deleted channel is skipped outright: no second teardown, no ChannelRemoved
+        // for a channel this sync never owned. Exactly ONE teardown ran, so exactly ONE push landed.
+        Assert.That(_harness.AllSignals.Count - pushesBefore, Is.EqualTo(1),
+            "a channel whose doc vanished between the scan and its turn is skipped, not torn down on stale data");
+    }
 }

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -297,6 +297,9 @@ public class MatchChannelServiceTests : IntegrationTestBase
         Assert.That(reloaded.Name, Is.EqualTo("Real Match Name"), "the backfilled name is durably persisted");
     }
 
+    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): this whole region covers the
+    // DELTA path. mm keeps sending deltas until its own deploy; DELETE THIS ENTIRE REGION in the
+    // mm-deploy-confirmed cleanup PR alongside ApplyMembersDelta itself — see docs plan Task 6.
     // ============================================================================================
     // C7 Task 7 — ApplyMembersDelta: add creates membership + pushes ChannelAdded
     // ============================================================================================
@@ -670,18 +673,20 @@ public class MatchChannelServiceTests : IntegrationTestBase
     [Test]
     public async Task Assert_CaseOnlyDifference_DoesNotChurnMembership()
     {
-        const string alice = "Alice#1";
+        RegisterOnline("conn-alice", "Alice#1");
         await _service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
-        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(alice), name: null, detached: false);
+        // Seeded so the stored row is the lowercased key "alice#1"...
+        await _service.ApplyRosterAssertion("match-1", "e1", 1, Members("alice#1"), name: null, detached: false);
         var pushCountAfterFirst = _harness.AllSignals.Count;
 
-        // Re-assert with a DIFFERENT casing of the same tag.
-        await _service.ApplyRosterAssertion("match-1", "e1", 2, Members("alice#1"), name: null, detached: false);
+        // ...and re-asserted with mm's JWT casing. THIS is the direction that occurs in production.
+        await _service.ApplyRosterAssertion("match-1", "e1", 2, Members("Alice#1"), name: null, detached: false);
 
         Assert.That(_harness.AllSignals.Count, Is.EqualTo(pushCountAfterFirst),
             "a case-only difference between stored (lowercased) and asserted (JWT-cased) battleTags must not churn membership");
         var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-1");
-        Assert.That(await _membershipRepository.LoadForChannel(channel.Id), Has.Count.EqualTo(1), "exactly one membership row — no delete+re-add");
+        Assert.That(await _membershipRepository.LoadForChannel(channel.Id), Has.Count.EqualTo(1),
+            "exactly one membership row — no delete+re-add");
     }
 
     [Test]
@@ -860,6 +865,38 @@ public class MatchChannelServiceTests : IntegrationTestBase
         Assert.That(reloaded.Detached, Is.True, "then the channel is frozen");
     }
 
+    // Records the membership row count at the instant the freeze latch lands — the only way to pin the
+    // plan's DETACH-LAST ordering (D4/D10), whose in-process post-conditions are identical either way
+    // (nothing between the latch and the member writes reads Detached — see ChannelRepository.SetDetached's
+    // doc). Used by both the ApplyRosterAssertion and CreateOrGet detach-ordering tests below.
+    private sealed class DetachOrderChannelRepository(MongoClient mongoClient) : ChannelRepository(mongoClient)
+    {
+        public MembershipRepository Memberships;
+        public int RowsAtDetach = -1;
+
+        public override async Task SetDetached(string channelId)
+        {
+            RowsAtDetach = (await Memberships.LoadForChannel(channelId)).Count;
+            await base.SetDetached(channelId);
+        }
+    }
+
+    [Test]
+    public async Task Assert_WithDetachedTrue_DetachLatchLandsAfterTheDiffConverged()
+    {
+        var repo = new DetachOrderChannelRepository(MongoClient);
+        var memberships = new MembershipRepository(MongoClient, repo);
+        repo.Memberships = memberships;
+        var service = new MatchChannelService(repo, memberships, _messageRepository, _fanOutEngine, _time);
+        await service.CreateOrGet("match-1", "Match 1", Members(), focus: false);
+
+        await service.ApplyRosterAssertion("match-1", "e1", 1, Members("Alice#1"), name: null, detached: true);
+
+        Assert.That(repo.RowsAtDetach, Is.EqualTo(1),
+            "DETACH LAST (D4): the final member set must already be persisted when the freeze latch lands — "
+            + "detach-first plus a crash mid-diff freezes a wrong roster until the 24h TTL");
+    }
+
     [Test]
     public async Task Assert_AfterDetach_IsDiscarded_EvenWithHigherSeq_AndNewEpoch()
     {
@@ -874,6 +911,32 @@ public class MatchChannelServiceTests : IntegrationTestBase
         Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null, "a post-detach assertion never applies, even with a higher seq and a different epoch");
     }
 
+    // Admits everything, so the CAS's own Ne(Detached, true) backstop cannot mask the DOMAIN-level
+    // detach guard this test targets (plan D4 requires BOTH layers — see TryAdvanceAssertion's own
+    // "REDUNDANT BY DESIGN" doc for the analogous Task 1 precedent).
+    private sealed class AlwaysAdmitChannelRepository(MongoClient mongoClient) : ChannelRepository(mongoClient)
+    {
+        public override Task<bool> TryAdvanceAssertion(string channelId, string epoch, long seq) => Task.FromResult(true);
+    }
+
+    [Test]
+    public async Task Assert_AfterDetach_DomainGuardDiscards_WithoutTheCasBackstop()
+    {
+        var repo = new AlwaysAdmitChannelRepository(MongoClient);
+        var memberships = new MembershipRepository(MongoClient, repo);
+        var service = new MatchChannelService(repo, memberships, _messageRepository, _fanOutEngine, _time);
+        var channel = await service.CreateOrGet("match-1", "Ladder", Members("Alice#1"), focus: false, detached: true);
+
+        await service.ApplyRosterAssertion("match-1", "e2", 99, Members("Bob#2"), name: null, detached: false);
+
+        Assert.That(await memberships.Load(channel.Id, "Bob#2"), Is.Null,
+            "the domain-level detach freeze discards on its own — it does not lean on the CAS filter");
+        Assert.That(await memberships.Load(channel.Id, "Alice#1"), Is.Not.Null);
+    }
+
+    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): delta-path-only — pins
+    // ApplyMembersDelta's detach guard specifically. DELETE alongside ApplyMembersDelta itself in the
+    // mm-deploy-confirmed cleanup PR — see docs plan Task 6.
     [Test]
     public async Task Delta_AfterDetach_IsDiscarded()
     {
@@ -998,6 +1061,20 @@ public class MatchChannelServiceTests : IntegrationTestBase
         // A follow-up assertion must be discarded — the channel is frozen from birth.
         await _service.ApplyRosterAssertion("match-1", "e1", 1, Members(bob), name: null, detached: false);
         Assert.That(await _membershipRepository.Load(channel.Id, bob), Is.Null);
+    }
+
+    [Test]
+    public async Task CreateOrGet_WithDetached_LatchLandsAfterTheBirthAdds()
+    {
+        var repo = new DetachOrderChannelRepository(MongoClient);
+        var memberships = new MembershipRepository(MongoClient, repo);
+        repo.Memberships = memberships;
+        var service = new MatchChannelService(repo, memberships, _messageRepository, _fanOutEngine, _time);
+
+        await service.CreateOrGet("match-1", "Ladder Match", Members("Alice#1"), focus: false, detached: true);
+
+        Assert.That(repo.RowsAtDetach, Is.EqualTo(1),
+            "D10 adds-before-detach: a crashed-then-retried create only converges because the adds always precede the latch");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -1424,6 +1424,47 @@ public class MatchChannelServiceTests : IntegrationTestBase
             "(e2, 6) still applies — the untouched counter continues advancing normally post-sync");
     }
 
+    // ============================================================================================
+    // 2026-08-05 fix wave (final review H2) — ApplyEpochSync honors the caller's CancellationToken
+    // ============================================================================================
+
+    [Test]
+    public async Task EpochSync_PreCancelledToken_StopsLoopEarly_PartialProcessing()
+    {
+        const string alice = "Alice#1";
+        const string bob = "Bob#2";
+        await _service.CreateOrGet("match-a", "A", Members(alice), focus: false, epoch: "e1", seq: 1);
+        await _service.CreateOrGet("match-b", "B", Members(bob), focus: false, epoch: "e1", seq: 1);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Empty live list: BOTH candidates would normally be torn down. A token that is ALREADY
+        // cancelled before the loop's first iteration must bail before touching either one — the
+        // check-and-bail happens at the TOP of the loop, between channels, never mid-teardown.
+        await _service.ApplyEpochSync("e2", Members(), cts.Token);
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-a"), Is.Not.Null,
+            "a pre-cancelled token must stop the sweep before it processes ANY candidate — partial (here, zero) "
+            + "processing is safe: nothing already-processed is left half-mutated, and the next attempt's "
+            + "candidate set is unchanged, so it makes full durable progress");
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-b"), Is.Not.Null);
+    }
+
+    [Test]
+    public async Task EpochSync_NonCancelledToken_CompletesNormally_UnchangedBehavior()
+    {
+        // Back-compat pin: the default CancellationToken (the overload every pre-H2 caller — including
+        // every other test in this file — uses) must behave byte-for-byte as before H2's change.
+        const string alice = "Alice#1";
+        await _service.CreateOrGet("match-gone", "Gone", Members(alice), focus: false, epoch: "e1", seq: 1);
+
+        await _service.ApplyEpochSync("e2", Members(), CancellationToken.None);
+
+        Assert.That(await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-gone"), Is.Null,
+            "an explicit non-cancelled token completes the sweep exactly as the default-token overload does");
+    }
+
     // Fires a one-shot hook the first time a teardown reads a channel's member list — TearDownChannel's
     // very first statement, and the ONLY caller of LoadForChannel on this path. That instant is inside
     // ApplyEpochSync's loop but strictly AFTER its discovery scan, i.e. exactly the TOCTOU window the

--- a/W3ChampionsChatService.Tests/ProtocolContractTests.cs
+++ b/W3ChampionsChatService.Tests/ProtocolContractTests.cs
@@ -379,4 +379,31 @@ public class ProtocolContractTests
         StringAssert.DoesNotContain("Declined", json);
         StringAssert.DoesNotContain("declined", json);
     }
+
+    // ── 2026-08-05 reconciliation plan Task 1 (D6) — assertion-state leak wall ───────────────
+
+    [Test]
+    public void ChatChannel_AssertionState_IsNeverSerializedToClients()
+    {
+        // D6: AssertEpoch/AssertSeq/Detached are mm<->chat reconciliation bookkeeping, never client
+        // protocol — the raw entity rides ChannelAddedDto.Channel / ChannelDto.Channel to clients.
+        var channel = new ChatChannel
+        {
+            Id = "c1",
+            AssertEpoch = "e1",
+            AssertSeq = 5,
+            Detached = true,
+        };
+
+        var json = JsonSerializer.Serialize(channel);
+
+        StringAssert.DoesNotContain("assertEpoch", json);
+        StringAssert.DoesNotContain("AssertEpoch", json);
+        StringAssert.DoesNotContain("assertSeq", json);
+        StringAssert.DoesNotContain("AssertSeq", json);
+        StringAssert.DoesNotContain("detached", json);
+        StringAssert.DoesNotContain("Detached", json);
+        // Positive control — proves the object really did serialize.
+        StringAssert.Contains("Id", json);
+    }
 }

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -274,6 +274,11 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
             fb.Ne(c => c.AssertEpoch, epoch),
             fb.And(
                 fb.Eq(c => c.AssertEpoch, epoch),
+                // Strict Lt (not Lte) is REDUNDANT BY DESIGN with the ModifiedCount check below: either
+                // one alone already rejects an equal-seq replay (Lt excludes the doc from the filter;
+                // ModifiedCount==0 catches a no-op $set when the filter is relaxed to Lte). Only the
+                // COMBINATION is mutation-tested/pinned — do not relax one on the assumption the other
+                // is independently test-pinned (Task 1 review r1, mutations M1/M3).
                 fb.Or(fb.Exists(c => c.AssertSeq, false), fb.Lt(c => c.AssertSeq, seq))));
         var filter = fb.And(fb.Eq(c => c.Id, channelId), fb.Ne(c => c.Detached, true), admissible);
         var update = Builders<ChatChannel>.Update
@@ -281,6 +286,9 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
             .Set(c => c.AssertSeq, seq);
 
         var result = await Channels.UpdateOneAsync(filter, update);
+        // ModifiedCount (not MatchedCount) is REDUNDANT BY DESIGN with the strict Lt above — see the
+        // comment there. Do not switch to MatchedCount on the assumption "TryAdvanceAssertion always
+        // writes when it matches"; that assumption breaks the moment Lt is ever relaxed to Lte.
         return result.ModifiedCount == 1;
     }
 

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -292,8 +292,11 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
         return result.ModifiedCount == 1;
     }
 
-    /// <summary>Freezes the room (plan D4) — see ChatChannel.Detached. Idempotent.</summary>
-    public Task SetDetached(string channelId) =>
+    /// <summary>Freezes the room (plan D4) — see ChatChannel.Detached. Idempotent.
+    /// Virtual: a test seam (the TryAdvanceAssertion idiom) so a subclass can observe WHEN the latch
+    /// lands and pin the plan's DETACH-LAST / adds-before-detach ordering, which is otherwise
+    /// invisible in-process (nothing between the latch and the member writes reads Detached).</summary>
+    public virtual Task SetDetached(string channelId) =>
         Channels.UpdateOneAsync(c => c.Id == channelId, Builders<ChatChannel>.Update.Set(c => c.Detached, true));
 
     /// <summary>

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -300,8 +300,21 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
         Channels.UpdateOneAsync(c => c.Id == channelId, Builders<ChatChannel>.Update.Set(c => c.Detached, true));
 
     /// <summary>
-    /// Every System+Match channel eligible for an epoch sync — i.e. NOT detached (a detached room is
-    /// excluded from every sweep by design, so it is filtered out server-side and never even loaded).
+    /// Every System+Match channel eligible for an epoch sync — NOT detached (a detached room is excluded
+    /// from every sweep by design, so it is filtered out server-side and never even loaded) AND already
+    /// stamped by the assertion protocol (<c>AssertEpoch</c> exists).
+    /// <para>
+    /// The <c>AssertEpoch</c>-exists clause is a 2026-08-05 fix wave amendment (final review H1, plan D8
+    /// amendment). Every channel the reconciliation-era mm creates is stamped by construction (create
+    /// carries epoch/seq; the roster-assertion endpoint stamps on demand), so it is correctly a sweep
+    /// candidate. A channel minted by the PRE-reconciliation mm (deprecated delta protocol only, never an
+    /// assertion) has no <c>AssertEpoch</c> field at all — <see cref="ChatChannel.AssertEpoch"/> is
+    /// <c>[BsonIgnoreIfNull]</c>, so it is genuinely absent from the document, not merely null — and is
+    /// therefore invisible to this query. It falls to its own 24h creation-anchored TTL instead of being
+    /// torn down by the very first post-deploy epoch sync. Without this clause, that first sync would tear
+    /// down every non-detached System+Match channel already in the database at mm's deploy instant,
+    /// including every in-progress ladder game's chat (~4,900 channels/day measured against production).
+    /// </para>
     /// Bounded in practice by the 24h creation-anchored TTL on match channels, which is why this needs
     /// no pagination; served by the ux_systemKind_systemRef index's SystemKind prefix.
     /// </summary>
@@ -311,7 +324,8 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
         return Channels.Find(fb.And(
             fb.Eq(c => c.Type, ChannelType.System),
             fb.Eq(c => c.SystemKind, SystemChannelKind.Match),
-            fb.Ne(c => c.Detached, true))).ToListAsync();
+            fb.Ne(c => c.Detached, true),
+            fb.Exists(c => c.AssertEpoch, true))).ToListAsync();
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -307,8 +307,8 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
     /// The <c>AssertEpoch</c>-exists clause is a 2026-08-05 fix wave amendment (final review H1, plan D8
     /// amendment). Every channel the reconciliation-era mm creates is stamped by construction (create
     /// carries epoch/seq; the roster-assertion endpoint stamps on demand), so it is correctly a sweep
-    /// candidate. A channel minted by the PRE-reconciliation mm (deprecated delta protocol only, never an
-    /// assertion) has no <c>AssertEpoch</c> field at all — <see cref="ChatChannel.AssertEpoch"/> is
+    /// candidate. A channel created via <c>POST /internal/channels</c> without epoch/seq and never since
+    /// asserted has no <c>AssertEpoch</c> field at all — <see cref="ChatChannel.AssertEpoch"/> is
     /// <c>[BsonIgnoreIfNull]</c>, so it is genuinely absent from the document, not merely null — and is
     /// therefore invisible to this query. It falls to its own 24h creation-anchored TTL instead of being
     /// torn down by the very first post-deploy epoch sync. Without this clause, that first sync would tear

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -315,14 +315,37 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
     }
 
     /// <summary>
-    /// Epoch-sync authority reset for the channels a sync SPARES (plan D8): adopt the new epoch and
-    /// reset the per-lobby counter to the 0 sentinel, so mm's first assertion under the new epoch
-    /// (seq >= 1) applies cleanly. Writes 0 rather than $unset — see ChatChannel.AssertSeq.
+    /// Epoch-sync authority reset for the channels a sync SPARES (plan D8) — CONDITIONAL: the update
+    /// only lands when the stored <c>AssertEpoch</c> differs from <paramref name="epoch"/> (absent
+    /// counts as different, mirroring <see cref="TryAdvanceAssertion"/>'s rule (a)/(c) split). When it
+    /// does, adopt the new epoch and reset the per-lobby counter to the 0 sentinel, so mm's first
+    /// assertion under the new epoch (seq >= 1) applies cleanly. Writes 0 rather than $unset — see
+    /// ChatChannel.AssertSeq.
+    /// <para>
+    /// A channel ALREADY anchored to the sync's own epoch is left completely untouched. Such a channel
+    /// was created or asserted by mm DURING this same boot — a new lobby, or a retried assertion, that
+    /// landed while the epoch sync was still retrying — so it is not "stale" in the sense this reset
+    /// exists to fix. Resetting it anyway would zero out an already-advancing seq counter, re-opening
+    /// the duplicate-replay window for every assertion already applied under this epoch (2026-08-05
+    /// Task-4 review r1, INFO-1): a retried lower-seq assertion would be wrongly re-admitted and would
+    /// apply a stale full member set, reverting the roster until mm's next assertion re-converges it.
+    /// The conditional keeps the reset scoped to its actual purpose — re-anchoring channels stamped
+    /// under a now-dead PRE-restart epoch — and keeps <see cref="TryAdvanceAssertion"/>'s D3(c) anomaly
+    /// Warning meaningful (it fires on a genuine mismatch, not on every graceful restart).
+    /// </para>
     /// </summary>
-    public Task StampAssertionEpoch(string channelId, string epoch) =>
-        Channels.UpdateOneAsync(
-            c => c.Id == channelId,
-            Builders<ChatChannel>.Update.Set(c => c.AssertEpoch, epoch).Set(c => c.AssertSeq, 0L));
+    public Task StampAssertionEpoch(string channelId, string epoch)
+    {
+        var fb = Builders<ChatChannel>.Filter;
+        var filter = fb.And(
+            fb.Eq(c => c.Id, channelId),
+            fb.Or(fb.Exists(c => c.AssertEpoch, false), fb.Ne(c => c.AssertEpoch, epoch)));
+        var update = Builders<ChatChannel>.Update
+            .Set(c => c.AssertEpoch, epoch)
+            .Set(c => c.AssertSeq, 0L);
+
+        return Channels.UpdateOneAsync(filter, update);
+    }
 
     /// <summary>Hard-deletes a channel doc (C5 D12 — e.g. the last group member leaving; residual
     /// memberships are cleaned up separately via <see cref="Memberships.MembershipRepository.DeleteAllForChannel"/>).

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -254,6 +254,65 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
         return result.ModifiedCount == 1;
     }
 
+    /// <summary>
+    /// The (epoch, seq) ADMISSION GATE for a roster assertion, expressed as ONE conditional update —
+    /// admit and stamp are atomic (the SetRequestAccepted idiom). Returns true when the assertion may
+    /// be applied. Staleness semantics (plan D3): (a) no epoch stored yet => accept; (b) SAME epoch =>
+    /// accept only when seq is STRICTLY greater than the stored one; (c) DIFFERENT epoch => accept and
+    /// RE-ANCHOR (epochs are opaque and unordered, and a discard rule would permanently wedge a channel
+    /// that survived an mm restart — the caller logs this anomaly). A detached channel is never
+    /// admitted: the domain layer checks Detached first, and this filter re-checks it as the durable
+    /// backstop against a concurrent detach.
+    /// Virtual: a test seam (the MembershipRepository.LoadForChannel idiom) so a subclass can block
+    /// inside this call and prove the per-ref gate actually serializes two concurrent assertions.
+    /// </summary>
+    public virtual async Task<bool> TryAdvanceAssertion(string channelId, string epoch, long seq)
+    {
+        var fb = Builders<ChatChannel>.Filter;
+        var admissible = fb.Or(
+            fb.Exists(c => c.AssertEpoch, false),
+            fb.Ne(c => c.AssertEpoch, epoch),
+            fb.And(
+                fb.Eq(c => c.AssertEpoch, epoch),
+                fb.Or(fb.Exists(c => c.AssertSeq, false), fb.Lt(c => c.AssertSeq, seq))));
+        var filter = fb.And(fb.Eq(c => c.Id, channelId), fb.Ne(c => c.Detached, true), admissible);
+        var update = Builders<ChatChannel>.Update
+            .Set(c => c.AssertEpoch, epoch)
+            .Set(c => c.AssertSeq, seq);
+
+        var result = await Channels.UpdateOneAsync(filter, update);
+        return result.ModifiedCount == 1;
+    }
+
+    /// <summary>Freezes the room (plan D4) — see ChatChannel.Detached. Idempotent.</summary>
+    public Task SetDetached(string channelId) =>
+        Channels.UpdateOneAsync(c => c.Id == channelId, Builders<ChatChannel>.Update.Set(c => c.Detached, true));
+
+    /// <summary>
+    /// Every System+Match channel eligible for an epoch sync — i.e. NOT detached (a detached room is
+    /// excluded from every sweep by design, so it is filtered out server-side and never even loaded).
+    /// Bounded in practice by the 24h creation-anchored TTL on match channels, which is why this needs
+    /// no pagination; served by the ux_systemKind_systemRef index's SystemKind prefix.
+    /// </summary>
+    public Task<List<ChatChannel>> LoadNonDetachedMatchChannels()
+    {
+        var fb = Builders<ChatChannel>.Filter;
+        return Channels.Find(fb.And(
+            fb.Eq(c => c.Type, ChannelType.System),
+            fb.Eq(c => c.SystemKind, SystemChannelKind.Match),
+            fb.Ne(c => c.Detached, true))).ToListAsync();
+    }
+
+    /// <summary>
+    /// Epoch-sync authority reset for the channels a sync SPARES (plan D8): adopt the new epoch and
+    /// reset the per-lobby counter to the 0 sentinel, so mm's first assertion under the new epoch
+    /// (seq >= 1) applies cleanly. Writes 0 rather than $unset — see ChatChannel.AssertSeq.
+    /// </summary>
+    public Task StampAssertionEpoch(string channelId, string epoch) =>
+        Channels.UpdateOneAsync(
+            c => c.Id == channelId,
+            Builders<ChatChannel>.Update.Set(c => c.AssertEpoch, epoch).Set(c => c.AssertSeq, 0L));
+
     /// <summary>Hard-deletes a channel doc (C5 D12 — e.g. the last group member leaving; residual
     /// memberships are cleaned up separately via <see cref="Memberships.MembershipRepository.DeleteAllForChannel"/>).
     /// Messages are left to the 90d message TTL — no reader exists for a deleted channel's history

--- a/W3ChampionsChatService/Channels/ChatChannel.cs
+++ b/W3ChampionsChatService/Channels/ChatChannel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using W3ChampionsChatService.Domain;
@@ -53,4 +54,37 @@ public class ChatChannel
     /// <summary>Absolute expiry instant (TTL index, expireAfterSeconds 0). Absent = permanent.</summary>
     [BsonIgnoreIfNull]
     public DateTime? ExpiresAt { get; set; }
+
+    /// <summary>
+    /// System+Match only — the mm authority EPOCH of the last applied full-set roster assertion
+    /// (2026-08-05 reconciliation spec). An opaque token: compared for equality ONLY, never parsed or
+    /// ordered. Absent on every channel that predates the assertion protocol (created via the legacy
+    /// create/delta path) — every read must tolerate absence. [JsonIgnore]: mm↔chat reconciliation
+    /// bookkeeping, never client protocol (the raw entity rides ChannelAddedDto/ChannelDto).
+    /// </summary>
+    [BsonIgnoreIfNull]
+    [JsonIgnore]
+    public string AssertEpoch { get; set; }
+
+    /// <summary>
+    /// System+Match only — the per-(channel, epoch) sequence number of the last applied roster
+    /// assertion. Contract: mm sends seq >= 1, so 0 is the "nothing applied yet under this epoch"
+    /// sentinel the epoch sync writes when it re-anchors a spared channel (never $unset — a MISSING
+    /// field would not match Mongo's $lt, which does not compare across BSON types, and would wedge
+    /// the channel).
+    /// </summary>
+    [BsonIgnoreIfDefault]
+    [JsonIgnore]
+    public long AssertSeq { get; set; }
+
+    /// <summary>
+    /// System+Match only — true once mm's GAME_STARTED final assertion froze this room: membership is
+    /// frozen (later assertions AND legacy deltas are discarded), and the channel is excluded from
+    /// EVERY sweep including epoch syncs. The 24h creation-anchored TTL is its sole cleanup path.
+    /// [BsonIgnoreIfDefault] keeps the field ABSENT on non-detached docs, so Ne(Detached, true) matches
+    /// every pre-existing document.
+    /// </summary>
+    [BsonIgnoreIfDefault]
+    [JsonIgnore]
+    public bool Detached { get; set; }
 }

--- a/W3ChampionsChatService/Channels/ChatChannel.cs
+++ b/W3ChampionsChatService/Channels/ChatChannel.cs
@@ -79,8 +79,18 @@ public class ChatChannel
 
     /// <summary>
     /// System+Match only — true once mm's GAME_STARTED final assertion froze this room: membership is
-    /// frozen (later assertions AND legacy deltas are discarded), and the channel is excluded from
-    /// EVERY sweep including epoch syncs. The 24h creation-anchored TTL is its sole cleanup path.
+    /// frozen against BOTH mutating protocols (later assertions AND legacy deltas are discarded), and the
+    /// channel is excluded from EVERY sweep including epoch syncs. The 24h creation-anchored TTL is its
+    /// sole cleanup path.
+    /// <para>
+    /// DELIBERATE BYPASS (2026-08-05 fix wave, final review N2): the freeze does NOT cover
+    /// <c>W3ChampionsChatService.Internal.MatchChannelService.AddMemberWithInvariant</c>'s cross-channel
+    /// eviction — when a user's NEXT match starts, the one-match-channel-per-user invariant still deletes
+    /// their membership row on THIS (detached, frozen) channel to make room for the new one. This is
+    /// intentional, not a hole in the freeze: it is exactly how a post-game room leaves a user's channel
+    /// tray once their next game begins, rather than lingering there until the 24h TTL reaps the whole
+    /// channel.
+    /// </para>
     /// [BsonIgnoreIfDefault] keeps the field ABSENT on non-detached docs, so Ne(Detached, true) matches
     /// every pre-existing document.
     /// </summary>

--- a/W3ChampionsChatService/Channels/ChatChannel.cs
+++ b/W3ChampionsChatService/Channels/ChatChannel.cs
@@ -58,8 +58,8 @@ public class ChatChannel
     /// <summary>
     /// System+Match only — the mm authority EPOCH of the last applied full-set roster assertion
     /// (2026-08-05 reconciliation spec). An opaque token: compared for equality ONLY, never parsed or
-    /// ordered. Absent on every channel that predates the assertion protocol (created via the legacy
-    /// create/delta path) — every read must tolerate absence. [JsonIgnore]: mm↔chat reconciliation
+    /// ordered. Absent on every channel created without epoch/seq and never since asserted — every read
+    /// must tolerate absence. [JsonIgnore]: mm↔chat reconciliation
     /// bookkeeping, never client protocol (the raw entity rides ChannelAddedDto/ChannelDto).
     /// </summary>
     [BsonIgnoreIfNull]
@@ -79,9 +79,8 @@ public class ChatChannel
 
     /// <summary>
     /// System+Match only — true once mm's GAME_STARTED final assertion froze this room: membership is
-    /// frozen against BOTH mutating protocols (later assertions AND legacy deltas are discarded), and the
-    /// channel is excluded from EVERY sweep including epoch syncs. The 24h creation-anchored TTL is its
-    /// sole cleanup path.
+    /// frozen (every later roster assertion for this ref is discarded), and the channel is excluded from
+    /// EVERY sweep including epoch syncs. The 24h creation-anchored TTL is its sole cleanup path.
     /// <para>
     /// DELIBERATE BYPASS (2026-08-05 fix wave, final review N2): the freeze does NOT cover
     /// <c>W3ChampionsChatService.Internal.MatchChannelService.AddMemberWithInvariant</c>'s cross-channel

--- a/W3ChampionsChatService/Chats/ChatHub.Channels.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Channels.cs
@@ -417,6 +417,23 @@ public partial class ChatHub
     /// private-lane teardown): the last member leaving deletes the channel doc + residual memberships; a
     /// departing LAST owner auto-promotes the longest-standing remaining member.</item>
     /// </list>
+    /// <para>
+    /// H4 (2026-08-05 reconciliation review, <c>final-review-fable.md</c>) — product decision (Marco,
+    /// 2026-08-05): the membership delete below stays deliberately TYPE-AGNOSTIC and UNGATED, no
+    /// <see cref="ChannelType"/> check and no ref lock. That is what keeps the launcher's stuck-row escape
+    /// hatch working — a user can always force-leave a channel the client considers stuck, whatever kind
+    /// it is. Accepted cost: on a LIVE (non-detached, still assertion-reachable) match channel this races
+    /// <c>MatchChannelService.ApplyRosterAssertion</c>'s full-set diff, so a leave landing between two
+    /// assertions is silently reverted by the next one. That is correct, not a bug — mm is authoritative
+    /// for lobby membership while a channel is live; membership of a live lobby belongs to mm, not the
+    /// user. It is also UI-unreachable in practice: the launcher hides Leave for the caller's
+    /// currently-live match channel (<c>launcher-e/src/components/chat/ChannelListRow.tsx</c>,
+    /// <c>!isCurrentLiveMatchChannel</c>) and shows it only for stale/stuck System rows. Stale rows (dead
+    /// lobby ⇒ no assertion ever reaches them again) and detached/frozen post-game rooms (assertions
+    /// discarded once frozen) get no further assertions either way, so a leave on either of THOSE sticks —
+    /// exactly the case the escape hatch exists for. No behavior change; this codifies the decision to
+    /// keep the exception as-is rather than adding a server-side no-op-for-live-match-channel guard.
+    /// </para>
     /// </summary>
     public async Task<ChannelOperationResult> LeaveChannel(string channelId)
     {

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -209,6 +209,17 @@ public static class ChatLimits
     /// here only.</summary>
     public const int InternalChannelNameMaxLength = 100;
 
+    /// <summary>
+    /// 2026-08-05 reconciliation spec §3: `liveLobbyRefs` array cap on POST /internal/channels/epoch-sync.
+    /// Plan decision, not spec-pinned text; hard-coded, adjust here only. Sized to stay comfortably
+    /// inside <see cref="InternalMaxBodyBytes"/> (a 64-char ref plus JSON quoting/comma is ≈68 bytes, so
+    /// 512 refs ≈ 35 KB of a 64 KB budget) while sitting far above any realistic count of simultaneously
+    /// OPEN (not-yet-started) lobbies — mm creates a lobby moments before its game starts, so the live
+    /// set is tens, not hundreds. An over-cap body is a 400: mm would retry, which is the correct
+    /// fail-loud behavior for "chat cannot safely reconcile a world it only partially received".
+    /// </summary>
+    public const int InternalMaxLiveRefsPerSync = 512;
+
     /// <summary>2026-08-05 PR36 feedback, Part 3: <see cref="FanOut.ReadRateLimiter"/>'s single per-
     /// battleTag token bucket, shared across every READ-shaped hub method it guards
     /// (<c>GetConversations</c>, <c>GetMessages</c>). This is a server-protection abuse guard, not UX

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -70,10 +70,20 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
             return BadRequest(new ErrorResult(GenericValidationError));
         }
 
+        // 2026-08-05 fix wave (final review C1): `name` is cosmetic — members is the authoritative
+        // payload — so a name chat cannot store must NEVER reject the whole create. mm applies no
+        // length/trim/charset validation of its own to a custom-game lobby name before sending it (any
+        // authenticated player can trigger a whitespace-only or >100-char name), and CreateOrGet already
+        // knows how to fall back to the ref placeholder for a null name. Empty-after-trim normalizes to
+        // null; overlong is truncated. Neither is ever a 400.
         var name = request.Name?.Trim();
-        if (string.IsNullOrEmpty(name) || name.Length > ChatLimits.InternalChannelNameMaxLength)
+        if (string.IsNullOrEmpty(name))
         {
-            return BadRequest(new ErrorResult(GenericValidationError));
+            name = null;
+        }
+        else if (name.Length > ChatLimits.InternalChannelNameMaxLength)
+        {
+            name = name[..ChatLimits.InternalChannelNameMaxLength];
         }
 
         if (!IsValidMembers(request.Members))
@@ -192,10 +202,18 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
             return BadRequest(new ErrorResult(GenericValidationError));
         }
 
+        // The assertion's authoritative payload is `members`. `name` is cosmetic (create-on-demand only,
+        // ignored on an existing channel), so a name chat cannot store must NEVER reject the roster — mm
+        // has no per-status retry policy and would re-send the same rejected name forever (2026-08-05 fix
+        // wave, final review C1).
         var name = request.Name?.Trim();
-        if (request.Name != null && (string.IsNullOrEmpty(name) || name.Length > ChatLimits.InternalChannelNameMaxLength))
+        if (string.IsNullOrEmpty(name))
         {
-            return BadRequest(new ErrorResult(GenericValidationError));
+            name = null; // ⇒ ApplyRosterAssertion falls back to the ref placeholder
+        }
+        else if (name.Length > ChatLimits.InternalChannelNameMaxLength)
+        {
+            name = name[..ChatLimits.InternalChannelNameMaxLength];
         }
 
         try

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -13,19 +13,16 @@ namespace W3ChampionsChatService.Internal;
 /// <summary>
 /// C7 Task 9 — the HTTP surface for the match-channel lifecycle mm drives: <c>POST /internal/channels</c>
 /// (idempotent create-or-get, 200 for BOTH a fresh channel and a duplicate call — the pinned idempotency
-/// contract), <c>PUT /internal/channels/{ref}/members</c> (membership delta), and
-/// <c>DELETE /internal/channels/{ref}</c> (hard teardown, 200 even for an unknown ref — a 404 would only
-/// trigger a pointless mm retry). All three delegate to <see cref="MatchChannelService"/> (Tasks 6-8);
-/// this controller owns ONLY input validation, the HTTP shape, and logging.
+/// contract), <c>PUT /internal/channels/{ref}/roster</c> (the authoritative full-set membership assertion,
+/// 2026-08-05 reconciliation spec, plan D1-D4/D7), <c>POST /internal/channels/epoch-sync</c> (mm's
+/// boot-time convergence sweep, plan D8), and <c>DELETE /internal/channels/{ref}</c> (hard teardown, 200
+/// even for an unknown ref — a 404 would only trigger a pointless mm retry). All four delegate to
+/// <see cref="MatchChannelService"/>; this controller owns ONLY input validation, the HTTP shape, and
+/// logging.
 /// <para>
-/// 2026-08-05 reconciliation spec — two ADDITIVE endpoints replacing the delta protocol above:
-/// <c>PUT /internal/channels/{ref}/roster</c> (the authoritative full-set membership assertion, plan
-/// D1-D4/D7) and <c>POST /internal/channels/epoch-sync</c> (mm's boot-time convergence sweep, plan D8).
-/// Both are named to avoid a one-character collision with the surviving <c>.../members</c> delta route
-/// (<c>.../roster</c>, not <c>.../membership</c>) and both delegate to
-/// <see cref="MatchChannelService.ApplyRosterAssertion"/> / <see cref="MatchChannelService.ApplyEpochSync"/>
-/// respectively. The delta route and <see cref="Create"/> keep working unchanged until mm's own deploy —
-/// see the D9 <c>TRANSITION</c> markers.
+/// The roster route is named <c>.../roster</c> rather than <c>.../membership</c> deliberately — a
+/// one-character-away name from <c>.../members</c> would have collided with the now-removed legacy delta
+/// route this endpoint replaced.
 /// </para>
 /// <para>
 /// SECURITY (H1): gated by <see cref="InternalHmacAuthAttribute"/> at CLASS level with an Mm-only
@@ -128,44 +125,6 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
         }
     }
 
-    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): the DELTA path. mm keeps
-    // sending deltas until its own deploy; DELETE THIS ENTIRE METHOD in the mm-deploy-confirmed
-    // cleanup PR — see docs plan Task 6.
-    [HttpPut("{ref}/members")]
-    public async Task<IActionResult> UpdateMembers(string @ref, [FromBody] InternalMembersDeltaRequest request)
-    {
-        if (!IsValidRef(@ref))
-        {
-            return BadRequest(new ErrorResult(GenericValidationError));
-        }
-
-        // Null add/remove arrays are tolerated on the wire — coerced to empty here since
-        // MatchChannelService.ApplyMembersDelta does NOT null-guard its own list parameters.
-        var add = request?.Add ?? new List<string>();
-        var remove = request?.Remove ?? new List<string>();
-
-        if (!IsValidMembers(add) || !IsValidMembers(remove))
-        {
-            return BadRequest(new ErrorResult(GenericValidationError));
-        }
-
-        try
-        {
-            await matchChannelService.ApplyMembersDelta(@ref, add, remove, request?.Focus ?? false);
-
-            Log.Information(
-                "Internal channel members-delta succeeded {Caller} {Verb} {Ref} addCount={AddCount} removeCount={RemoveCount}",
-                InternalHmacAuthFilter.ResolveCaller(HttpContext), "PUT", @ref, add.Count, remove.Count);
-
-            return Ok();
-        }
-        catch (Exception ex)
-        {
-            LogUnexpected(ex, "PUT", @ref);
-            throw;
-        }
-    }
-
     [HttpPut("{ref}/roster")]
     public async Task<IActionResult> AssertRoster(string @ref, [FromBody] InternalRosterAssertRequest request)
     {
@@ -189,9 +148,9 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
             return BadRequest(new ErrorResult(GenericValidationError));
         }
 
-        // Deliberately NOT coerced to empty (contrast UpdateMembers above): for a full-set assertion,
-        // null and [] are the difference between "no-op" and "tear the whole lobby's membership down"
-        // (plan D7) — the caller must state which it means, so a missing array is a 400.
+        // Deliberately NOT coerced to empty: for a full-set assertion, null and [] are the difference
+        // between "no-op" and "tear the whole lobby's membership down" (plan D7) — the caller must state
+        // which it means, so a missing array is a 400.
         if (request.Members == null)
         {
             return BadRequest(new ErrorResult(GenericValidationError));

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -218,13 +218,18 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
 
         try
         {
-            await matchChannelService.ApplyRosterAssertion(
+            var outcome = await matchChannelService.ApplyRosterAssertion(
                 @ref, request.Epoch, request.Seq, request.Members,
                 name, request.Detached ?? false);
 
+            // 2026-08-05 fix wave (final review M2): the outcome REPLACES the old unconditional
+            // "succeeded" wording — a discarded assertion (stale/duplicate or against a frozen channel)
+            // used to log a contradictory "succeeded" line here ALONGSIDE the domain layer's own discard
+            // line, exactly on the storm paths (an mm retry storm, or mm asserting a frozen lobby) the
+            // staleness/detach gates exist to absorb. One line, the real outcome.
             Log.Information(
-                "Internal channel roster-assert succeeded {Caller} {Verb} {Ref} epoch={Epoch} seq={Seq} memberCount={MemberCount} detached={Detached}",
-                InternalHmacAuthFilter.ResolveCaller(HttpContext), "PUT", @ref,
+                "Internal channel roster-assert {Outcome} {Caller} {Verb} {Ref} epoch={Epoch} seq={Seq} memberCount={MemberCount} detached={Detached}",
+                outcome, InternalHmacAuthFilter.ResolveCaller(HttpContext), "PUT", @ref,
                 request.Epoch, request.Seq, request.Members.Count, request.Detached ?? false);
 
             // A DISCARDED (stale/detached) assertion is still a 200 — it is a successful no-op, not a

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -18,6 +18,16 @@ namespace W3ChampionsChatService.Internal;
 /// trigger a pointless mm retry). All three delegate to <see cref="MatchChannelService"/> (Tasks 6-8);
 /// this controller owns ONLY input validation, the HTTP shape, and logging.
 /// <para>
+/// 2026-08-05 reconciliation spec — two ADDITIVE endpoints replacing the delta protocol above:
+/// <c>PUT /internal/channels/{ref}/roster</c> (the authoritative full-set membership assertion, plan
+/// D1-D4/D7) and <c>POST /internal/channels/epoch-sync</c> (mm's boot-time convergence sweep, plan D8).
+/// Both are named to avoid a one-character collision with the surviving <c>.../members</c> delta route
+/// (<c>.../roster</c>, not <c>.../membership</c>) and both delegate to
+/// <see cref="MatchChannelService.ApplyRosterAssertion"/> / <see cref="MatchChannelService.ApplyEpochSync"/>
+/// respectively. The delta route and <see cref="Create"/> keep working unchanged until mm's own deploy —
+/// see the D9 <c>TRANSITION</c> markers.
+/// </para>
+/// <para>
 /// SECURITY (H1): gated by <see cref="InternalHmacAuthAttribute"/> at CLASS level with an Mm-only
 /// allow-list — the disjoint HMAC auth realm, never <see cref="UserHasPermissionAttribute"/>. See
 /// <c>InternalChannelsControllerTests</c>'s dynamic reflection sweep, which fails CI the day any future
@@ -71,13 +81,33 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
             return BadRequest(new ErrorResult(GenericValidationError));
         }
 
+        // D10 pair rule (2026-08-05 reconciliation spec): epoch/seq must come TOGETHER — a lone one is
+        // ambiguous (an unstamped seq, or a seq with no epoch to compare it against), so exactly one
+        // present is a 400.
+        if ((request.Epoch != null) != request.Seq.HasValue)
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (request.Epoch != null && !IsValidEpoch(request.Epoch))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (request.Seq.HasValue && request.Seq.Value < 1)
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
         try
         {
-            var channel = await matchChannelService.CreateOrGet(request.Ref, name, request.Members, request.Focus ?? false);
+            var channel = await matchChannelService.CreateOrGet(
+                request.Ref, name, request.Members, request.Focus ?? false,
+                request.Epoch, request.Seq, request.Detached ?? false);
 
             Log.Information(
-                "Internal channel create succeeded {Caller} {Verb} {Ref} memberCount={MemberCount}",
-                InternalHmacAuthFilter.ResolveCaller(HttpContext), "POST", request.Ref, request.Members.Count);
+                "Internal channel create succeeded {Caller} {Verb} {Ref} memberCount={MemberCount} detached={Detached}",
+                InternalHmacAuthFilter.ResolveCaller(HttpContext), "POST", request.Ref, request.Members.Count, request.Detached ?? false);
 
             return Ok(InternalChannelDto.FromChannel(channel));
         }
@@ -123,6 +153,116 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
         }
     }
 
+    [HttpPut("{ref}/roster")]
+    public async Task<IActionResult> AssertRoster(string @ref, [FromBody] InternalRosterAssertRequest request)
+    {
+        if (request == null)
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (!IsValidRef(@ref))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (!IsValidEpoch(request.Epoch))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (request.Seq < 1)
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        // Deliberately NOT coerced to empty (contrast UpdateMembers above): for a full-set assertion,
+        // null and [] are the difference between "no-op" and "tear the whole lobby's membership down"
+        // (plan D7) — the caller must state which it means, so a missing array is a 400.
+        if (request.Members == null)
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (!IsValidMembers(request.Members))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        var name = request.Name?.Trim();
+        if (request.Name != null && (string.IsNullOrEmpty(name) || name.Length > ChatLimits.InternalChannelNameMaxLength))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        try
+        {
+            await matchChannelService.ApplyRosterAssertion(
+                @ref, request.Epoch, request.Seq, request.Members,
+                name, request.Detached ?? false);
+
+            Log.Information(
+                "Internal channel roster-assert succeeded {Caller} {Verb} {Ref} epoch={Epoch} seq={Seq} memberCount={MemberCount} detached={Detached}",
+                InternalHmacAuthFilter.ResolveCaller(HttpContext), "PUT", @ref,
+                request.Epoch, request.Seq, request.Members.Count, request.Detached ?? false);
+
+            // A DISCARDED (stale/detached) assertion is still a 200 — it is a successful no-op, not a
+            // failure. mm must not retry a correctly-rejected stale assertion; the domain layer already
+            // logged the discard.
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            LogUnexpected(ex, "PUT", @ref);
+            throw;
+        }
+    }
+
+    [HttpPost("epoch-sync")]
+    public async Task<IActionResult> EpochSync([FromBody] InternalEpochSyncRequest request)
+    {
+        if (request == null)
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (!IsValidEpoch(request.Epoch))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (request.LiveLobbyRefs == null)
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (request.LiveLobbyRefs.Count > ChatLimits.InternalMaxLiveRefsPerSync)
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        if (request.LiveLobbyRefs.Any(r => !IsValidRef(r)))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        try
+        {
+            await matchChannelService.ApplyEpochSync(request.Epoch, request.LiveLobbyRefs);
+
+            Log.Information(
+                "Internal channel epoch-sync succeeded {Caller} {Verb} epoch={Epoch} liveRefCount={LiveRefCount}",
+                InternalHmacAuthFilter.ResolveCaller(HttpContext), "POST", request.Epoch, request.LiveLobbyRefs.Count);
+
+            return Ok();
+        }
+        catch (Exception ex)
+        {
+            LogUnexpected(ex, "POST", "epoch-sync");
+            throw;
+        }
+    }
+
     [HttpDelete("{ref}")]
     public async Task<IActionResult> Delete(string @ref)
     {
@@ -148,6 +288,11 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
     }
 
     private static bool IsValidRef(string @ref) => @ref != null && RefPattern.IsMatch(@ref);
+
+    // The epoch is an OPAQUE token, never parsed — the SAME character class and length cap that
+    // defends `ref` (log injection into the Serilog {Epoch} sink; a polluted Mongo key) is exactly the
+    // defense it needs, so it reuses RefPattern deliberately rather than inventing a second regex.
+    private static bool IsValidEpoch(string epoch) => epoch != null && RefPattern.IsMatch(epoch);
 
     private static bool IsValidMembers(List<string> members) =>
         members != null

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -269,7 +269,11 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
 
         try
         {
-            await matchChannelService.ApplyEpochSync(request.Epoch, request.LiveLobbyRefs);
+            // 2026-08-05 fix wave (final review H2): thread the client's own abort signal through the
+            // sweep loop. mm's client timeout is far shorter than a large sweep can take; without this,
+            // an aborted mm attempt leaves the sweep running headless while mm's retry launches ANOTHER
+            // overlapping one. A cancelled sweep is safe — see ApplyEpochSync's own doc.
+            await matchChannelService.ApplyEpochSync(request.Epoch, request.LiveLobbyRefs, HttpContext.RequestAborted);
 
             Log.Information(
                 "Internal channel epoch-sync succeeded {Caller} {Verb} epoch={Epoch} liveRefCount={LiveRefCount}",

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -322,7 +322,17 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
     private static bool IsValidMembers(List<string> members) =>
         members != null
         && members.Count <= ChatLimits.InternalMaxMembersPerCall
-        && members.All(m => !string.IsNullOrWhiteSpace(m));
+        && members.All(IsValidMemberEntry);
+
+    // 2026-08-05 fix wave (final review M5): mirrors InternalRelationshipChangesController's
+    // IsValidParticipant EXACTLY — non-blank AND control-char-free. Before this, a member entry was
+    // bounded only by the 64 KB body cap and landed as a lowercased Mongo BattleTag key with no
+    // per-entry length or control-char guard, asymmetric with the relationship-changes surface's
+    // identical-shaped field. char.IsControl catches an embedded '\n'/'\r'/'\t'/NUL (log-injection);
+    // U+2028/U+2029 are checked explicitly because they are category Zl/Zp, not Cc, so char.IsControl
+    // alone misses them.
+    private static bool IsValidMemberEntry(string value) =>
+        !string.IsNullOrWhiteSpace(value) && !value.Any(c => char.IsControl(c) || c is '\u2028' or '\u2029');
 
     private void LogUnexpected(Exception ex, string verb, string @ref) =>
         Log.Error(ex, "Internal channels endpoint failed {Caller} {Verb} {Ref}", InternalHmacAuthFilter.ResolveCaller(HttpContext), verb, @ref);

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -118,6 +118,9 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
         }
     }
 
+    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): the DELTA path. mm keeps
+    // sending deltas until its own deploy; DELETE THIS ENTIRE METHOD in the mm-deploy-confirmed
+    // cleanup PR — see docs plan Task 6.
     [HttpPut("{ref}/members")]
     public async Task<IActionResult> UpdateMembers(string @ref, [FromBody] InternalMembersDeltaRequest request)
     {

--- a/W3ChampionsChatService/Internal/InternalDtos.cs
+++ b/W3ChampionsChatService/Internal/InternalDtos.cs
@@ -38,6 +38,9 @@ public class InternalChannelCreateRequest
     public bool? Detached { get; set; }
 }
 
+// TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): the DELTA path. mm keeps
+// sending deltas until its own deploy; DELETE THIS ENTIRE CLASS in the mm-deploy-confirmed
+// cleanup PR — see docs plan Task 6.
 /// <summary>
 /// <c>PUT /internal/channels/{ref}/members</c> request body (C7 Task 9) — mm's membership delta.
 /// <see cref="Add"/>/<see cref="Remove"/> tolerate a null array on the wire: the controller coerces

--- a/W3ChampionsChatService/Internal/InternalDtos.cs
+++ b/W3ChampionsChatService/Internal/InternalDtos.cs
@@ -46,32 +46,16 @@ public class InternalChannelCreateRequest
     public bool? Detached { get; set; }
 }
 
-// TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): the DELTA path. mm keeps
-// sending deltas until its own deploy; DELETE THIS ENTIRE CLASS in the mm-deploy-confirmed
-// cleanup PR — see docs plan Task 6.
-/// <summary>
-/// <c>PUT /internal/channels/{ref}/members</c> request body (C7 Task 9) — mm's membership delta.
-/// <see cref="Add"/>/<see cref="Remove"/> tolerate a null array on the wire: the controller coerces
-/// either to an empty list before calling <see cref="MatchChannelService.ApplyMembersDelta"/>, which
-/// does NOT null-guard its own list parameters.
-/// </summary>
-public class InternalMembersDeltaRequest
-{
-    public List<string> Add { get; set; }
-    public List<string> Remove { get; set; }
-    public bool? Focus { get; set; }
-}
-
 /// <summary>
 /// <c>PUT /internal/channels/{ref}/roster</c> request body — mm's AUTHORITATIVE full-set membership
-/// assertion (2026-08-05 reconciliation spec §1), the replacement for the delta shape above.
+/// assertion (2026-08-05 reconciliation spec §1), the sole membership-mutation protocol mm drives.
 /// <see cref="Epoch"/> is an OPAQUE token (mm's authority generation, fresh per mm boot) — compared
 /// for equality only, never parsed or ordered, and re-validated against the same character class and
 /// length cap as <c>ref</c>. <see cref="Seq"/> is mm's per-(lobby, epoch) monotonic counter and MUST
 /// be >= 1 (0 is chat-side's "nothing applied yet under this epoch" sentinel).
-/// <see cref="Members"/> is the COMPLETE member set and — unlike the delta's add/remove — is NOT
-/// null-tolerant: null and [] differ by "no-op" vs "tear the whole lobby's membership down", so the
-/// caller must state which it means. <see cref="Name"/> is the display name used ONLY when the
+/// <see cref="Members"/> is the COMPLETE member set and is NOT null-tolerant: null and [] differ by
+/// "no-op" vs "tear the whole lobby's membership down", so the caller must state which it means.
+/// <see cref="Name"/> is the display name used ONLY when the
 /// assertion must create the channel on demand (mm's boot-race healing — a recreated room must not
 /// display its nanoid ref); ignored for an existing channel; optional (null ⇒ ref placeholder).
 /// NORMALIZED, NEVER REJECTED (2026-08-05 fix wave, final review C1): trimmed and clamped to

--- a/W3ChampionsChatService/Internal/InternalDtos.cs
+++ b/W3ChampionsChatService/Internal/InternalDtos.cs
@@ -30,6 +30,14 @@ public class InternalChannelCreateRequest
 {
     public string Kind { get; set; }
     public string Ref { get; set; }
+
+    /// <summary>
+    /// Cosmetic display name — NORMALIZED, NEVER REJECTED (2026-08-05 fix wave, final review C1):
+    /// trimmed and clamped to <see cref="Domain.ChatLimits.InternalChannelNameMaxLength"/> (100 chars);
+    /// empty-after-trim falls back to <see cref="Ref"/> as a placeholder. mm applies no length/trim/
+    /// charset validation of its own before sending this, so a name chat cannot store must never be able
+    /// to reject an otherwise-valid create.
+    /// </summary>
     public string Name { get; set; }
     public List<string> Members { get; set; }
     public bool? Focus { get; set; }
@@ -66,6 +74,9 @@ public class InternalMembersDeltaRequest
 /// caller must state which it means. <see cref="Name"/> is the display name used ONLY when the
 /// assertion must create the channel on demand (mm's boot-race healing — a recreated room must not
 /// display its nanoid ref); ignored for an existing channel; optional (null ⇒ ref placeholder).
+/// NORMALIZED, NEVER REJECTED (2026-08-05 fix wave, final review C1): trimmed and clamped to
+/// <see cref="Domain.ChatLimits.InternalChannelNameMaxLength"/>; empty-after-trim also falls back to the
+/// ref placeholder — a cosmetic field must never block an authoritative roster.
 /// <see cref="Detached"/> marks mm's GAME_STARTED final assertion: the set is applied, then the
 /// room freezes. There is deliberately NO Focus field — mm has never sent one on any internal call,
 /// and a new contract carries no dead parameters (plan §2.3).

--- a/W3ChampionsChatService/Internal/InternalDtos.cs
+++ b/W3ChampionsChatService/Internal/InternalDtos.cs
@@ -12,6 +12,19 @@ namespace W3ChampionsChatService.Internal;
 /// re-validated server-side against the M1 dot-segment defense regardless of what the caller sent.
 /// <see cref="Members"/> is the initial battleTag roster; <see cref="Focus"/> hints whether newly-added
 /// members should have the channel auto-focused client-side (defaults to <c>false</c> when omitted).
+/// <para>
+/// <see cref="Epoch"/>/<see cref="Seq"/>/<see cref="Detached"/> are OPTIONAL additions (2026-08-05
+/// reconciliation spec, plan D10) — absent ⇒ today's create behavior, byte-for-byte (the transition
+/// guarantee for today's not-yet-deployed mm). They MUST come together: exactly one of
+/// <see cref="Epoch"/>/<see cref="Seq"/> present is a 400. When present, they stamp
+/// <c>(epoch, seq)</c> so a late-landing create retry cannot resurrect a member a newer roster
+/// assertion already removed (<see cref="MatchChannelService.CreateOrGet"/>'s member handling is
+/// additive). <see cref="Detached"/> marks a channel born already frozen — the LADDER-MATCH case:
+/// chat-service uses one <c>SystemKind=Match</c> for both custom-lobby and ladder-match channels, and
+/// ladder refs are never in mm's <c>liveLobbyRefs</c> (that registry only holds custom lobbies), so
+/// without birth-detach the FIRST epoch sync after any mm restart would tear down every in-progress
+/// ladder game's chat.
+/// </para>
 /// </summary>
 public class InternalChannelCreateRequest
 {
@@ -20,6 +33,9 @@ public class InternalChannelCreateRequest
     public string Name { get; set; }
     public List<string> Members { get; set; }
     public bool? Focus { get; set; }
+    public string Epoch { get; set; }
+    public long? Seq { get; set; }
+    public bool? Detached { get; set; }
 }
 
 /// <summary>
@@ -33,6 +49,45 @@ public class InternalMembersDeltaRequest
     public List<string> Add { get; set; }
     public List<string> Remove { get; set; }
     public bool? Focus { get; set; }
+}
+
+/// <summary>
+/// <c>PUT /internal/channels/{ref}/roster</c> request body — mm's AUTHORITATIVE full-set membership
+/// assertion (2026-08-05 reconciliation spec §1), the replacement for the delta shape above.
+/// <see cref="Epoch"/> is an OPAQUE token (mm's authority generation, fresh per mm boot) — compared
+/// for equality only, never parsed or ordered, and re-validated against the same character class and
+/// length cap as <c>ref</c>. <see cref="Seq"/> is mm's per-(lobby, epoch) monotonic counter and MUST
+/// be >= 1 (0 is chat-side's "nothing applied yet under this epoch" sentinel).
+/// <see cref="Members"/> is the COMPLETE member set and — unlike the delta's add/remove — is NOT
+/// null-tolerant: null and [] differ by "no-op" vs "tear the whole lobby's membership down", so the
+/// caller must state which it means. <see cref="Name"/> is the display name used ONLY when the
+/// assertion must create the channel on demand (mm's boot-race healing — a recreated room must not
+/// display its nanoid ref); ignored for an existing channel; optional (null ⇒ ref placeholder).
+/// <see cref="Detached"/> marks mm's GAME_STARTED final assertion: the set is applied, then the
+/// room freezes. There is deliberately NO Focus field — mm has never sent one on any internal call,
+/// and a new contract carries no dead parameters (plan §2.3).
+/// </summary>
+public class InternalRosterAssertRequest
+{
+    public string Epoch { get; set; }
+    public long Seq { get; set; }
+    public List<string> Members { get; set; }
+    public string Name { get; set; }
+    public bool? Detached { get; set; }
+}
+
+/// <summary>
+/// <c>POST /internal/channels/epoch-sync</c> request body — mm's boot-time authoritative world
+/// (2026-08-05 reconciliation spec §3). <see cref="LiveLobbyRefs"/> is the COMPLETE set of lobby
+/// refs mm still knows about (the EMPTY set after a crash, since lobbies are ephemeral in mm) and is
+/// NOT null-tolerant for the same reason <see cref="InternalRosterAssertRequest.Members"/> isn't.
+/// Every entry is re-validated against the same ref character class, and the array is capped at
+/// <see cref="Domain.ChatLimits.InternalMaxLiveRefsPerSync"/>.
+/// </summary>
+public class InternalEpochSyncRequest
+{
+    public string Epoch { get; set; }
+    public List<string> LiveLobbyRefs { get; set; }
 }
 
 /// <summary>

--- a/W3ChampionsChatService/Internal/MatchChannelRefGate.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelRefGate.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace W3ChampionsChatService.Internal;
+
+/// <summary>
+/// Serializes every mutating operation on a single match channel by its systemRef (plan D5, 2026-08-05
+/// reconciliation spec). WHY IT EXISTS: <see cref="Channels.ChannelRepository.TryAdvanceAssertion"/>
+/// admits an <c>(epoch, seq)</c> assertion atomically, but the MEMBERSHIP DIFF that follows it is a
+/// sequence of independent writes — two admitted assertions (seq 6 and seq 7) could otherwise interleave
+/// their diffs and leave the channel doc claiming seq 7 while the membership rows still reflect seq 6.
+/// This gate closes that gap by making the whole "admit, diff, converge" operation atomic per ref, not
+/// just the admission check.
+/// <para>
+/// A COMPLETE guard, not merely a best-effort one — the service runs single-instance by design (already
+/// documented on <see cref="Channels.ChannelRepository.AllocateSeq"/>). The durable
+/// <c>TryAdvanceAssertion</c> CAS remains the backstop if that assumption is ever broken; only the diff
+/// interleaving above would then be unguarded, which is the pre-existing residual already called out on
+/// <c>MatchChannelService</c>'s class doc.
+/// </para>
+/// <para>
+/// EVICTION: match refs are unbounded over time — one per lobby, forever — so a semaphore-per-ref map
+/// that only ever grows is not acceptable. Entries are reference-counted and removed the instant the last
+/// holder releases, so the map only ever holds refs with a genuinely in-flight operation.
+/// </para>
+/// <para>
+/// Only one gate is ever held at a time by a caller (no nesting, no lock-ordering hazard) — the mutating
+/// service methods this guards never call each other, so there is no re-entrancy deadlock. Callers MUST
+/// acquire via <c>using var _ = await AcquireAsync(...);</c>: <c>using</c> lowers to a <c>try/finally</c>,
+/// so a throwing guarded body still releases — but nothing here recovers a holder that never calls
+/// <see cref="IDisposable.Dispose"/> at all, which would wedge every future caller for that ref
+/// permanently.
+/// </para>
+/// </summary>
+internal sealed class MatchChannelRefGate
+{
+    // StringComparer.Ordinal: systemRef is already validated to [A-Za-z0-9_-]{1,64} and is an exact Mongo
+    // key elsewhere in the codebase — no case folding is meaningful or wanted here.
+    private readonly Dictionary<string, Entry> _entries = new(StringComparer.Ordinal);
+
+    // Guards ONLY the dictionary + ref-counts below; no async work (in particular, no
+    // SemaphoreSlim.WaitAsync) ever happens while this is held.
+    private readonly object _lock = new();
+
+    /// <summary>
+    /// Acquires the exclusive gate for <paramref name="systemRef"/>, awaiting the current holder (if any)
+    /// first. Returns a releaser — wrap the call as <c>using var _ = await AcquireAsync(systemRef);</c>;
+    /// see this class's doc for why the caller, not the gate, owns exception-safety here.
+    /// </summary>
+    public async Task<IDisposable> AcquireAsync(string systemRef)
+    {
+        Entry entry;
+        lock (_lock)
+        {
+            if (!_entries.TryGetValue(systemRef, out entry))
+            {
+                entry = new Entry();
+                _entries[systemRef] = entry;
+            }
+
+            // Bumped BEFORE the wait below, under the same lock as every other ref-count mutation — this
+            // is what keeps a contended entry alive while a second caller is queued on its semaphore (see
+            // Release: eviction only fires once RefCount reaches zero).
+            entry.RefCount++;
+        }
+
+        // The wait itself happens OUTSIDE the lock: SemaphoreSlim.WaitAsync can genuinely suspend, and a
+        // plain `lock` cannot span an `await`. Holding the dictionary lock across the wait would also
+        // serialize acquires for every OTHER ref on one global lock, defeating the point of a keyed,
+        // per-ref gate.
+        await entry.Semaphore.WaitAsync();
+
+        return new Releaser(this, systemRef, entry);
+    }
+
+    // Test seam (assembly has InternalsVisibleTo, mirrors ReadRateLimiter.TrackedUserCount) — proves
+    // eviction: 0 once every acquired holder has released.
+    internal int TrackedRefCount
+    {
+        get { lock (_lock) { return _entries.Count; } }
+    }
+
+    // Invoked at most once per Releaser (guarded by its own Interlocked idempotency flag — see below).
+    // Releases the semaphore FIRST so a queued waiter can proceed immediately, then removes and disposes
+    // the entry under the lock only once its ref-count reaches zero. A queued waiter already bumped
+    // RefCount before it started waiting (AcquireAsync above), so a contended entry can never be evicted
+    // out from under a pending acquire.
+    private void Release(string systemRef, Entry entry)
+    {
+        entry.Semaphore.Release();
+
+        lock (_lock)
+        {
+            entry.RefCount--;
+            if (entry.RefCount == 0)
+            {
+                _entries.Remove(systemRef);
+                entry.Semaphore.Dispose();
+            }
+        }
+    }
+
+    private sealed class Entry
+    {
+        internal readonly SemaphoreSlim Semaphore = new(1, 1);
+        internal int RefCount;
+    }
+
+    // Idempotent by construction: `_released` flips from 0 to 1 via a single Interlocked.Exchange, so a
+    // second (or racing concurrent) Dispose observes a nonzero result and is a guaranteed no-op — a
+    // `using` nested inside a `try/finally`, or any other double-release shape, can never over-release the
+    // underlying semaphore and let two holders in at once.
+    private sealed class Releaser(MatchChannelRefGate gate, string systemRef, Entry entry) : IDisposable
+    {
+        private int _released;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _released, 1) != 0)
+            {
+                return;
+            }
+
+            gate.Release(systemRef, entry);
+        }
+    }
+}

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -373,8 +373,16 @@ public class MatchChannelService(
     /// <paramref name="name"/> is nullable (null ⇒ ref placeholder on create-on-demand). There is NO
     /// <c>focus</c> parameter — mm has never sent focus on any internal call, so adds pass
     /// <c>focus: false</c> to <see cref="AddMemberWithInvariant"/>, byte-identical to today's behavior.
+    /// <para>
+    /// RETURN VALUE (2026-08-05 fix wave, final review M2): <see cref="RosterAssertionOutcome"/> lets the
+    /// CALLER log the real outcome exactly once, instead of the controller's old unconditional "succeeded"
+    /// line coexisting with this method's own separate discard line — a contradictory Information pair on
+    /// precisely the storm paths (an mm retry storm, or mm asserting a frozen lobby) the staleness/detach
+    /// gates exist to absorb. The two discard paths below now log at Debug, not Information; the
+    /// controller owns the single Information-level outcome line.
+    /// </para>
     /// </summary>
-    public async Task ApplyRosterAssertion(
+    public async Task<RosterAssertionOutcome> ApplyRosterAssertion(
         string systemRef, string epoch, long seq, IReadOnlyList<string> members, string name, bool detached)
     {
         using var _ = await _refGate.AcquireAsync(systemRef);
@@ -387,8 +395,8 @@ public class MatchChannelService(
 
         if (channel.Detached)
         {
-            Log.Information("ApplyRosterAssertion: discarded — match channel {Ref} is detached (frozen)", systemRef);
-            return;
+            Log.Debug("ApplyRosterAssertion: discarded — match channel {Ref} is detached (frozen)", systemRef);
+            return RosterAssertionOutcome.DiscardedFrozen;
         }
 
         // Captured BEFORE the CAS call — the durable backstop below re-checks Detached and staleness
@@ -399,10 +407,10 @@ public class MatchChannelService(
 
         if (!await channelRepository.TryAdvanceAssertion(channel.Id, epoch, seq))
         {
-            Log.Information(
+            Log.Debug(
                 "ApplyRosterAssertion: discarded stale/duplicate assertion for match channel {Ref} (epoch {Epoch}, seq {Seq})",
                 systemRef, epoch, seq);
-            return;
+            return RosterAssertionOutcome.DiscardedStale;
         }
 
         if (storedEpoch != null && storedEpoch != epoch)
@@ -446,6 +454,8 @@ public class MatchChannelService(
             channel.Detached = true;
             Log.Information("ApplyRosterAssertion: match channel {Ref} detached (frozen) by final roster assertion", systemRef);
         }
+
+        return RosterAssertionOutcome.Applied;
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -448,14 +448,27 @@ public class MatchChannelService(
     /// once at boot under a fresh epoch. Every NON-DETACHED System+Match channel whose SystemRef is
     /// absent from <paramref name="liveLobbyRefs"/> is torn down (memberships deleted, ChannelRemoved
     /// pushed so stuck rows vanish from connected clients immediately, channel doc removed); the
-    /// channels that ARE listed are SPARED and re-anchored to the new epoch with the seq counter
-    /// reset to the 0 sentinel (plan D8), so mm's first assertion under the new epoch applies cleanly.
+    /// channels that ARE listed are SPARED and passed to <see cref="ChannelRepository.StampAssertionEpoch"/>,
+    /// which — CONDITIONALLY, only when the stored <c>AssertEpoch</c> differs from <paramref name="epoch"/>
+    /// (absent counts as different) — re-anchors the channel to the new epoch with the seq counter reset to
+    /// the 0 sentinel (plan D8), so mm's first assertion under the new epoch applies cleanly. A spared
+    /// channel already anchored to THIS sync's own epoch (created or asserted during this same boot, while
+    /// the sync itself was still retrying) is left entirely untouched by the re-stamp: resetting its seq
+    /// would re-open the duplicate-replay window for assertions already applied under this epoch (Task-4
+    /// review INFO-1).
     /// <para>DETACHED CHANNELS ARE EXCLUDED ENTIRELY — filtered server-side by
     /// <see cref="ChannelRepository.LoadNonDetachedMatchChannels"/>, so an in-game/post-game room is
     /// never loaded, never torn down, never re-stamped. Its 24h TTL owns it.</para>
-    /// <para>Each channel is processed under its OWN per-ref gate (never one global lock) and
-    /// RE-LOADED inside that gate before teardown, so a channel that was (re)created or detached
-    /// between the discovery scan and its turn is not torn down on stale information.</para>
+    /// <para>Each channel is processed under its OWN per-ref gate (never one global lock) and RE-LOADED
+    /// inside that gate before teardown, so the teardown/spare decision is always made on FRESHLY loaded
+    /// state: a channel deleted or detached between the discovery scan and its own turn is skipped
+    /// outright (never torn down on stale information), and a channel recreated in that window is judged
+    /// on its NEW document rather than the stale scan-time candidate — a recreated channel whose ref is
+    /// still absent from <paramref name="liveLobbyRefs"/> IS torn down; recreation does not spare it, it
+    /// just means the decision is made on fresh data instead of stale data.</para>
+    /// <para>Conversely, a channel created AFTER the discovery scan is not a candidate at all and is never
+    /// swept — by definition any lobby mm creates after boot is live under the new epoch, so it survives
+    /// to the next assertion or the 24h TTL (plan residual 4).</para>
     /// </summary>
     public async Task ApplyEpochSync(string epoch, IReadOnlyList<string> liveLobbyRefs)
     {

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -46,7 +46,11 @@ namespace W3ChampionsChatService.Internal;
 /// (<see cref="_refGate"/>) that every mutating match-channel path now acquires FIRST, and detach guards
 /// (plan D4) on the assertion and legacy delta paths. <see cref="CreateOrGet"/> gains OPTIONAL
 /// <c>epoch</c>/<c>seq</c>/<c>detached</c> parameters (plan D10) so a create can also participate in the
-/// (epoch, seq) staleness protocol and birth ladder-match channels already detached.
+/// (epoch, seq) staleness protocol and birth ladder-match channels already detached. The teardown body
+/// of <see cref="DeleteChannel"/> is extracted into the private <c>TearDownChannel</c>, shared by
+/// <see cref="ApplyEpochSync"/> — the startup mm-crash-recovery sweep (plan D8) that tears down every
+/// non-detached match channel absent from mm's freshly-booted <c>liveLobbyRefs</c> and re-anchors the
+/// channels it spares to the new epoch.
 /// </para>
 /// </summary>
 public class MatchChannelService(
@@ -310,6 +314,18 @@ public class MatchChannelService(
             return;
         }
 
+        await TearDownChannel(channel);
+    }
+
+    /// <summary>
+    /// The shared match-channel TEARDOWN, authoritative-DB-first then best-effort live pushes.
+    /// Used by BOTH the explicit DELETE endpoint and the startup epoch sync, so an mm-crash sweep is
+    /// byte-for-byte the same teardown an explicit mm teardown performs (and leaves no orphaned
+    /// membership rows for CleanupJobs.SweepOrphanedMemberships to find).
+    /// Callers MUST already hold the per-ref gate.
+    /// </summary>
+    private async Task TearDownChannel(ChatChannel channel)
+    {
         var memberBattleTags = (await membershipRepository.LoadForChannel(channel.Id))
             .Select(m => m.BattleTag)
             .ToList();
@@ -425,6 +441,60 @@ public class MatchChannelService(
             channel.Detached = true;
             Log.Information("ApplyRosterAssertion: match channel {Ref} detached (frozen) by final roster assertion", systemRef);
         }
+    }
+
+    /// <summary>
+    /// STARTUP EPOCH SYNC (2026-08-05 reconciliation spec §3) — mm asserts its authoritative world
+    /// once at boot under a fresh epoch. Every NON-DETACHED System+Match channel whose SystemRef is
+    /// absent from <paramref name="liveLobbyRefs"/> is torn down (memberships deleted, ChannelRemoved
+    /// pushed so stuck rows vanish from connected clients immediately, channel doc removed); the
+    /// channels that ARE listed are SPARED and re-anchored to the new epoch with the seq counter
+    /// reset to the 0 sentinel (plan D8), so mm's first assertion under the new epoch applies cleanly.
+    /// <para>DETACHED CHANNELS ARE EXCLUDED ENTIRELY — filtered server-side by
+    /// <see cref="ChannelRepository.LoadNonDetachedMatchChannels"/>, so an in-game/post-game room is
+    /// never loaded, never torn down, never re-stamped. Its 24h TTL owns it.</para>
+    /// <para>Each channel is processed under its OWN per-ref gate (never one global lock) and
+    /// RE-LOADED inside that gate before teardown, so a channel that was (re)created or detached
+    /// between the discovery scan and its turn is not torn down on stale information.</para>
+    /// </summary>
+    public async Task ApplyEpochSync(string epoch, IReadOnlyList<string> liveLobbyRefs)
+    {
+        // Refs are exact Mongo keys (unlike battleTags, which are the case-insensitive thing here) —
+        // Ordinal, not OrdinalIgnoreCase.
+        var live = new HashSet<string>(liveLobbyRefs, StringComparer.Ordinal);
+        var tornDown = 0;
+        var spared = 0;
+
+        foreach (var candidate in await channelRepository.LoadNonDetachedMatchChannels())
+        {
+            using var _ = await _refGate.AcquireAsync(candidate.SystemRef);
+
+            // RE-LOAD inside the gate: the discovery scan above ran outside any per-ref gate, so the
+            // candidate could have been torn down, recreated, or detached by another mutating call
+            // between the scan and this channel's turn — never act on stale information.
+            var channel = await channelRepository.LoadBySystemRef(SystemChannelKind.Match, candidate.SystemRef);
+            if (channel == null || channel.Detached)
+            {
+                continue;
+            }
+
+            if (live.Contains(channel.SystemRef))
+            {
+                await channelRepository.StampAssertionEpoch(channel.Id, epoch);
+                spared++;
+            }
+            else
+            {
+                await TearDownChannel(channel);
+                tornDown++;
+            }
+        }
+
+        // Unconditional — a boot-time convergence event is exactly what an operator wants in the log,
+        // including the healthy tornDown=0 case (mirrors the class's other Information-level summaries).
+        Log.Information(
+            "Epoch sync applied {Epoch} liveRefCount={LiveRefCount} tornDown={TornDown} spared={Spared}",
+            epoch, liveLobbyRefs.Count, tornDown, spared);
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
 using W3ChampionsChatService.Channels;
@@ -484,17 +485,39 @@ public class MatchChannelService(
     /// <para>Conversely, a channel created AFTER the discovery scan is not a candidate at all and is never
     /// swept — by definition any lobby mm creates after boot is live under the new epoch, so it survives
     /// to the next assertion or the 24h TTL (plan residual 4).</para>
+    /// <para>
+    /// CANCELLATION (2026-08-05 fix wave, final review H2): <paramref name="cancellationToken"/> — the
+    /// caller's <c>HttpContext.RequestAborted</c> — is checked at the TOP of each loop iteration, i.e.
+    /// BETWEEN channels, never mid-<see cref="TearDownChannel"/>. mm's client timeout (1.5s) is far
+    /// shorter than a large sweep can take, so without this an aborted mm attempt would leave the sweep
+    /// running headless server-side while mm's retry launches ANOTHER overlapping sweep on top of it. A
+    /// cancelled sweep is SAFE: every channel already processed made durable progress (teardown and
+    /// re-stamp are both terminal, idempotent writes), the abort is logged with a partial
+    /// <c>tornDown</c>/<c>spared</c> summary, and mm's next attempt resumes against a strictly smaller
+    /// candidate set — no data is left in a worse state than before the call, it just takes another
+    /// attempt (or several) to fully converge.
+    /// </para>
     /// </summary>
-    public async Task ApplyEpochSync(string epoch, IReadOnlyList<string> liveLobbyRefs)
+    public async Task ApplyEpochSync(string epoch, IReadOnlyList<string> liveLobbyRefs, CancellationToken cancellationToken = default)
     {
         // Refs are exact Mongo keys (unlike battleTags, which are the case-insensitive thing here) —
         // Ordinal, not OrdinalIgnoreCase.
         var live = new HashSet<string>(liveLobbyRefs, StringComparer.Ordinal);
         var tornDown = 0;
         var spared = 0;
+        var aborted = false;
 
         foreach (var candidate in await channelRepository.LoadNonDetachedMatchChannels())
         {
+            // Check-and-bail BETWEEN channels (H2) — never mid-teardown. Each channel already processed
+            // this call made durable, terminal progress, so bailing here is safe: nothing is left
+            // half-mutated, and the next attempt's candidate set is strictly smaller.
+            if (cancellationToken.IsCancellationRequested)
+            {
+                aborted = true;
+                break;
+            }
+
             using var _ = await _refGate.AcquireAsync(candidate.SystemRef);
 
             // RE-LOAD inside the gate: the discovery scan above ran outside any per-ref gate, so the
@@ -521,9 +544,11 @@ public class MatchChannelService(
 
         // Unconditional — a boot-time convergence event is exactly what an operator wants in the log,
         // including the healthy tornDown=0 case (mirrors the class's other Information-level summaries).
+        // aborted=true marks a PARTIAL summary (H2) — the sweep was cut short by the caller's own
+        // cancellation, not a failure; the counts reflect exactly how much durable progress landed.
         Log.Information(
-            "Epoch sync applied {Epoch} liveRefCount={LiveRefCount} tornDown={TornDown} spared={Spared}",
-            epoch, liveLobbyRefs.Count, tornDown, spared);
+            "Epoch sync applied {Epoch} liveRefCount={LiveRefCount} tornDown={TornDown} spared={Spared} aborted={Aborted}",
+            epoch, liveLobbyRefs.Count, tornDown, spared, aborted);
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -463,13 +463,24 @@ public class MatchChannelService(
     /// <para>DETACHED CHANNELS ARE EXCLUDED ENTIRELY — filtered server-side by
     /// <see cref="ChannelRepository.LoadNonDetachedMatchChannels"/>, so an in-game/post-game room is
     /// never loaded, never torn down, never re-stamped. Its 24h TTL owns it.</para>
+    /// <para>UNSTAMPED CHANNELS ARE EXCLUDED ENTIRELY TOO (2026-08-05 fix wave, final review H1, plan D8
+    /// amendment): the same query additionally requires <c>AssertEpoch</c> to exist — only a channel that
+    /// has participated in the assertion protocol at least once (created with epoch/seq, or asserted via
+    /// the roster endpoint) is a sweep candidate. A channel minted only by the deprecated delta path
+    /// during the transition window has no stamp at all and is invisible to this sweep; it falls to its
+    /// own 24h creation-anchored TTL instead. This is what makes the very first epoch sync after mm's own
+    /// deploy safe against the (measured, ~4,900/day) non-detached ladder-match channels that already
+    /// exist in the database at cutover — that first sync's candidate set does not include them, so it
+    /// cannot tear them down, with no runbook or deploy-order choreography required beyond "chat-service
+    /// ships first".</para>
     /// <para>Each channel is processed under its OWN per-ref gate (never one global lock) and RE-LOADED
     /// inside that gate before teardown, so the teardown/spare decision is always made on FRESHLY loaded
-    /// state: a channel deleted or detached between the discovery scan and its own turn is skipped
-    /// outright (never torn down on stale information), and a channel recreated in that window is judged
-    /// on its NEW document rather than the stale scan-time candidate — a recreated channel whose ref is
-    /// still absent from <paramref name="liveLobbyRefs"/> IS torn down; recreation does not spare it, it
-    /// just means the decision is made on fresh data instead of stale data.</para>
+    /// state: a channel deleted, detached, OR recreated-but-unstamped between the discovery scan and its
+    /// own turn is skipped outright (never torn down on stale information), and a channel recreated in
+    /// that window WITH a stamp is judged on its NEW document rather than the stale scan-time candidate —
+    /// a recreated, still-stamped channel whose ref is still absent from <paramref name="liveLobbyRefs"/>
+    /// IS torn down; recreation does not spare it, it just means the decision is made on fresh data
+    /// instead of stale data.</para>
     /// <para>Conversely, a channel created AFTER the discovery scan is not a candidate at all and is never
     /// swept — by definition any lobby mm creates after boot is live under the new epoch, so it survives
     /// to the next assertion or the 24h TTL (plan residual 4).</para>
@@ -487,10 +498,11 @@ public class MatchChannelService(
             using var _ = await _refGate.AcquireAsync(candidate.SystemRef);
 
             // RE-LOAD inside the gate: the discovery scan above ran outside any per-ref gate, so the
-            // candidate could have been torn down, recreated, or detached by another mutating call
-            // between the scan and this channel's turn — never act on stale information.
+            // candidate could have been torn down, recreated, detached, or (H1) recreated WITHOUT a stamp
+            // by another mutating call between the scan and this channel's turn — never act on stale
+            // information. An unstamped reload is treated exactly like a detached one: skip outright.
             var channel = await channelRepository.LoadBySystemRef(SystemChannelKind.Match, candidate.SystemRef);
-            if (channel == null || channel.Detached)
+            if (channel == null || channel.Detached || channel.AssertEpoch == null)
             {
                 continue;
             }

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -117,7 +117,11 @@ public class MatchChannelService(
         string epoch, long? seq, bool detached)
     {
         var now = timeProvider.GetUtcNow().UtcDateTime;
-        var trimmedName = name.Trim();
+        // 2026-08-05 fix wave (final review C1): name is nullable — mirrors ApplyRosterAssertion's own
+        // ref-placeholder fallback (below) so an empty-after-trim / omitted name never blocks creation.
+        // The controller is the only production caller and now normalizes (never rejects) before calling
+        // in, but this fallback keeps CreateOrGet itself correct independent of that caller behavior.
+        var trimmedName = string.IsNullOrWhiteSpace(name) ? systemRef : name.Trim();
 
         var channel = await channelRepository.FindOrCreateSystem(SystemChannelKind.Match, systemRef, trimmedName, now);
 

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -15,11 +15,12 @@ namespace W3ChampionsChatService.Internal;
 /// <summary>
 /// C7 Tasks 6-8 — the match-channel domain core the /internal/* match endpoints drive. Owns
 /// <see cref="CreateOrGet"/> (idempotent System+Match find-or-create + display-name backfill, the
-/// <c>PUT /internal/channels/{ref}</c>-style upsert), <see cref="ApplyMembersDelta"/> (the
-/// <c>PUT /internal/channels/{ref}/members</c> delta — tolerant of arriving before the create),
-/// <see cref="DeleteChannel"/> (the <c>DELETE /internal/channels/{ref}</c> hard-teardown — tolerant of
-/// arriving before the create too), and the shared <see cref="AddMemberWithInvariant"/> that enforces the
-/// ONE-MATCH-CHANNEL-PER-USER invariant — every add path (both public add methods) reuses it.
+/// <c>PUT /internal/channels/{ref}</c>-style upsert), <see cref="ApplyRosterAssertion"/> (the
+/// <c>PUT /internal/channels/{ref}/roster</c> authoritative full-set membership assertion — tolerant of
+/// arriving before the create), <see cref="DeleteChannel"/> (the <c>DELETE /internal/channels/{ref}</c>
+/// hard-teardown — tolerant of arriving before the create too), and the shared
+/// <see cref="AddMemberWithInvariant"/> that enforces the ONE-MATCH-CHANNEL-PER-USER invariant — every
+/// add path (both public add methods) reuses it.
 /// <para>
 /// Singleton (registered in <see cref="Startup"/>): it holds no per-call state. Its
 /// <see cref="ChannelRepository"/>/<see cref="MembershipRepository"/>/<see cref="MessageRepository"/> deps
@@ -50,9 +51,9 @@ namespace W3ChampionsChatService.Internal;
 /// </para>
 /// <para>
 /// 2026-08-05 RECONCILIATION (plan D5, D10): adds <see cref="ApplyRosterAssertion"/> — the authoritative
-/// full-set protocol that supersedes <see cref="ApplyMembersDelta"/> — plus a <see cref="MatchChannelRefGate"/>
+/// full-set membership protocol mm drives — plus a <see cref="MatchChannelRefGate"/>
 /// (<see cref="_refGate"/>) that every mutating match-channel path IN THIS CLASS now acquires FIRST, and
-/// detach guards (plan D4) on the assertion and legacy delta paths. TWO DOCUMENTED EXCEPTIONS (2026-08-05
+/// a detach guard (plan D4) on the assertion path. TWO DOCUMENTED EXCEPTIONS (2026-08-05
 /// fix wave, final review H4 + M1): <c>ChatHub.LeaveChannel</c> (<c>Chats/ChatHub.Channels.cs</c>) deletes
 /// a membership row directly with no channel-type guard and no gate at all — it lives OUTSIDE this class
 /// and races <see cref="ApplyRosterAssertion"/>'s diff, a divergence bounded by the next assertion
@@ -65,8 +66,8 @@ namespace W3ChampionsChatService.Internal;
 /// <c>TearDownChannel</c>, shared by <see cref="ApplyEpochSync"/> — the startup mm-crash-recovery sweep
 /// (plan D8) that tears down every non-detached, assertion-stamped match channel absent from mm's
 /// freshly-booted <c>liveLobbyRefs</c> and re-anchors the channels it spares to the new epoch (an
-/// UNSTAMPED legacy/transition channel is excluded from the sweep entirely and falls to its own 24h TTL
-/// instead — 2026-08-05 fix wave, final review H1).
+/// UNSTAMPED channel — created without <c>epoch</c>/<c>seq</c> and never asserted — is excluded from the
+/// sweep entirely and falls to its own 24h TTL instead — 2026-08-05 fix wave, final review H1).
 /// </para>
 /// </summary>
 public class MatchChannelService(
@@ -230,72 +231,6 @@ public class MatchChannelService(
     }
 
     /// <summary>
-    /// <c>PUT /internal/channels/{ref}/members</c> domain logic (C7 Task 7) — applies an mm-driven
-    /// membership delta to the System+Match channel keyed by <paramref name="systemRef"/>, tolerant of the
-    /// delta arriving BEFORE the channel's own create (M1 — never a hard 404).
-    /// <list type="number">
-    /// <item>CREATE-ON-DEMAND (§3.3): if no channel exists yet for <paramref name="systemRef"/>, find-or-create
-    /// a shell via <see cref="ChannelRepository.FindOrCreateSystem"/> with a PLACEHOLDER name equal to the ref
-    /// itself. The shell's 24h expiry is anchored to its OWN creation time (set by <c>FindOrCreateSystem</c>
-    /// via <c>$setOnInsert</c>); a later real <see cref="CreateOrGet"/> backfills the display name and — per
-    /// that method's own idempotent $setOnInsert semantics — does NOT reset this expiry.</item>
-    /// <item><paramref name="add"/> is processed FIRST, each battleTag via the shared
-    /// <see cref="AddMemberWithInvariant"/> — so the one-match-channel-per-user invariant (swap) and the
-    /// focus-hinted <c>ChannelAdded</c> push fire on this path exactly as they do from <see cref="CreateOrGet"/>.</item>
-    /// <item><paramref name="remove"/> is processed AFTER: per battleTag, <see cref="MembershipRepository.Load"/>
-    /// — ABSENT is a silent no-op (no push, mm's delta can legitimately race a membership that already left);
-    /// PRESENT is <see cref="MembershipRepository.Delete"/> then <see cref="FanOutEngine.PushChannelRemoved"/>,
-    /// whose <see cref="FanOut.FocusRegistry.Unfocus"/> tail IS the server force-unfocus of the removed user's
-    /// connection (acceptance 4).</item>
-    /// </list>
-    /// A battleTag appearing in BOTH lists ends up REMOVED — adds run before removes, so this is
-    /// deterministic even though mm never legitimately sends such an overlapping delta.
-    /// <para>
-    /// DETACH FREEZE (2026-08-05 reconciliation spec, plan D4): if the resolved channel is already
-    /// <see cref="ChatChannel.Detached"/>, the whole delta is discarded (logged once at Information) —
-    /// membership stays frozen regardless of which protocol (assertion or legacy delta) asks.
-    /// </para>
-    /// </summary>
-    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): the DELTA path. mm keeps
-    // sending deltas until its own deploy; DELETE THIS ENTIRE MEMBER in the mm-deploy-confirmed
-    // cleanup PR — see docs plan Task 6.
-    public async Task ApplyMembersDelta(string systemRef, IReadOnlyList<string> add, IReadOnlyList<string> remove, bool focus)
-    {
-        using var _ = await _refGate.AcquireAsync(systemRef);
-        await ApplyMembersDeltaLocked(systemRef, add, remove, focus);
-    }
-
-    private async Task ApplyMembersDeltaLocked(string systemRef, IReadOnlyList<string> add, IReadOnlyList<string> remove, bool focus)
-    {
-        var now = timeProvider.GetUtcNow().UtcDateTime;
-
-        var channel = await channelRepository.LoadBySystemRef(SystemChannelKind.Match, systemRef)
-            ?? await channelRepository.FindOrCreateSystem(SystemChannelKind.Match, systemRef, systemRef, now);
-
-        if (channel.Detached)
-        {
-            Log.Information("ApplyMembersDelta: discarded — match channel {Ref} is detached (frozen)", systemRef);
-            return;
-        }
-
-        foreach (var battleTag in add)
-        {
-            await AddMemberWithInvariant(channel, battleTag, focus, now);
-        }
-
-        foreach (var battleTag in remove)
-        {
-            if (await membershipRepository.Load(channel.Id, battleTag) == null)
-            {
-                continue;
-            }
-
-            await membershipRepository.Delete(channel.Id, battleTag);
-            await fanOutEngine.PushChannelRemoved(channel.Id, battleTag);
-        }
-    }
-
-    /// <summary>
     /// <c>DELETE /internal/channels/{ref}</c> domain logic (C7 Task 8) — hard-tears-down the System+Match
     /// channel keyed by <paramref name="systemRef"/>: its membership rows AND its messages (a HARD purge,
     /// distinct from moderation's TTL-only soft-delete — see <see cref="MessageRepository.DeleteAllForChannel"/>),
@@ -315,9 +250,9 @@ public class MatchChannelService(
     /// </list>
     /// <para>
     /// NOT DETACH-GUARDED, DELIBERATELY (2026-08-05 reconciliation spec, plan D4): unlike
-    /// <see cref="ApplyRosterAssertion"/> and <see cref="ApplyMembersDelta"/>, an explicit DELETE still
-    /// tears down an already-detached channel — detach freezes ASSERTIONS and SWEEPS, not an explicit
-    /// authoritative teardown command. If mm sends one after detaching a channel, it means it.
+    /// <see cref="ApplyRosterAssertion"/>, an explicit DELETE still tears down an already-detached
+    /// channel — detach freezes ASSERTIONS and SWEEPS, not an explicit authoritative teardown command.
+    /// If mm sends one after detaching a channel, it means it.
     /// </para>
     /// </summary>
     public async Task DeleteChannel(string systemRef)
@@ -361,16 +296,16 @@ public class MatchChannelService(
     }
 
     /// <summary>
-    /// The AUTHORITATIVE full-set roster assertion (2026-08-05 reconciliation spec §1) — replaces the
-    /// delta protocol. mm sends the lobby's COMPLETE member set for <paramref name="systemRef"/>; this
-    /// converges the stored membership rows onto it, idempotently.
+    /// The AUTHORITATIVE full-set roster assertion (2026-08-05 reconciliation spec §1) — the sole
+    /// membership-mutation protocol mm drives. mm sends the lobby's COMPLETE member set for
+    /// <paramref name="systemRef"/>; this converges the stored membership rows onto it, idempotently.
     /// <list type="number">
-    /// <item>Serialize on <paramref name="systemRef"/> (plan D5) so two in-flight assertions — or an
-    /// assertion racing a transition-era delta — cannot interleave their diffs.</item>
+    /// <item>Serialize on <paramref name="systemRef"/> (plan D5) so two in-flight assertions for the same
+    /// ref cannot interleave their diffs.</item>
     /// <item>CREATE-ON-DEMAND: an assertion arriving before mm's create POST — or after an epoch sync
     /// tore the channel down (the boot race) — find-or-creates the shell, using <paramref name="name"/>
     /// when provided (so a recreated room never displays its nanoid ref) and the ref as placeholder
-    /// otherwise, exactly like <see cref="ApplyMembersDelta"/> (never a 404). On an EXISTING channel
+    /// otherwise (never a 404). On an EXISTING channel
     /// <paramref name="name"/> is ignored — CreateOrGet remains the name authority.</item>
     /// <item>DETACH FREEZE (plan D4): a detached channel discards the assertion outright.</item>
     /// <item>STALENESS GATE (plan D3): <see cref="ChannelRepository.TryAdvanceAssertion"/> admits and
@@ -381,7 +316,7 @@ public class MatchChannelService(
     /// <item>DIFF, case-insensitively (stored battleTags are LOWERCASED, mm sends JWT casing): missing
     /// => <c>AddMemberWithInvariant</c> (keeps the one-match-channel-per-user eviction invariant);
     /// extra => Delete then <c>PushChannelRemoved</c> (whose FocusRegistry.Unfocus tail force-unfocuses
-    /// the removed user). Adds run before removes, mirroring <see cref="ApplyMembersDelta"/>.</item>
+    /// the removed user). Adds run before removes.</item>
     /// <item>DETACH LAST: when <paramref name="detached"/>, the final member set is applied FIRST, then
     /// the channel is marked detached — so the freeze rule never has to special-case its own trigger.</item>
     /// </list>
@@ -451,7 +386,7 @@ public class MatchChannelService(
             .ToList();
         var extra = current.Where(row => !asserted.Contains(row.BattleTag)).ToList();
 
-        // Adds before removes — mirrors ApplyMembersDelta.
+        // Adds before removes.
         foreach (var battleTag in missing)
         {
             await AddMemberWithInvariant(channel, battleTag, focus: false, now);
@@ -492,9 +427,9 @@ public class MatchChannelService(
     /// <para>UNSTAMPED CHANNELS ARE EXCLUDED ENTIRELY TOO (2026-08-05 fix wave, final review H1, plan D8
     /// amendment): the same query additionally requires <c>AssertEpoch</c> to exist — only a channel that
     /// has participated in the assertion protocol at least once (created with epoch/seq, or asserted via
-    /// the roster endpoint) is a sweep candidate. A channel minted only by the deprecated delta path
-    /// during the transition window has no stamp at all and is invisible to this sweep; it falls to its
-    /// own 24h creation-anchored TTL instead. This is what makes the very first epoch sync after mm's own
+    /// the roster endpoint) is a sweep candidate. A channel created via <c>POST /internal/channels</c>
+    /// without epoch/seq and never since asserted has no stamp at all and is invisible to this sweep; it
+    /// falls to its own 24h creation-anchored TTL instead. This is what makes the very first epoch sync after mm's own
     /// deploy safe against the (measured, ~4,900/day) non-detached ladder-match channels that already
     /// exist in the database at cutover — that first sync's candidate set does not include them, so it
     /// cannot tear them down, with no runbook or deploy-order choreography required beyond "chat-service

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Serilog;
 using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
@@ -39,6 +40,14 @@ namespace W3ChampionsChatService.Internal;
 /// within a single <see cref="AddMemberWithInvariant"/> call, <c>ChannelRemoved(old)</c> is emitted STRICTLY
 /// BEFORE <c>ChannelAdded(new)</c>, so a user moving A→B never transiently sees both channels.
 /// </para>
+/// <para>
+/// 2026-08-05 RECONCILIATION (plan D5, D10): adds <see cref="ApplyRosterAssertion"/> — the authoritative
+/// full-set protocol that supersedes <see cref="ApplyMembersDelta"/> — plus a <see cref="MatchChannelRefGate"/>
+/// (<see cref="_refGate"/>) that every mutating match-channel path now acquires FIRST, and detach guards
+/// (plan D4) on the assertion and legacy delta paths. <see cref="CreateOrGet"/> gains OPTIONAL
+/// <c>epoch</c>/<c>seq</c>/<c>detached</c> parameters (plan D10) so a create can also participate in the
+/// (epoch, seq) staleness protocol and birth ladder-match channels already detached.
+/// </para>
 /// </summary>
 public class MatchChannelService(
     ChannelRepository channelRepository,
@@ -47,6 +56,13 @@ public class MatchChannelService(
     FanOutEngine fanOutEngine,
     TimeProvider timeProvider)
 {
+    // 2026-08-05 reconciliation spec, plan D5: serializes every mutating operation on a single match
+    // channel by its systemRef — see MatchChannelRefGate's own doc for the full "why". Owned PRIVATELY
+    // (not a constructor parameter) so Startup.cs and every existing `new MatchChannelService(...)` test
+    // call site stay unchanged; InternalsVisibleTo still lets MatchChannelRefGateTests exercise the gate
+    // type directly, and this class's own tests exercise it indirectly via the public methods below.
+    private readonly MatchChannelRefGate _refGate = new();
+
     /// <summary>
     /// Idempotent create-or-get of the System+Match channel keyed by <paramref name="systemRef"/>, then adds
     /// every <paramref name="members"/> battleTag under the one-match-channel-per-user invariant. Safe to call
@@ -62,8 +78,39 @@ public class MatchChannelService(
     /// <item>Add each member via <see cref="AddMemberWithInvariant"/> — a duplicate POST that lists extra members
     /// treats the already-present ones as no-ops and only pushes/persists the genuinely new ones (late repair).</item>
     /// </list>
+    /// <para>
+    /// 2026-08-05 RECONCILIATION (plan D10) — three OPTIONAL trailing parameters, all defaulted so every
+    /// existing caller compiles and behaves byte-for-byte unchanged:
+    /// <list type="bullet">
+    /// <item><paramref name="epoch"/>/<paramref name="seq"/> (must arrive TOGETHER): when present,
+    /// <see cref="ChannelRepository.TryAdvanceAssertion"/> is called to stamp (epoch, seq) — REGARDLESS of
+    /// the channel's current <see cref="ChatChannel.Detached"/> state (a no-advance there is harmless; the
+    /// CAS's own Detached filter and staleness rules already make it a safe no-op). The MEMBER-ADD GATE this
+    /// enables is deliberately WEAKER than the assertion staleness gate: adds are skipped iff the channel is
+    /// (already) detached, OR the stamped state for this epoch is STRICTLY ahead of this call's seq — an
+    /// EQUAL stored seq still PROCEEDS with the adds (it means this exact call's own earlier attempt already
+    /// stamped but crashed before adding, and <see cref="AddMemberWithInvariant"/> is idempotent). This is
+    /// what stops a late-landing create retry from resurrecting a member a newer roster assertion already
+    /// removed.</item>
+    /// <item><paramref name="detached"/>: when true, AFTER the member adds above,
+    /// <see cref="ChannelRepository.SetDetached"/> freezes the room. Ladder-match channels are born detached
+    /// — they are never in mm's <c>liveLobbyRefs</c> (that registry only holds custom lobbies), so without
+    /// birth-detach the FIRST epoch sync after any mm restart would tear down every in-progress ladder
+    /// game's chat. Idempotent: a retried detached create with the same members changes nothing further.</item>
+    /// </list>
+    /// </para>
     /// </summary>
-    public async Task<ChatChannel> CreateOrGet(string systemRef, string name, IReadOnlyList<string> members, bool focus)
+    public async Task<ChatChannel> CreateOrGet(
+        string systemRef, string name, IReadOnlyList<string> members, bool focus,
+        string epoch = null, long? seq = null, bool detached = false)
+    {
+        using var _ = await _refGate.AcquireAsync(systemRef);
+        return await CreateOrGetLocked(systemRef, name, members, focus, epoch, seq, detached);
+    }
+
+    private async Task<ChatChannel> CreateOrGetLocked(
+        string systemRef, string name, IReadOnlyList<string> members, bool focus,
+        string epoch, long? seq, bool detached)
     {
         var now = timeProvider.GetUtcNow().UtcDateTime;
         var trimmedName = name.Trim();
@@ -79,9 +126,33 @@ public class MatchChannelService(
             channel.Name = trimmedName;
         }
 
-        foreach (var battleTag in members)
+        // D10 stamping — called REGARDLESS of Detached (see the method doc); the CAS itself is a safe no-op
+        // on a detached channel or a stale (epoch, seq).
+        if (epoch != null && seq.HasValue)
         {
-            await AddMemberWithInvariant(channel, battleTag, focus, now);
+            await channelRepository.TryAdvanceAssertion(channel.Id, epoch, seq.Value);
+        }
+
+        // D10 member-add gate — deliberately WEAKER than the assertion staleness gate (see method doc):
+        // skip iff already detached, OR this epoch's stamped seq is STRICTLY ahead of this call's seq.
+        // Read from `channel` as returned by FindOrCreateSystem above — for an EXISTING channel that is
+        // exactly a fresh load of current state; the TryAdvanceAssertion call above never mutates it.
+        var skipAdds = channel.Detached
+            || (epoch != null && seq.HasValue && channel.AssertEpoch == epoch && channel.AssertSeq > seq.Value);
+
+        if (!skipAdds)
+        {
+            foreach (var battleTag in members)
+            {
+                await AddMemberWithInvariant(channel, battleTag, focus, now);
+            }
+        }
+
+        if (detached)
+        {
+            await channelRepository.SetDetached(channel.Id);
+            channel.Detached = true;
+            Log.Information("CreateOrGet: match channel {Ref} marked detached", systemRef);
         }
 
         return channel;
@@ -152,13 +223,33 @@ public class MatchChannelService(
     /// </list>
     /// A battleTag appearing in BOTH lists ends up REMOVED — adds run before removes, so this is
     /// deterministic even though mm never legitimately sends such an overlapping delta.
+    /// <para>
+    /// DETACH FREEZE (2026-08-05 reconciliation spec, plan D4): if the resolved channel is already
+    /// <see cref="ChatChannel.Detached"/>, the whole delta is discarded (logged once at Information) —
+    /// membership stays frozen regardless of which protocol (assertion or legacy delta) asks.
+    /// </para>
     /// </summary>
+    // TRANSITION (2026-08-05 reconciliation spec §"Verification gates"): the DELTA path. mm keeps
+    // sending deltas until its own deploy; DELETE THIS ENTIRE MEMBER in the mm-deploy-confirmed
+    // cleanup PR — see docs plan Task 6.
     public async Task ApplyMembersDelta(string systemRef, IReadOnlyList<string> add, IReadOnlyList<string> remove, bool focus)
+    {
+        using var _ = await _refGate.AcquireAsync(systemRef);
+        await ApplyMembersDeltaLocked(systemRef, add, remove, focus);
+    }
+
+    private async Task ApplyMembersDeltaLocked(string systemRef, IReadOnlyList<string> add, IReadOnlyList<string> remove, bool focus)
     {
         var now = timeProvider.GetUtcNow().UtcDateTime;
 
         var channel = await channelRepository.LoadBySystemRef(SystemChannelKind.Match, systemRef)
             ?? await channelRepository.FindOrCreateSystem(SystemChannelKind.Match, systemRef, systemRef, now);
+
+        if (channel.Detached)
+        {
+            Log.Information("ApplyMembersDelta: discarded — match channel {Ref} is detached (frozen)", systemRef);
+            return;
+        }
 
         foreach (var battleTag in add)
         {
@@ -195,8 +286,20 @@ public class MatchChannelService(
     /// member — the in-memory session/focus/online-member registries are unaffected by the DB deletes above,
     /// and the push itself no-ops for a member who is offline.</item>
     /// </list>
+    /// <para>
+    /// NOT DETACH-GUARDED, DELIBERATELY (2026-08-05 reconciliation spec, plan D4): unlike
+    /// <see cref="ApplyRosterAssertion"/> and <see cref="ApplyMembersDelta"/>, an explicit DELETE still
+    /// tears down an already-detached channel — detach freezes ASSERTIONS and SWEEPS, not an explicit
+    /// authoritative teardown command. If mm sends one after detaching a channel, it means it.
+    /// </para>
     /// </summary>
     public async Task DeleteChannel(string systemRef)
+    {
+        using var _ = await _refGate.AcquireAsync(systemRef);
+        await DeleteChannelLocked(systemRef);
+    }
+
+    private async Task DeleteChannelLocked(string systemRef)
     {
         var channel = await channelRepository.LoadBySystemRef(SystemChannelKind.Match, systemRef);
         if (channel == null)
@@ -215,6 +318,105 @@ public class MatchChannelService(
         foreach (var battleTag in memberBattleTags)
         {
             await fanOutEngine.PushChannelRemoved(channel.Id, battleTag);
+        }
+    }
+
+    /// <summary>
+    /// The AUTHORITATIVE full-set roster assertion (2026-08-05 reconciliation spec §1) — replaces the
+    /// delta protocol. mm sends the lobby's COMPLETE member set for <paramref name="systemRef"/>; this
+    /// converges the stored membership rows onto it, idempotently.
+    /// <list type="number">
+    /// <item>Serialize on <paramref name="systemRef"/> (plan D5) so two in-flight assertions — or an
+    /// assertion racing a transition-era delta — cannot interleave their diffs.</item>
+    /// <item>CREATE-ON-DEMAND: an assertion arriving before mm's create POST — or after an epoch sync
+    /// tore the channel down (the boot race) — find-or-creates the shell, using <paramref name="name"/>
+    /// when provided (so a recreated room never displays its nanoid ref) and the ref as placeholder
+    /// otherwise, exactly like <see cref="ApplyMembersDelta"/> (never a 404). On an EXISTING channel
+    /// <paramref name="name"/> is ignored — CreateOrGet remains the name authority.</item>
+    /// <item>DETACH FREEZE (plan D4): a detached channel discards the assertion outright.</item>
+    /// <item>STALENESS GATE (plan D3): <see cref="ChannelRepository.TryAdvanceAssertion"/> admits and
+    /// stamps (epoch, seq) atomically; a false return means stale/duplicate/reordered — DISCARD, and
+    /// return WITHOUT touching membership. A DIFFERENT stored epoch is anomalous but accepted (a lobby
+    /// lives within one mm epoch) — logged Warning; see that method's doc for why discarding would
+    /// permanently wedge the channel.</item>
+    /// <item>DIFF, case-insensitively (stored battleTags are LOWERCASED, mm sends JWT casing): missing
+    /// => <c>AddMemberWithInvariant</c> (keeps the one-match-channel-per-user eviction invariant);
+    /// extra => Delete then <c>PushChannelRemoved</c> (whose FocusRegistry.Unfocus tail force-unfocuses
+    /// the removed user). Adds run before removes, mirroring <see cref="ApplyMembersDelta"/>.</item>
+    /// <item>DETACH LAST: when <paramref name="detached"/>, the final member set is applied FIRST, then
+    /// the channel is marked detached — so the freeze rule never has to special-case its own trigger.</item>
+    /// </list>
+    /// <paramref name="name"/> is nullable (null ⇒ ref placeholder on create-on-demand). There is NO
+    /// <c>focus</c> parameter — mm has never sent focus on any internal call, so adds pass
+    /// <c>focus: false</c> to <see cref="AddMemberWithInvariant"/>, byte-identical to today's behavior.
+    /// </summary>
+    public async Task ApplyRosterAssertion(
+        string systemRef, string epoch, long seq, IReadOnlyList<string> members, string name, bool detached)
+    {
+        using var _ = await _refGate.AcquireAsync(systemRef);
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var trimmedName = string.IsNullOrWhiteSpace(name) ? systemRef : name.Trim();
+
+        var channel = await channelRepository.LoadBySystemRef(SystemChannelKind.Match, systemRef)
+            ?? await channelRepository.FindOrCreateSystem(SystemChannelKind.Match, systemRef, trimmedName, now);
+
+        if (channel.Detached)
+        {
+            Log.Information("ApplyRosterAssertion: discarded — match channel {Ref} is detached (frozen)", systemRef);
+            return;
+        }
+
+        // Captured BEFORE the CAS call — the durable backstop below re-checks Detached and staleness
+        // atomically, but the anomalous-epoch-mismatch Warning (D3c) needs the PRE-CAS stored epoch to
+        // tell "no epoch stored yet" (rule a, not anomalous) apart from "a genuinely different epoch"
+        // (rule c, anomalous) — TryAdvanceAssertion's own return value can't distinguish the two.
+        var storedEpoch = channel.AssertEpoch;
+
+        if (!await channelRepository.TryAdvanceAssertion(channel.Id, epoch, seq))
+        {
+            Log.Information(
+                "ApplyRosterAssertion: discarded stale/duplicate assertion for match channel {Ref} (epoch {Epoch}, seq {Seq})",
+                systemRef, epoch, seq);
+            return;
+        }
+
+        if (storedEpoch != null && storedEpoch != epoch)
+        {
+            Log.Warning(
+                "ApplyRosterAssertion: anomalous epoch mismatch for match channel {Ref} — re-anchored from stored epoch {StoredEpoch} to incoming {IncomingEpoch}",
+                systemRef, storedEpoch, epoch);
+        }
+
+        var asserted = new HashSet<string>(members, StringComparer.OrdinalIgnoreCase);
+        var current = await membershipRepository.LoadForChannel(channel.Id);
+
+        // Missing/extra are computed case-insensitively (stored battleTags are lowercased, mm sends JWT
+        // casing) — a case-only difference between the stored row and the asserted tag must never read as
+        // a remove+add churn. `missing` preserves mm's incoming list ORDER (not the set) for deterministic
+        // add sequencing.
+        var missing = members
+            .Where(m => !current.Any(row => string.Equals(row.BattleTag, m, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+        var extra = current.Where(row => !asserted.Contains(row.BattleTag)).ToList();
+
+        // Adds before removes — mirrors ApplyMembersDelta.
+        foreach (var battleTag in missing)
+        {
+            await AddMemberWithInvariant(channel, battleTag, focus: false, now);
+        }
+
+        foreach (var row in extra)
+        {
+            await membershipRepository.Delete(channel.Id, row.BattleTag);
+            await fanOutEngine.PushChannelRemoved(channel.Id, row.BattleTag);
+        }
+
+        if (detached)
+        {
+            await channelRepository.SetDetached(channel.Id);
+            channel.Detached = true;
+            Log.Information("ApplyRosterAssertion: match channel {Ref} detached (frozen) by final roster assertion", systemRef);
         }
     }
 

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -137,6 +137,9 @@ public class MatchChannelService(
         // skip iff already detached, OR this epoch's stamped seq is STRICTLY ahead of this call's seq.
         // Read from `channel` as returned by FindOrCreateSystem above — for an EXISTING channel that is
         // exactly a fresh load of current state; the TryAdvanceAssertion call above never mutates it.
+        // NOTE (fix round 1, review r1 Minor-3): deliberately NOT the literal "if (channel.Detached) return
+        // channel;" early-return shape from Task 3 step 4 — D10 requires the TryAdvanceAssertion stamp
+        // attempt above to run regardless of Detached, which an early return before it would prevent.
         var skipAdds = channel.Detached
             || (epoch != null && seq.HasValue && channel.AssertEpoch == epoch && channel.AssertSeq > seq.Value);
 
@@ -394,7 +397,11 @@ public class MatchChannelService(
         // Missing/extra are computed case-insensitively (stored battleTags are lowercased, mm sends JWT
         // casing) — a case-only difference between the stored row and the asserted tag must never read as
         // a remove+add churn. `missing` preserves mm's incoming list ORDER (not the set) for deterministic
-        // add sequencing.
+        // add sequencing. NOTE (fix round 1, review r1 Major-1 residual): if OrdinalIgnoreCase were ever
+        // dropped here, no test would fail — AddMemberWithInvariant's normalizing membershipRepository.Load
+        // gate (:188) swallows every over-reported "missing" member as a no-op add. That masked failure mode
+        // is a silent PERFORMANCE regression (an extra Load round-trip per member per assertion), not a
+        // correctness one — do not "simplify" this comparison away on the observation that the suite stays green.
         var missing = members
             .Where(m => !current.Any(row => string.Equals(row.BattleTag, m, StringComparison.OrdinalIgnoreCase)))
             .ToList();

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -40,18 +40,33 @@ namespace W3ChampionsChatService.Internal;
 /// via mm's serialized per-user flows. The strict ordering guarantee this class DOES provide is per-add:
 /// within a single <see cref="AddMemberWithInvariant"/> call, <c>ChannelRemoved(old)</c> is emitted STRICTLY
 /// BEFORE <c>ChannelAdded(new)</c>, so a user moving A→B never transiently sees both channels.
+/// NOT CLOSED BY THE GATE BELOW (2026-08-05 fix wave, final review M1): <see cref="_refGate"/> serializes
+/// per-`systemRef`, but the stale-eviction delete inside <see cref="AddMemberWithInvariant"/> targets a
+/// DIFFERENT ref (the user's OLD channel) than the one the caller's gate token covers — by construction,
+/// since eviction exists specifically to clear a ref the caller is NOT currently operating on. The gate
+/// cannot close this residual without holding two tokens at once, which <see cref="MatchChannelRefGate"/>'s
+/// own no-nesting invariant forbids. This is the SAME residual race already documented above, restated
+/// post-gate: the gate is not a fix for it, and was never meant to be.
 /// </para>
 /// <para>
 /// 2026-08-05 RECONCILIATION (plan D5, D10): adds <see cref="ApplyRosterAssertion"/> — the authoritative
 /// full-set protocol that supersedes <see cref="ApplyMembersDelta"/> — plus a <see cref="MatchChannelRefGate"/>
-/// (<see cref="_refGate"/>) that every mutating match-channel path now acquires FIRST, and detach guards
-/// (plan D4) on the assertion and legacy delta paths. <see cref="CreateOrGet"/> gains OPTIONAL
-/// <c>epoch</c>/<c>seq</c>/<c>detached</c> parameters (plan D10) so a create can also participate in the
-/// (epoch, seq) staleness protocol and birth ladder-match channels already detached. The teardown body
-/// of <see cref="DeleteChannel"/> is extracted into the private <c>TearDownChannel</c>, shared by
-/// <see cref="ApplyEpochSync"/> — the startup mm-crash-recovery sweep (plan D8) that tears down every
-/// non-detached match channel absent from mm's freshly-booted <c>liveLobbyRefs</c> and re-anchors the
-/// channels it spares to the new epoch.
+/// (<see cref="_refGate"/>) that every mutating match-channel path IN THIS CLASS now acquires FIRST, and
+/// detach guards (plan D4) on the assertion and legacy delta paths. TWO DOCUMENTED EXCEPTIONS (2026-08-05
+/// fix wave, final review H4 + M1): <c>ChatHub.LeaveChannel</c> (<c>Chats/ChatHub.Channels.cs</c>) deletes
+/// a membership row directly with no channel-type guard and no gate at all — it lives OUTSIDE this class
+/// and races <see cref="ApplyRosterAssertion"/>'s diff, a divergence bounded by the next assertion
+/// re-adding the member (or permanent only where the user wanted exactly that, on a channel no further
+/// assertion ever reaches); and this class's OWN cross-ref eviction inside <see cref="AddMemberWithInvariant"/>
+/// documented just above, which by definition writes to a ref the caller's gate token does not cover.
+/// <see cref="CreateOrGet"/> gains OPTIONAL <c>epoch</c>/<c>seq</c>/<c>detached</c> parameters (plan D10) so
+/// a create can also participate in the (epoch, seq) staleness protocol and birth ladder-match channels
+/// already detached. The teardown body of <see cref="DeleteChannel"/> is extracted into the private
+/// <c>TearDownChannel</c>, shared by <see cref="ApplyEpochSync"/> — the startup mm-crash-recovery sweep
+/// (plan D8) that tears down every non-detached, assertion-stamped match channel absent from mm's
+/// freshly-booted <c>liveLobbyRefs</c> and re-anchors the channels it spares to the new epoch (an
+/// UNSTAMPED legacy/transition channel is excluded from the sweep entirely and falls to its own 24h TTL
+/// instead — 2026-08-05 fix wave, final review H1).
 /// </para>
 /// </summary>
 public class MatchChannelService(

--- a/W3ChampionsChatService/Internal/RosterAssertionOutcome.cs
+++ b/W3ChampionsChatService/Internal/RosterAssertionOutcome.cs
@@ -1,0 +1,22 @@
+namespace W3ChampionsChatService.Internal;
+
+/// <summary>
+/// The result of <see cref="MatchChannelService.ApplyRosterAssertion"/> (2026-08-05 fix wave, final
+/// review M2). Before this type existed, the controller logged an unconditional "roster-assert
+/// succeeded" Information line regardless of what the domain layer actually did, WHILE the domain layer
+/// separately logged its own "discarded ..." Information line on the staleness/detach paths — a
+/// contradictory pair, both at Information, on exactly the storm paths (an mm retry storm, or mm
+/// asserting a frozen lobby) those gates exist to absorb. The controller now logs exactly ONE
+/// outcome-tagged line per assertion, and the domain layer's own discard lines are demoted to Debug.
+/// </summary>
+public enum RosterAssertionOutcome
+{
+    /// <summary>The (epoch, seq) CAS admitted the assertion and the membership diff was applied.</summary>
+    Applied,
+
+    /// <summary>Discarded — the channel was already detached (frozen); membership left untouched.</summary>
+    DiscardedFrozen,
+
+    /// <summary>Discarded — stale/duplicate/reordered (epoch, seq); membership left untouched.</summary>
+    DiscardedStale,
+}


### PR DESCRIPTION
## What

Root-cause fix for mm↔chat match-channel membership desync (the 2026-08-05 stuck-lobby incident). Replaces the delta-based fire-and-forget membership sync with **authoritative full-set roster assertions** guarded by **(epoch, seq)**, plus a **boot-time epoch sync** and a **detach freeze** at game start. The legacy delta path (`PUT .../members`) is **deleted outright** — the chat rewrite has no production traffic, so no transition window is kept (the test environment's not-yet-updated mm 404s its delta calls harmlessly, fail-soft, until its sibling PR deploys). Design spec approved 2026-08-05; sibling PR in matchmaking-service (private).

## Internal API surface (HMAC realm, mm caller — documented in README)

- `PUT /internal/channels/{ref}/roster` — `{epoch, seq, members[], name?, detached?}`: the complete member set; chat diffs and converges (adds via the one-match-channel-per-user invariant, removals push `ChannelRemoved`). Idempotent; `(epoch, seq)` staleness guard persisted on the channel doc (same-epoch strictly-greater seq; different epoch re-anchors with a Warning); a discarded assertion is a 200 no-op. `name` is used only for create-on-demand and is normalized (trim/clamp/ref-fallback), never rejected.
- `POST /internal/channels/epoch-sync` — `{epoch, liveLobbyRefs[]}`: boot-time authority reset. Tears down every **assertion-stamped**, non-detached match channel not in the list; spares + re-anchors listed ones (conditional: only when the stored epoch differs). Cancellable via the request's abort token; unstamped channels are invisible to the sweep and fall to their 24h TTL (safety net: "not stamped by this protocol ⇒ not mine to sweep").
- `POST /internal/channels` gains optional `epoch`/`seq`/`detached` — ladder-match channels are **born detached** (single SystemKind means the epoch sync would otherwise kill in-progress ladder chats after any mm restart); a stale create retry can no longer resurrect removed members.
- `detached: true` (sent once at GAME_STARTED) freezes the room: later assertions discard; excluded from every sweep; the 24h TTL owns cleanup. Post-game chat (Decision #5) preserved.

## Concurrency & semantics

- Every mutating match-channel path is serialized per `systemRef` (new ref-counted keyed async mutex) on top of an atomic `(epoch, seq)` CAS on the channel doc.
- `LeaveChannel` stays deliberately type-agnostic (product decision, documented at the code site): a user leave on a **live** match channel is re-converged by the next assertion — mm is authoritative for lobby membership; stale/stuck rows and detached post-game rooms keep leave sticky (the escape-hatch case). UI-unreachable for live rooms (launcher hides Leave there).

## Verification

- Full suite **1309/1309** green; every task adversarially reviewed + mutation-tested (per-task findings + two independent final whole-branch reviews, opus + Fable-adjudicated), plus a coverage-loss audit on the delta-path deletion.
- Backward-compat: legacy channel docs deserialize untouched, client-facing SignalR payloads unchanged (`[JsonIgnore]` pinned), no new index/migration/env/config.

## Deploy

Deploy **before (or together with) mm's PR** — an mm build older than its sibling PR simply 404s its delta calls (fail-soft) until it deploys. Once the new mm is live, don't roll chat back below this build (mm's roster/epoch-sync retry loops would 404) — roll mm back first.

## Follow-ups (non-blocking)

- Native TTL on match-channel membership rows (pre-existing ~5k/day ladder orphan rows; the #38 sweep already reaps them — this would remove the cadence dependency).
- Optional threshold warning on epoch-sync teardown counts; sweep batching if match volume grows 10x.