### PR TITLE
fix(chat): restore the clan channel — connect-time auto-join, non-leavable

### DIFF
--- a/W3ChampionsChatService.Tests/ChatHubClanChannelTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubClanChannelTests.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+using W3ChampionsChatService.Memberships;
+using W3ChampionsChatService.Mentions;
+using W3ChampionsChatService.Mutes;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Relationships;
+using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Clan-channel membership tests (2026-08-09 clan-channel regression). The chat revamp (#33) rebuilt
+/// channels as server-persisted membership rows but shipped no clan path at all, so the clan channel —
+/// which the PRE-revamp launcher fabricated client-side as an ephemeral <c>clan &lt;tag&gt;</c> SignalR
+/// group — silently vanished for every clan member.
+/// <para>
+/// These tests pin the replacement contract: the connect path reconciles a System+<see
+/// cref="SystemChannelKind.Clan"/> channel keyed by the clan id ALREADY resolved from wb's
+/// <c>clan-and-picture</c> (<see cref="ChatUser.ClanTag"/>), so the membership is durable and lands in
+/// the SAME <c>SessionState</c> the client renders. Removal of a stale clan membership is gated on
+/// <see cref="ChatUserResolution.FreshFromWb"/> — the NEVER-CLOBBER invariant already used by the
+/// directory upsert: a wb outage resolves ClanTag to null, and that must never rip a user out of their
+/// clan channel.
+/// </para>
+/// </summary>
+public class ChatHubClanChannelTests : IntegrationTestBase
+{
+    private const string BattleTag = "peter#123";
+    private const string ClanId = "EwOk";
+
+    private TicketStore _ticketStore;
+    private SessionRegistry _sessionRegistry;
+    private ConnectionMapping _connectionMapping;
+    private UserDirectoryRepository _userDirectory;
+    private MuteRepository _muteRepository;
+    private MuteReconciliationService _reconcileService;
+    private Mock<IChatAuthenticationService> _authService;
+
+    private ChannelRepository _channelRepository;
+    private MembershipRepository _membershipRepository;
+    private FocusRegistry _focusRegistry;
+    private OnlineMemberRegistry _onlineMemberRegistry;
+    private MessageRateLimiter _messageRateLimiter;
+    private ReadRateLimiter _readRateLimiter;
+    private ChannelCreationRateLimiter _channelCreationRateLimiter;
+    private SessionStateAssembler _assembler;
+    private FakeRelationshipSource _relationshipSource;
+    private IRelationshipProvider _relationshipProvider;
+
+    // Ordered capture of (target, method, payload) so a test can assert on the ACTUAL SessionState the
+    // client would render, not merely that some event fired.
+    private readonly List<(string Target, string Method, object[] Args)> _sends = new();
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _ticketStore = new TicketStore();
+        _sessionRegistry = new SessionRegistry();
+        _connectionMapping = new ConnectionMapping();
+        _userDirectory = new UserDirectoryRepository(MongoClient);
+        _muteRepository = new MuteRepository(MongoClient);
+        _reconcileService = new MuteReconciliationTestHarness(_connectionMapping, _muteRepository).Service;
+        _sends.Clear();
+
+        _authService = new Mock<IChatAuthenticationService>();
+        SetupResolution(ClanId, freshFromWb: true);
+
+        _channelRepository = new ChannelRepository(MongoClient);
+        _membershipRepository = new MembershipRepository(MongoClient, _channelRepository);
+        _focusRegistry = new FocusRegistry();
+        _onlineMemberRegistry = new OnlineMemberRegistry();
+        _messageRateLimiter = new MessageRateLimiter();
+        _readRateLimiter = new ReadRateLimiter();
+        _channelCreationRateLimiter = new ChannelCreationRateLimiter();
+        _relationshipSource = new FakeRelationshipSource();
+        _relationshipProvider = new RelationshipProvider(_relationshipSource, TimeProvider.System);
+        _assembler = new SessionStateAssembler(
+            _membershipRepository,
+            _channelRepository,
+            new W3ChampionsChatService.Messages.MessageRepository(MongoClient),
+            _muteRepository,
+            _onlineMemberRegistry,
+            _connectionMapping,
+            new MentionInboxRepository(MongoClient));
+    }
+
+    /// <summary>Points the flair resolver at a given clan id / freshness tier.</summary>
+    private void SetupResolution(string clanId, bool freshFromWb)
+    {
+        _authService.Setup(m => m.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .ReturnsAsync((W3CUserAuthentication id) =>
+                new ChatUserResolution(
+                    new ChatUser(id.BattleTag, id.IsAdmin, clanId, new ProfilePicture(), null, null),
+                    freshFromWb));
+    }
+
+    private static W3CUserAuthentication Identity(string battleTag = BattleTag, string name = "peter") =>
+        new() { BattleTag = battleTag, Name = name, IsAdmin = false };
+
+    private ChatHub BuildConnection(string connectionId, string accessToken)
+    {
+        var hub = new ChatHub(
+            _connectionMapping,
+            _reconcileService,
+            _ticketStore,
+            _sessionRegistry,
+            _userDirectory,
+            _assembler,
+            _focusRegistry,
+            _onlineMemberRegistry,
+            _messageRateLimiter,
+            _readRateLimiter,
+            TimeProvider.System,
+            _channelRepository,
+            _membershipRepository,
+            _channelCreationRateLimiter,
+            new W3ChampionsChatService.Messages.MessageRepository(MongoClient),
+            FanOutEngineTestFactory.CreateIgnored(),
+            ViewersAccumulatorTestFactory.CreateIgnored(),
+            new NoOpMentionInboxCleaner(),
+            _relationshipProvider,
+            new UserSettingsRepository(MongoClient),
+            new DmInitiationTracker(),
+            _authService.Object,
+            MentionFanOutTestFactory.CreateIgnored(MongoClient),
+            new PresenceInterestRegistry(),
+            new MentionInboxRepository(MongoClient),
+            new NotificationPreferenceRepository(MongoClient));
+
+        var clients = new Mock<IHubCallerClients>();
+        clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));
+        clients.Setup(c => c.Group(It.IsAny<string>())).Returns(CapturingGroup());
+        clients.Setup(c => c.Client(It.IsAny<string>())).Returns<string>(CapturingSingle);
+        hub.Clients = clients.Object;
+
+        var context = new Mock<HubCallerContext>();
+        context.Setup(c => c.ConnectionId).Returns(connectionId);
+        context.Setup(c => c.Features).Returns(BuildFeatures(accessToken));
+        hub.Context = context.Object;
+        hub.Groups = new Mock<IGroupManager>().Object;
+
+        return hub;
+    }
+
+    private static IFeatureCollection BuildFeatures(string accessToken)
+    {
+        var features = new FeatureCollection();
+        var httpContext = new DefaultHttpContext();
+        if (accessToken != null)
+        {
+            httpContext.Request.QueryString = new QueryString($"?access_token={accessToken}");
+        }
+        var httpContextFeature = new Mock<IHttpContextFeature>();
+        httpContextFeature.Setup(f => f.HttpContext).Returns(httpContext);
+        features.Set<IHttpContextFeature>(httpContextFeature.Object);
+        return features;
+    }
+
+    private ISingleClientProxy CapturingSingle(string target)
+    {
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) => _sends.Add((target, method, args)))
+            .Returns(Task.CompletedTask);
+        return proxy.Object;
+    }
+
+    private IClientProxy CapturingGroup()
+    {
+        var proxy = new Mock<IClientProxy>();
+        proxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, args, _) => _sends.Add(("group", method, args)))
+            .Returns(Task.CompletedTask);
+        return proxy.Object;
+    }
+
+    /// <summary>The SessionState pushed to the caller — the exact snapshot the launcher renders from.</summary>
+    private SessionStateDto CapturedSessionState() =>
+        (SessionStateDto)_sends.Single(s => s.Method == ChatEvents.SessionState).Args[0];
+
+    private async Task<ChatHub> Connect(string connectionId = "conn-1", string battleTag = BattleTag)
+    {
+        var ticket = _ticketStore.Mint(Identity(battleTag), DateTime.UtcNow);
+        var hub = BuildConnection(connectionId, ticket);
+        await hub.OnConnectedAsync();
+        return hub;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Auto-join
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Connect_WithClan_CreatesClanChannelAndJoinsIt()
+    {
+        await Connect();
+
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId);
+        Assert.IsNotNull(channel, "A clan member's connect must find-or-create the System+Clan channel shell");
+        Assert.AreEqual(ChannelType.System, channel.Type);
+        Assert.AreEqual(ClanId, channel.SystemRef, "SystemRef is the clan id straight from wb's clan-and-picture");
+        Assert.IsNull(channel.ExpiresAt, "A clan shell is permanent — ExpiresAt must stay ABSENT (ExpiryCalculator)");
+
+        var membership = await _membershipRepository.Load(channel.Id, BattleTag);
+        Assert.IsNotNull(membership, "The connecting clan member must be auto-joined to their clan channel");
+    }
+
+    [Test]
+    public async Task Connect_WithClan_ClanChannelIsInTheSessionStateSnapshot()
+    {
+        await Connect();
+
+        var state = CapturedSessionState();
+        var clanEntry = state.Channels.SingleOrDefault(c =>
+            c.Channel.Type == ChannelType.System && c.Channel.SystemKind == SystemChannelKind.Clan);
+
+        Assert.IsNotNull(clanEntry,
+            "Reconciliation must run BEFORE AssembleAndSeed — otherwise the membership exists but the "
+            + "client never sees it until the NEXT connect, which is the user-visible bug.");
+        Assert.AreEqual(ClanId, clanEntry.Channel.SystemRef);
+    }
+
+    [Test]
+    public async Task Connect_WithoutClan_CreatesNoClanChannel()
+    {
+        SetupResolution(clanId: null, freshFromWb: true);
+
+        await Connect();
+
+        var state = CapturedSessionState();
+        Assert.IsFalse(
+            state.Channels.Any(c => c.Channel.SystemKind == SystemChannelKind.Clan),
+            "A clanless user must get no clan channel");
+    }
+
+    [Test]
+    public async Task Connect_Twice_IsIdempotent_OneChannelOneMembership()
+    {
+        await Connect("conn-1");
+        _sends.Clear();
+        await Connect("conn-2");
+
+        var channels = await _channelRepository.LoadAllOfType(ChannelType.System);
+        Assert.AreEqual(1, channels.Count(c => c.SystemKind == SystemChannelKind.Clan),
+            "Reconnecting must not create a second clan channel shell");
+
+        var memberships = await _membershipRepository.LoadForUser(BattleTag);
+        Assert.AreEqual(1, memberships.Count, "Reconnecting must not duplicate the clan membership");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Reconciliation on clan change
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Connect_AfterClanChange_DropsStaleClanMembershipAndJoinsTheNewOne()
+    {
+        await Connect("conn-1");
+        var oldChannel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId);
+
+        SetupResolution("s4s", freshFromWb: true);
+        _sends.Clear();
+        await Connect("conn-2");
+
+        Assert.IsNull(await _membershipRepository.Load(oldChannel.Id, BattleTag),
+            "Switching clans must drop the membership in the previous clan's channel");
+
+        var newChannel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, "s4s");
+        Assert.IsNotNull(await _membershipRepository.Load(newChannel.Id, BattleTag),
+            "Switching clans must join the new clan's channel");
+    }
+
+    [Test]
+    public async Task Connect_AfterLeavingClan_DropsTheClanMembership()
+    {
+        await Connect("conn-1");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId);
+
+        SetupResolution(clanId: null, freshFromWb: true);
+        _sends.Clear();
+        await Connect("conn-2");
+
+        Assert.IsNull(await _membershipRepository.Load(channel.Id, BattleTag),
+            "A FRESH wb read saying the user has no clan is authoritative — the membership must go");
+    }
+
+    [Test]
+    public async Task Connect_DuringWbOutage_NeverRemovesAnExistingClanMembership()
+    {
+        await Connect("conn-1");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId);
+
+        // A total wb + directory-cache miss resolves ClanTag to null with FreshFromWb: false
+        // (ChatAuthenticationService tier 3). That null is an ABSENCE OF DATA, not a clan departure.
+        SetupResolution(clanId: null, freshFromWb: false);
+        _sends.Clear();
+        await Connect("conn-2");
+
+        Assert.IsNotNull(await _membershipRepository.Load(channel.Id, BattleTag),
+            "NEVER-CLOBBER: a wb outage must not evict the user from their clan channel");
+
+        var state = CapturedSessionState();
+        Assert.IsTrue(
+            state.Channels.Any(c => c.Channel.SystemKind == SystemChannelKind.Clan),
+            "The clan channel must survive an outage connect in the rendered snapshot too");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Non-leavable
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task LeaveChannel_OnClanChannel_IsRejectedAndMembershipSurvives()
+    {
+        var hub = await Connect();
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId);
+
+        var result = await hub.LeaveChannel(channel.Id);
+
+        Assert.AreEqual(ChatResultCode.PermissionDenied, result.Code,
+            "A clan channel is not user-leavable (product decision 2026-08-09)");
+        Assert.IsNotNull(await _membershipRepository.Load(channel.Id, BattleTag),
+            "A rejected leave must not delete the membership row");
+    }
+
+    [Test]
+    public async Task LeaveChannel_OnANonClanChannel_StillWorks()
+    {
+        var hub = await Connect();
+        var join = await hub.JoinChannel("Some Room");
+
+        var result = await hub.LeaveChannel(join.Channel.Id);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code,
+            "The clan carve-out must not regress the type-agnostic escape hatch for every other kind (H4)");
+        Assert.IsNull(await _membershipRepository.Load(join.Channel.Id, BattleTag));
+    }
+}

--- a/W3ChampionsChatService/Chats/ChatHub.Channels.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Channels.cs
@@ -434,6 +434,22 @@ public partial class ChatHub
     /// exactly the case the escape hatch exists for. No behavior change; this codifies the decision to
     /// keep the exception as-is rather than adding a server-side no-op-for-live-match-channel guard.
     /// </para>
+    /// <para>
+    /// CLAN CARVE-OUT (2026-08-09 clan-channel regression) — product decision (Marco, 2026-08-09): H4's
+    /// type-agnostic rule now has EXACTLY ONE exception. A System+<see cref="SystemChannelKind.Clan"/>
+    /// channel is NOT user-leavable and is rejected below with <see cref="ChatResultCode.PermissionDenied"/>
+    /// before any mutation. Rationale: clan membership is owned by wb, not by the chat user, so "leaving"
+    /// a clan channel is not a state the user is entitled to author — and unlike a live match channel
+    /// there is no assertion stream to silently restore it, so an ungated leave would strand the user
+    /// outside their clan channel until their clan membership itself changed. The escape hatch is
+    /// deliberately narrowed rather than removed: EVERY other kind (Public, SemiPublic, Dm, GroupDm,
+    /// System+Match, System with no kind, and a vanished/unresolvable channel) keeps the unconditional
+    /// force-leave behaviour H4 exists to protect. The launcher correspondingly hides Leave for clan rows
+    /// (<c>launcher-e/src/components/chat/ChannelListRow.tsx</c>, <c>isClanChannel</c>), so this server
+    /// gate is the authoritative backstop for a stale/hand-rolled client rather than the primary UX.
+    /// Note the ASYMMETRY with the match case above: a clan leave is refused OUTRIGHT, whereas a live
+    /// match leave is permitted and then reverted by the next roster assertion.
+    /// </para>
     /// </summary>
     public async Task<ChannelOperationResult> LeaveChannel(string channelId)
     {
@@ -447,6 +463,15 @@ public partial class ChatHub
         // Load the channel BEFORE mutating so the departure can branch by type. A missing/vanished channel
         // stays a no-op Ok (treated as non-private-lane below) — LeaveChannel never returns NotFound.
         var channel = await _channelRepository.Load(channelId);
+
+        // Clan carve-out (see the doc comment above): the ONE type that is not user-leavable. Checked
+        // BEFORE any mutation so a rejected leave is a true no-op — no membership delete, no registry
+        // eviction, no viewer-roster delta. A null/vanished channel falls through to the ungated path, as
+        // it always has.
+        if (channel != null && channel.Type == ChannelType.System && channel.SystemKind == SystemChannelKind.Clan)
+        {
+            return new ChannelOperationResult(ChatResultCode.PermissionDenied);
+        }
 
         await _membershipRepository.Delete(channelId, battleTag);
         _onlineMemberRegistry.Leave(channelId, Context.ConnectionId);

--- a/W3ChampionsChatService/Chats/ChatHub.Clan.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Clan.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Memberships;
+using Serilog;
+
+namespace W3ChampionsChatService.Chats;
+
+/// <summary>
+/// Connect-time clan-channel reconciliation (2026-08-09 clan-channel regression).
+/// <para>
+/// BACKGROUND. Before the chat revamp, the clan channel was never a server concept at all: the launcher
+/// read the player's clan tag off the legacy <c>StartChat</c> payload and locally fabricated a room named
+/// <c>clan &lt;tag&gt;</c> (launcher-e <c>src/models/chat.ts</c>, removed in #833). Rooms were ephemeral
+/// SignalR groups, so "joining" was just naming one. The revamp (#33) rebuilt channels as PERSISTED
+/// <see cref="ChannelMembership"/> rows assembled by
+/// <see cref="Protocol.SessionStateAssembler.AssembleAndSeed"/>, and shipped Match/Dm/GroupDm/Public/
+/// SemiPublic write paths only. <see cref="SystemChannelKind.Clan"/> survived as a POLICY stub —
+/// permanent lifetime (<see cref="ExpiryCalculator.ForChannelShell"/>) and moderation exemption
+/// (<see cref="ChannelModeration.IsModeratable"/>) — with nothing that ever creates such a channel or
+/// inserts a membership into one. Net effect: the clan channel silently disappeared for every clan
+/// member (~2.4k accounts at the time of the fix).
+/// </para>
+/// <para>
+/// SYNC MODEL — CONNECT-TIME ONLY (product decision, Marco, 2026-08-09). Reconciliation is driven by
+/// the clan id the connect path has ALREADY resolved: <see cref="ChatUser.ClanTag"/>, populated by
+/// <see cref="IChatAuthenticationService.GetUserFromIdentity"/> from wb's
+/// <c>GET /api/players/{battleTag}/clan-and-picture</c>. That means ZERO new infrastructure — no poller,
+/// no webhook, no extra round-trip: the wb read that already happens for chat flair now also drives
+/// routing. Accepted cost: a clan join/leave/disband reaches chat on the user's NEXT chat connect
+/// rather than instantly.
+/// </para>
+/// <para>
+/// THE NEVER-CLOBBER INVARIANT. <see cref="ChatAuthenticationService"/> is fail-soft by design: on a wb
+/// outage it falls back to the cached directory profile, and on a total miss (tier 3) it returns a plain
+/// <see cref="ChatUser"/> whose <see cref="ChatUser.ClanTag"/> is <c>null</c>. A null from that tier means
+/// ABSENCE OF DATA, not "this user left their clan" — treating it as authoritative would evict every
+/// connecting clan member from their clan channel for the duration of a wb outage. So the REMOVAL half of
+/// reconciliation is gated on <see cref="ChatUserResolution.FreshFromWb"/>, exactly mirroring the gate
+/// <see cref="ChatHub.UpsertDirectory"/> already applies before replacing a cached Profile. A non-fresh
+/// resolution is ADDITIVE-ONLY.
+/// </para>
+/// <para>
+/// ORDERING. This runs in <see cref="ChatHub.OnConnectedAsync"/> BEFORE
+/// <see cref="Protocol.SessionStateAssembler.AssembleAndSeed"/>, which reads membership rows straight from
+/// Mongo. Reconciling first is what puts the clan channel in the SAME <c>SessionState</c> the client
+/// renders on THIS connect — reconciling afterwards would persist the row but leave the user staring at a
+/// missing channel until their next reconnect, i.e. the original bug with extra steps. Because the
+/// snapshot carries it, no <c>ChannelAdded</c> push is needed (and none is emitted).
+/// </para>
+/// <para>
+/// FAIL-SOFT. Every step is wrapped: a Mongo hiccup or a malformed clan id must never fail an otherwise
+/// good connect. The user simply connects without their clan channel and self-heals on the next connect.
+/// This matches the posture of every other non-essential connect-path step (directory upsert, relationship
+/// prefetch) and deliberately NOT the fatal posture of <c>AssembleAndSeed</c> itself.
+/// </para>
+/// </summary>
+public partial class ChatHub
+{
+    /// <summary>
+    /// Display name for a clan channel shell. The clan id IS the clan tag in wb's data model
+    /// (<c>Clan._id</c> / <c>ClanMembership.ClanId</c>, e.g. <c>"EwOk"</c>), so this needs no extra
+    /// lookup — deliberate, given the connect-time-only sync model above. Only ever applied on INSERT
+    /// (<see cref="ChannelRepository.FindOrCreateSystem"/> uses <c>$setOnInsert</c>), so renaming a clan
+    /// does not rewrite an existing shell.
+    /// </summary>
+    internal static string ClanChannelName(string clanId) => $"Clan {clanId}";
+
+    /// <summary>
+    /// Normalizes wb's clan id into either a usable ref or null. Guards the two shapes wb/legacy data
+    /// actually produce for "no clan": a genuine null and the literal string <c>"null"</c> — the latter
+    /// being the exact sentinel the PRE-revamp launcher screened for
+    /// (<c>clanTag &amp;&amp; clanTag !== "null"</c>), so it is a real value seen in the wild, not a
+    /// hypothetical.
+    /// </summary>
+    private static string NormalizeClanRef(string clanId)
+    {
+        var trimmed = clanId?.Trim();
+        return string.IsNullOrEmpty(trimmed) || trimmed.Equals("null", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : trimmed;
+    }
+
+    /// <summary>
+    /// Brings the caller's System+Clan membership in line with <paramref name="resolution"/>: joins the
+    /// channel for their current clan (find-or-create), and — only on a FRESH wb resolution — drops any
+    /// clan membership that is no longer theirs. Idempotent: a reconnect with an unchanged clan writes
+    /// nothing. See the class doc for the ordering, sync-model and never-clobber rationale.
+    /// </summary>
+    private async Task ReconcileClanMembership(W3CUserAuthentication identity, ChatUserResolution resolution, DateTime now)
+    {
+        try
+        {
+            var clanRef = NormalizeClanRef(resolution.User?.ClanTag);
+
+            // Resolve the clan memberships the user currently holds. LoadForUser is already on the
+            // connect path's hot loop (AssembleAndSeed calls it moments later), so this is a cheap
+            // repeat read against the same BattleTag-prefixed index, not a new access pattern.
+            var memberships = await _membershipRepository.LoadForUser(identity.BattleTag);
+            var existingClanChannelIds = memberships.Count == 0
+                ? Array.Empty<string>()
+                : (await _channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
+                    .Where(c => c.Type == ChannelType.System && c.SystemKind == SystemChannelKind.Clan)
+                    .Select(c => c.Id)
+                    .ToArray();
+
+            string targetChannelId = null;
+            if (clanRef != null)
+            {
+                var channel = await _channelRepository.FindOrCreateSystem(
+                    SystemChannelKind.Clan, clanRef, ClanChannelName(clanRef), now);
+                targetChannelId = channel.Id;
+
+                if (!existingClanChannelIds.Contains(channel.Id))
+                {
+                    // NotificationLevel.All — a clan channel is a primary, non-leavable lane, so it gets
+                    // the same default as a match channel (MatchChannelService.AddMemberWithInvariant),
+                    // NOT JoinChannel's opt-in Mentions default for rooms a user picked themselves.
+                    // InsertIfAbsent (not Insert) for race-safety against ux_channelId_battleTag when two
+                    // sockets for the same battleTag reconcile concurrently.
+                    await _membershipRepository.InsertIfAbsent(new ChannelMembership
+                    {
+                        ChannelId = channel.Id,
+                        BattleTag = identity.BattleTag,
+                        Role = MembershipRole.Member,
+                        NotificationLevel = NotificationLevel.All,
+                        JoinedAt = now,
+                    });
+                    Log.Information(
+                        "Clan reconcile: joined {BattleTag} to clan channel {ClanRef}", identity.BattleTag, clanRef);
+                }
+            }
+
+            // NEVER-CLOBBER (see class doc): only a FRESH wb read is authoritative about clan DEPARTURE.
+            // A cached/plain resolution is additive-only — it may join, never evict.
+            if (!resolution.FreshFromWb)
+            {
+                return;
+            }
+
+            foreach (var staleChannelId in existingClanChannelIds.Where(id => id != targetChannelId))
+            {
+                await _membershipRepository.Delete(staleChannelId, identity.BattleTag);
+                Log.Information(
+                    "Clan reconcile: removed {BattleTag} from stale clan channel {ChannelId}",
+                    identity.BattleTag, staleChannelId);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Non-fatal by design — a clan-channel hiccup must never cost the user their chat session.
+            Log.Warning(ex, "Clan-channel reconciliation failed for {BattleTag} — connecting without it", identity.BattleTag);
+        }
+    }
+}

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -223,6 +223,13 @@ public partial class ChatHub(
         // one round-trip per connect, not two. Still fire-and-forget and non-fatal.
         _ = PushFriendPresenceFromSnapshot(identity.BattleTag, wentOnline, Context.ConnectionId, relationshipSnapshot);
 
+        // Clan-channel reconciliation (2026-08-09) — MUST run BEFORE AssembleAndSeed, which reads the
+        // membership rows this may write. Reuses the clan id already carried by `resolution` (the same wb
+        // round-trip hoisted above for flair), so it costs no extra network call. Self-contained and
+        // fail-soft — see ChatHub.Clan.cs for the full rationale, including why removal is gated on
+        // resolution.FreshFromWb.
+        await ReconcileClanMembership(identity, resolution, now);
+
         // C3 (Task 8): assemble the SessionState snapshot and seed this connection's fan-out state (the
         // OnlineMemberRegistry + the legacy mute cache, both done inside AssembleAndSeed), then push the
         // snapshot to the CALLER only — it is that connection's private state rebuild (spec acceptance


### PR DESCRIPTION
## The bug

A user reported their clan channel was missing. It is missing for **everyone** — **2,422 clan members across 1,016 clans** in production. There is no clan channel in the current system for anyone.

## Root cause

Pre-revamp, the clan channel was never a server concept. The launcher read the player`s clan tag off the legacy `StartChat` payload and locally fabricated a room named `clan <tag>`:

```ts
// launcher-e @ c4ad6812^ — src/models/chat.ts:236
if (clanTag && clanTag !== "null") {
    actions.addChatRoom(`clan ${clanTag.toLowerCase()}`);
}
```

Rooms were ephemeral SignalR groups, so naming one *was* joining it.

The revamp broke this from both ends simultaneously:

- **launcher-e #833** deleted the client-side fabrication along with the old room model.
- **chat-service #33** rebuilt channels as persisted `ChannelMembership` rows read by `SessionStateAssembler.AssembleAndSeed`, shipping write paths for Match / Dm / GroupDm / Public / SemiPublic only.

`SystemChannelKind.Clan` survived as a *policy stub* — permanent lifetime (`ExpiryCalculator`) and moderation exemption (`ChannelModeration`) both honor it — but no code path ever called `FindOrCreateSystem` with it or inserted a clan membership. Verified against every `FindOrCreateSystem` and membership-insert call site in the service.

## The fix

**`ChatHub.Clan.cs`** (new) reconciles the caller`s System+Clan membership on connect:

- Driven by the clan id **already** resolved from wb`s `clan-and-picture` for chat flair — no extra round-trip, no poller, no webhook.
- Runs **before** `AssembleAndSeed`, so the channel lands in the same `SessionState` this connect renders. Reconciling afterwards would persist the row but leave the user without the channel until their next reconnect — the original bug with extra steps. Because the snapshot carries it, no `ChannelAdded` push is needed.
- Idempotent; fail-soft (a clan-channel hiccup must never cost a chat session).

**Never-clobber invariant.** `ChatAuthenticationService` is fail-soft and resolves `ClanTag` to `null` on a total wb+cache miss. That null is *absence of data*, not a clan departure — treating it as authoritative would evict every connecting clan member for the duration of a wb outage. So the **removal** half is gated on `FreshFromWb`, mirroring the gate `UpsertDirectory` already applies before replacing a cached Profile. Joins stay additive regardless.

**`LeaveChannel`** now rejects System+Clan before any mutation.

## H4 carve-out — reviewer attention here

This adds the first exception to the documented H4 decision that `LeaveChannel` stays type-agnostic and ungated. Rationale, recorded in the doc comment in place:

- Clan membership is owned by wb, not by the chat user, so leaving is not a state the user is entitled to author.
- Unlike a live match channel there is no assertion stream to restore it, so an ungated leave would strand the user outside their clan channel indefinitely.
- The escape hatch is **narrowed, not removed** — every other kind (Public, SemiPublic, Dm, GroupDm, System+Match, System with no kind, vanished/unresolvable) keeps unconditional force-leave.

Note the asymmetry with the match case: a clan leave is **refused outright**, whereas a live match leave is permitted and then reverted by the next roster assertion.

## Decisions taken

- **Sync model: connect-time only.** A clan join/leave/disband reaches chat on the user`s next chat connect. Zero new infrastructure; accepted latency.
- **Channel naming:** `SystemRef` = clan id, name = `Clan <clanId>`. The clan id *is* the clan tag in wb`s model (`Clan._id`), so this needs no extra lookup. Surfacing a prettier `ClanName` would require a website-backend change to `ChatDetailsDto`.
- **`NotificationLevel.All`** — a clan channel is a primary, non-leavable lane, so it gets the match-channel default rather than `JoinChannel`s opt-in `Mentions` default for self-selected rooms.

## Testing

`ChatHubClanChannelTests.cs` adds 9 tests: auto-join, snapshot presence, the clanless case, reconnect idempotency, clan-switch reconciliation, clan departure, the wb-outage never-clobber invariant, and both halves of the leave gate.

> [!WARNING]
> **These tests have not been executed.** They compile and the solution builds clean (0 warnings, 0 errors), but the suite is Testcontainers-backed and Docker was unavailable in the authoring environment. **The implementation is behaviorally unverified** — please run `dotnet test --filter "FullyQualifiedName~ChatHubClanChannelTests"` before merging, and treat CI as the first real signal.

## Companion PR

launcher-e `fix/clan-channel-membership` hides the Leave affordance on clan rows. This server gate is the authoritative backstop; that PR is the UX half. Neither strictly depends on the other to land first — this PR alone restores the channel.