### PR TITLE
fix(chat): harden clan reconciliation after PR40 review

### DIFF
--- a/W3ChampionsChatService.Tests/ChatHubClanChannelTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubClanChannelTests.cs
@@ -322,8 +322,112 @@ public class ChatHubClanChannelTests : IntegrationTestBase
     }
 
     // ---------------------------------------------------------------------------------------------
+    // PR40 review — displaced connects must not write clan state (P2)
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Reconcile_FromADisplacedConnection_WritesNothing()
+    {
+        // Two connects for the same battleTag overlap: registering conn-2 aborts conn-1's context but does
+        // NOT cancel its in-flight OnConnectedAsync, which still holds the clan snapshot IT captured. If
+        // the loser finished last it would re-add the old membership and delete the new one — durable
+        // state decided by scheduling order. Driven directly because the race is mid-connect by nature.
+        var ticket = _ticketStore.Mint(Identity(), DateTime.UtcNow);
+        var staleHub = BuildConnection("conn-1", ticket);
+        _sessionRegistry.Register("conn-1", Identity(), staleHub.Context);
+
+        // conn-2 arrives and displaces conn-1.
+        _sessionRegistry.Register("conn-2", Identity(), BuildConnection("conn-2", "t2").Context);
+
+        await staleHub.ReconcileClanMembership(
+            Identity(),
+            new ChatUserResolution(
+                new ChatUser(BattleTag, false, ClanId, new ProfilePicture(), null, null), true),
+            DateTime.UtcNow);
+
+        Assert.IsNull(await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId),
+            "a displaced connection must not write clan state — the winner's view is the one that counts");
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // Non-leavable
     // ---------------------------------------------------------------------------------------------
+
+    // ---------------------------------------------------------------------------------------------
+    // PR40 review — freshness as an access-control gate (P1)
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Connect_WithCachedClanFlairDuringOutage_DoesNotGrantClanAccess()
+    {
+        // The scenario the review identified: directory entries are retained forever, but
+        // CleanupJobs.PruneIdleMemberships deletes the membership rows of users idle > 1 year. A user who
+        // left their clan while inactive therefore returns with a cached ClanId naming a clan they are no
+        // longer in, and no membership row to contradict it. Granting access off that cached value would
+        // re-admit them to the clan channel AND its retained history.
+        SetupResolution(ClanId, freshFromWb: false);
+
+        await Connect();
+
+        Assert.IsNull(await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId),
+            "a non-fresh resolution must not even create the clan shell");
+
+        var state = CapturedSessionState();
+        Assert.IsFalse(
+            state.Channels.Any(c => c.Channel.SystemKind == SystemChannelKind.Clan),
+            "clan access must never be granted from unverifiable cached flair");
+    }
+
+    [Test]
+    public async Task Connect_DuringWbOutage_MakesNoClanWritesAtAll()
+    {
+        // Regression guard for the tightening: the earlier rule was "additive-only when not fresh", which
+        // still granted access. The rule is now "no writes at all" — an existing membership is preserved
+        // untouched (asserted below and in the outage test above), nothing is created.
+        await Connect("conn-1");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId);
+        var before = await _membershipRepository.Load(channel.Id, BattleTag);
+
+        SetupResolution("s4s", freshFromWb: false);
+        _sends.Clear();
+        await Connect("conn-2");
+
+        Assert.IsNotNull(await _membershipRepository.Load(channel.Id, BattleTag),
+            "a non-fresh resolution must preserve the existing membership");
+        Assert.IsNull(await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, "s4s"),
+            "a non-fresh resolution must not act on its (unverifiable) new clan id either");
+        Assert.AreEqual(before.JoinedAt, (await _membershipRepository.Load(channel.Id, BattleTag)).JoinedAt,
+            "the preserved membership must be left byte-identical, not re-written");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // PR40 review — fail-closed revocation (P1)
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Connect_WhenStaleClanRemovalFails_FailsTheConnectRatherThanKeepingAccess()
+    {
+        await Connect("conn-1");
+        var oldChannel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId);
+
+        // A membership repository whose stale-row delete always fails. Swallowing this would leave the
+        // user readable/writable in their FORMER clan, which AssembleAndSeed would then seed.
+        var throwingMemberships = new Mock<MembershipRepository>(MongoClient, _channelRepository) { CallBase = true };
+        throwingMemberships
+            .Setup(m => m.Delete(oldChannel.Id, It.IsAny<string>()))
+            .ThrowsAsync(new TimeoutException("mongo hiccup"));
+        _membershipRepository = throwingMemberships.Object;
+
+        SetupResolution("s4s", freshFromWb: true);
+        _sends.Clear();
+
+        var ticket = _ticketStore.Mint(Identity(), DateTime.UtcNow);
+        var hub = BuildConnection("conn-2", ticket);
+
+        Assert.ThrowsAsync<TimeoutException>(
+            async () => await hub.OnConnectedAsync(),
+            "a failed revocation must fail the connect — never silently leave the user in their old clan");
+    }
 
     [Test]
     public async Task LeaveChannel_OnClanChannel_IsRejectedAndMembershipSurvives()

--- a/W3ChampionsChatService.Tests/ChatHubClanChannelTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubClanChannelTests.cs
@@ -321,6 +321,45 @@ public class ChatHubClanChannelTests : IntegrationTestBase
             "The clan channel must survive an outage connect in the rendered snapshot too");
     }
 
+    [Test]
+    public async Task Connect_WhenClanShellCreationFails_StillConnects_WithoutTheClanChannel()
+    {
+        // PR41 review (P2): creating the channel shell is part of the GRANT, not the revocation, so it
+        // belongs on the fail-soft path. Creating a shell grants nobody access, and this call sits on the
+        // hot path every clan member takes on every connect — rejecting the connection over a transient
+        // channel-upsert fault would be an availability regression, and would contradict the stated
+        // policy that only revocation is fatal.
+        var throwingChannels = new Mock<ChannelRepository>(MongoClient) { CallBase = true };
+        throwingChannels
+            .Setup(c => c.FindOrCreateSystem(SystemChannelKind.Clan, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>()))
+            .ThrowsAsync(new TimeoutException("mongo hiccup"));
+        _channelRepository = throwingChannels.Object;
+
+        Assert.DoesNotThrowAsync(async () => await Connect(),
+            "a failed clan-shell creation must never cost the user their chat session");
+
+        var state = CapturedSessionState();
+        Assert.IsFalse(
+            state.Channels.Any(c => c.Channel.SystemKind == SystemChannelKind.Clan),
+            "the user simply connects without the clan channel and self-heals on the next connect");
+    }
+
+    [Test]
+    public async Task Connect_AfterLeavingClan_RevokesEvenWhenNoShellIsEverCreated()
+    {
+        // Guards the PR41 restructure: staleness is now derived from SystemRef, so departure revocation
+        // must work without a target shell existing at all (the clanRef == null path creates nothing).
+        await Connect("conn-1");
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Clan, ClanId);
+
+        SetupResolution(clanId: null, freshFromWb: true);
+        _sends.Clear();
+        await Connect("conn-2");
+
+        Assert.IsNull(await _membershipRepository.Load(channel.Id, BattleTag),
+            "a fresh 'no clan' read must still revoke, with no shell resolution involved");
+    }
+
     // ---------------------------------------------------------------------------------------------
     // PR40 review — displaced connects must not write clan state (P2)
     // ---------------------------------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/WebsiteBackendRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/WebsiteBackendRepositoryTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Chats;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// PR40 review (P1): <see cref="WebsiteBackendRepository.GetChatDetails"/> must FAIL on an unusable wb
+/// response rather than returning a default-valued DTO.
+/// <para>
+/// Why this matters beyond a tidier error path: the return value feeds
+/// <see cref="ChatAuthenticationService.GetUserFromIdentity"/>, which stamps a NON-throwing result
+/// <c>FreshFromWb: true</c>. Two callers then treat that flag as authoritative —
+/// <c>ChatHub.ReconcileClanMembership</c> (which reads "no clan" as a clan DEPARTURE and deletes the
+/// membership) and <c>ChatHub.UpsertDirectory</c> (which replaces a cached Profile). A wb 5xx whose body
+/// still deserializes therefore used to look exactly like "this player genuinely has no clan".
+/// </para>
+/// </summary>
+[TestFixture]
+public class WebsiteBackendRepositoryTests
+{
+    /// <summary>Serves one canned response to whatever the repository requests.</summary>
+    private sealed class StubHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(status) { Content = new StringContent(body) });
+    }
+
+    private static WebsiteBackendRepository RepositoryReturning(HttpStatusCode status, string body)
+    {
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(new StubHandler(status, body)));
+        return new WebsiteBackendRepository(factory.Object);
+    }
+
+    [Test]
+    public void GetChatDetails_OnErrorStatusWithDeserializableBody_Throws()
+    {
+        // The exact shape that used to slip through: a JSON error envelope binds happily to
+        // ChatDetailsDto, leaving every property (including ClanId) null — with NO exception.
+        var repository = RepositoryReturning(HttpStatusCode.InternalServerError, "{\"error\":\"boom\"}");
+
+        Assert.ThrowsAsync<HttpRequestException>(
+            async () => await repository.GetChatDetails("peter#123"),
+            "a wb 500 must throw so GetUserFromIdentity falls back with FreshFromWb: false — otherwise an "
+            + "outage is indistinguishable from 'this player has no clan' and evicts them from their clan channel");
+    }
+
+    [Test]
+    public void GetChatDetails_OnNotFound_Throws()
+    {
+        var repository = RepositoryReturning(HttpStatusCode.NotFound, "{}");
+
+        Assert.ThrowsAsync<HttpRequestException>(async () => await repository.GetChatDetails("peter#123"));
+    }
+
+    [Test]
+    public void GetChatDetails_OnSuccessWithEmptyBody_Throws()
+    {
+        // A 200 with an empty body deserializes to a NULL DTO — malformed, not "no clan".
+        var repository = RepositoryReturning(HttpStatusCode.OK, "");
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await repository.GetChatDetails("peter#123"));
+    }
+
+    [Test]
+    public async Task GetChatDetails_OnSuccess_ReturnsTheClanId()
+    {
+        var repository = RepositoryReturning(HttpStatusCode.OK, "{\"clanId\":\"EwOk\"}");
+
+        var details = await repository.GetChatDetails("peter#123");
+
+        Assert.AreEqual("EwOk", details.ClanId, "the happy path must be unchanged by the new guards");
+    }
+
+    [Test]
+    public async Task GetChatDetails_OnSuccessWithNullClan_ReturnsNullClanId()
+    {
+        // A genuine 200 saying the player is in no clan stays a NON-throwing null ClanId — this is the
+        // one case that IS authoritative absence, and reconciliation must still act on it.
+        var repository = RepositoryReturning(HttpStatusCode.OK, "{\"clanId\":null}");
+
+        var details = await repository.GetChatDetails("peter#123");
+
+        Assert.IsNull(details.ClanId);
+    }
+}

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -198,7 +198,10 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
     /// omitting it, which the TTL convention documented on <see cref="Domain.ChatDomainIndexes"/>
     /// requires). Two concurrent calls for the SAME (kind, ref) resolve to exactly one document.
     /// </summary>
-    public async Task<ChatChannel> FindOrCreateSystem(SystemChannelKind kind, string systemRef, string name, DateTime now)
+    // Virtual: a test seam (same rationale as MembershipRepository.Delete / DeleteOrphanedForUser). PR41
+    // review (P2) moved this call onto the clan reconciler's FAIL-SOFT join path, and a throwing double is
+    // the only way to prove a shell-creation fault leaves the connect intact instead of rejecting it.
+    public virtual async Task<ChatChannel> FindOrCreateSystem(SystemChannelKind kind, string systemRef, string name, DateTime now)
     {
         var expiresAt = ExpiryCalculator.ForChannelShell(new ChatChannel { Type = ChannelType.System, SystemKind = kind }, now);
 

--- a/W3ChampionsChatService/Chats/ChatHub.Clan.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Clan.cs
@@ -169,49 +169,59 @@ public partial class ChatHub
         // the connect path (AssembleAndSeed calls it moments later), so this is a cheap repeat read
         // against the same BattleTag-prefixed index, not a new access pattern.
         var memberships = await _membershipRepository.LoadForUser(identity.BattleTag);
-        var existingClanChannelIds = memberships.Count == 0
-            ? Array.Empty<string>()
+        var existingClanChannels = memberships.Count == 0
+            ? Array.Empty<ChatChannel>()
             : (await _channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
                 .Where(c => c.Type == ChannelType.System && c.SystemKind == SystemChannelKind.Clan)
-                .Select(c => c.Id)
                 .ToArray();
 
-        // Resolve the target shell BEFORE removing anything, so "stale" is computed against a known
-        // target. Creating an empty shell grants nobody access, so doing it first is safe; the actual
-        // access grant (the membership insert) is deliberately the LAST step.
-        string targetChannelId = null;
-        ChatChannel targetChannel = null;
-        if (clanRef != null)
-        {
-            targetChannel = await _channelRepository.FindOrCreateSystem(
-                SystemChannelKind.Clan, clanRef, ClanChannelName(clanRef), now);
-            targetChannelId = targetChannel.Id;
-        }
+        // PR41 review (P2): staleness is derived from SystemRef, NOT from the id of a freshly-created
+        // target shell. System channels are unique on (SystemKind, SystemRef) — the ux_systemKind_systemRef
+        // index — so the clan channel whose SystemRef equals clanRef IS the target; comparing refs is
+        // exactly equivalent to comparing ids, without needing the shell to exist yet. Ordinal comparison
+        // mirrors the exact-match semantics FindOrCreateSystem's Mongo filter uses. A null clanRef (a fresh
+        // wb read saying "no clan") makes EVERY held clan channel stale, which is the intended departure
+        // case. This decoupling is what lets shell creation move onto the fail-soft join path below.
+        var staleClanChannels = existingClanChannels
+            .Where(c => clanRef == null || !string.Equals(c.SystemRef, clanRef, StringComparison.Ordinal))
+            .ToArray();
 
         // Revocation before grant: if this throws, the connect fails having granted nothing new.
-        foreach (var staleChannelId in existingClanChannelIds.Where(id => id != targetChannelId))
+        foreach (var stale in staleClanChannels)
         {
-            await _membershipRepository.Delete(staleChannelId, identity.BattleTag);
+            await _membershipRepository.Delete(stale.Id, identity.BattleTag);
             Log.Information(
                 "Clan reconcile: removed {BattleTag} from stale clan channel {ChannelId}",
-                identity.BattleTag, staleChannelId);
+                identity.BattleTag, stale.Id);
         }
 
-        if (targetChannel == null || existingClanChannelIds.Contains(targetChannelId))
+        // Nothing to grant: either a fresh wb read says the user is in no clan (the revocations above were
+        // the whole job), or they already hold the right clan channel — the idempotent reconnect case.
+        var alreadyMember = clanRef != null
+            && existingClanChannels.Any(c => string.Equals(c.SystemRef, clanRef, StringComparison.Ordinal));
+        if (clanRef == null || alreadyMember)
         {
             return;
         }
 
-        // FAIL-SOFT JOIN — see the method doc. A miss here costs the user a channel, never wrong access.
+        // FAIL-SOFT JOIN — see the method doc. Covers BOTH steps of the grant: the shell find-or-create
+        // AND the membership insert. PR41 review (P2) moved the find-or-create in here: creating a shell
+        // grants nobody access, so there is no access-control reason to fail closed on it, and leaving it
+        // outside made a transient channel-upsert fault reject the whole connection on the hot path every
+        // clan member takes on every connect — an availability regression against the behaviour on master,
+        // and a contradiction of this method's own stated policy that only revocation is fatal.
         try
         {
+            var channel = await _channelRepository.FindOrCreateSystem(
+                SystemChannelKind.Clan, clanRef, ClanChannelName(clanRef), now);
+
             // NotificationLevel.All — a clan channel is a primary, non-leavable lane, so it gets the same
             // default as a match channel (MatchChannelService.AddMemberWithInvariant), NOT JoinChannel's
             // opt-in Mentions default for rooms a user picked themselves. InsertIfAbsent (not Insert) for
             // race-safety against ux_channelId_battleTag when two sockets reconcile concurrently.
             await _membershipRepository.InsertIfAbsent(new ChannelMembership
             {
-                ChannelId = targetChannelId,
+                ChannelId = channel.Id,
                 BattleTag = identity.BattleTag,
                 Role = MembershipRole.Member,
                 NotificationLevel = NotificationLevel.All,

--- a/W3ChampionsChatService/Chats/ChatHub.Clan.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Clan.cs
@@ -34,14 +34,22 @@ namespace W3ChampionsChatService.Chats;
 /// rather than instantly.
 /// </para>
 /// <para>
-/// THE NEVER-CLOBBER INVARIANT. <see cref="ChatAuthenticationService"/> is fail-soft by design: on a wb
-/// outage it falls back to the cached directory profile, and on a total miss (tier 3) it returns a plain
-/// <see cref="ChatUser"/> whose <see cref="ChatUser.ClanTag"/> is <c>null</c>. A null from that tier means
-/// ABSENCE OF DATA, not "this user left their clan" — treating it as authoritative would evict every
-/// connecting clan member from their clan channel for the duration of a wb outage. So the REMOVAL half of
-/// reconciliation is gated on <see cref="ChatUserResolution.FreshFromWb"/>, exactly mirroring the gate
-/// <see cref="ChatHub.UpsertDirectory"/> already applies before replacing a cached Profile. A non-fresh
-/// resolution is ADDITIVE-ONLY.
+/// FRESHNESS IS AN ACCESS-CONTROL GATE. <see cref="ChatAuthenticationService"/> is fail-soft by design:
+/// on a wb outage it falls back to the cached directory profile, and on a total miss (tier 3) it returns
+/// a plain <see cref="ChatUser"/> whose <see cref="ChatUser.ClanTag"/> is <c>null</c>. Neither tier is
+/// authoritative — a null means ABSENCE OF DATA, not "this user left their clan", and a cached ClanId can
+/// name a clan the user has since left. Because a clan channel is PRIVATE, both directions of the
+/// decision (grant and revoke) are therefore made ONLY from a genuinely fresh wb read; a non-fresh
+/// resolution writes NOTHING and preserves whatever the user already had.
+/// <para>
+/// PR40 review (P1): this gate is only as trustworthy as the freshness flag feeding it, and that flag was
+/// lying. <see cref="WebsiteBackendRepository.GetChatDetails"/> did not check the HTTP status, so a wb
+/// 4xx/5xx whose body still deserialized produced a default-valued DTO, no exception, and
+/// <c>FreshFromWb: true</c> — an outage indistinguishable from "this user has no clan". That is fixed at
+/// the source (the repository now throws on a non-success status or an unusable body) rather than
+/// papered over here, because <see cref="ChatHub.UpsertDirectory"/> trusted the same flag and had the
+/// same latent never-clobber hole.
+/// </para>
 /// </para>
 /// <para>
 /// ORDERING. This runs in <see cref="ChatHub.OnConnectedAsync"/> BEFORE
@@ -52,10 +60,13 @@ namespace W3ChampionsChatService.Chats;
 /// snapshot carries it, no <c>ChannelAdded</c> push is needed (and none is emitted).
 /// </para>
 /// <para>
-/// FAIL-SOFT. Every step is wrapped: a Mongo hiccup or a malformed clan id must never fail an otherwise
-/// good connect. The user simply connects without their clan channel and self-heals on the next connect.
-/// This matches the posture of every other non-essential connect-path step (directory upsert, relationship
-/// prefetch) and deliberately NOT the fatal posture of <c>AssembleAndSeed</c> itself.
+/// ERROR POSTURE — SPLIT, NOT UNIFORMLY FAIL-SOFT (PR40 review P1). The original blanket catch was wrong
+/// in one direction: it also swallowed a failed REMOVAL, leaving the user readable/writable in a clan
+/// they had left, which <c>AssembleAndSeed</c> then seeded straight into the session. Revocation (and the
+/// read that decides what to revoke) is now FAIL-CLOSED — exceptions propagate and fail the connect,
+/// matching the fatal posture <c>AssembleAndSeed</c> already takes for this same collection. Only the
+/// JOIN is fail-soft, because its worst case is a missing channel that self-heals next connect, never a
+/// wrongly-granted one. See <see cref="ReconcileClanMembership"/> for the per-step breakdown.
 /// </para>
 /// </summary>
 public partial class ChatHub
@@ -85,74 +96,134 @@ public partial class ChatHub
     }
 
     /// <summary>
-    /// Brings the caller's System+Clan membership in line with <paramref name="resolution"/>: joins the
-    /// channel for their current clan (find-or-create), and — only on a FRESH wb resolution — drops any
-    /// clan membership that is no longer theirs. Idempotent: a reconnect with an unchanged clan writes
-    /// nothing. See the class doc for the ordering, sync-model and never-clobber rationale.
+    /// Brings the caller's System+Clan membership in line with <paramref name="resolution"/>.
+    /// <para>
+    /// PR40 review — the error posture is SPLIT along the security boundary rather than uniformly
+    /// fail-soft, because the two halves of reconciliation fail in opposite directions:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><b>Removing a stale clan membership — FAIL CLOSED (exceptions propagate).</b> A failed
+    /// delete leaves the user readable/writable in a clan they are no longer in, and
+    /// <see cref="Protocol.SessionStateAssembler.AssembleAndSeed"/> runs microseconds later and seeds that
+    /// very row into the session. Swallowing it would silently grant access to a former clan's channel and
+    /// its retained history. Letting it propagate fails the connect, which is the SAME posture
+    /// AssembleAndSeed itself already takes for this collection — and a Mongo fault that breaks this
+    /// delete would almost certainly fail AssembleAndSeed on the next line anyway.</item>
+    /// <item><b>Joining the current clan channel — FAIL SOFT (caught and logged).</b> The worst case is a
+    /// user briefly missing a channel they are entitled to, which self-heals on the next connect. No
+    /// access is wrongly granted, so this must never cost anyone their chat session.</item>
+    /// </list>
+    /// <para>
+    /// The read that decides WHICH rows are stale is likewise fail-closed: acting on a partial view of
+    /// the user's memberships is exactly how a stale row survives unnoticed.
+    /// </para>
+    /// <para>
+    /// Idempotent: a reconnect with an unchanged clan writes nothing. See the class doc for the ordering,
+    /// sync-model and freshness rationale.
+    /// </para>
     /// </summary>
-    private async Task ReconcileClanMembership(W3CUserAuthentication identity, ChatUserResolution resolution, DateTime now)
+    // internal (not private) purely as a test seam — the assembly already grants InternalsVisibleTo to
+    // the test project. Calling it directly is the only way to exercise the displacement gate below,
+    // which by definition requires the session registry to have moved on MID-connect.
+    internal async Task ReconcileClanMembership(W3CUserAuthentication identity, ChatUserResolution resolution, DateTime now)
     {
+        // GATE 1 — FRESHNESS (PR40 review P1, tightened from "additive-only" to "no writes at all").
+        // A non-fresh resolution carries flair from the directory cache (tier 2) or nothing at all
+        // (tier 3), and the cached ClanId can be arbitrarily stale: directory entries are retained
+        // FOREVER (never TTL'd), while CleanupJobs.PruneIdleMemberships deletes the membership rows of
+        // users idle > 1 year. So a user who left their clan while inactive and returns during a wb
+        // outage has a cached ClanId naming a clan they are no longer in, and no membership row to
+        // contradict it — the original additive-only rule would have re-admitted them to that clan's
+        // channel AND its retained message history on nothing but unverifiable cached data.
+        // Membership in a private channel is an ACCESS-CONTROL decision, so it is now made ONLY from a
+        // genuinely fresh wb read. A non-fresh connect preserves whatever the user already had and
+        // self-heals on the next fresh one.
+        if (!resolution.FreshFromWb)
+        {
+            Log.Debug(
+                "Clan reconcile: skipped for {BattleTag} — resolution is not fresh from wb", identity.BattleTag);
+            return;
+        }
+
+        // GATE 2 — DISPLACEMENT (PR40 review P2). Registering a newer connection for the same battleTag
+        // aborts the older HubCallerContext but does NOT cancel the older OnConnectedAsync task, which
+        // keeps running with the clan snapshot IT captured. If the two overlap across a clan change, the
+        // loser finishing last would re-add the old membership and delete the new one — durable state
+        // decided by scheduling order. TryGetByConnectionId resolves a displaced-but-not-yet-closed
+        // connection to nothing (it returns the entry only while it is still the CURRENT one for that
+        // battleTag), which is the same fail-closed check the permission filter relies on. This narrows
+        // the window to the reads/writes below rather than eliminating it; the residual race is a
+        // same-user reconnect landing inside those few milliseconds, which converges on the next connect.
+        if (!_sessionRegistry.TryGetByConnectionId(Context.ConnectionId, out _))
+        {
+            Log.Information(
+                "Clan reconcile: skipped for {BattleTag} — connection {ConnectionId} was displaced",
+                identity.BattleTag, Context.ConnectionId);
+            return;
+        }
+
+        var clanRef = NormalizeClanRef(resolution.User?.ClanTag);
+
+        // FAIL-CLOSED READ + REMOVAL (PR40 review P1). Deliberately NOT wrapped in a catch — see the
+        // method doc. Resolve the clan memberships the user currently holds; LoadForUser is already on
+        // the connect path (AssembleAndSeed calls it moments later), so this is a cheap repeat read
+        // against the same BattleTag-prefixed index, not a new access pattern.
+        var memberships = await _membershipRepository.LoadForUser(identity.BattleTag);
+        var existingClanChannelIds = memberships.Count == 0
+            ? Array.Empty<string>()
+            : (await _channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
+                .Where(c => c.Type == ChannelType.System && c.SystemKind == SystemChannelKind.Clan)
+                .Select(c => c.Id)
+                .ToArray();
+
+        // Resolve the target shell BEFORE removing anything, so "stale" is computed against a known
+        // target. Creating an empty shell grants nobody access, so doing it first is safe; the actual
+        // access grant (the membership insert) is deliberately the LAST step.
+        string targetChannelId = null;
+        ChatChannel targetChannel = null;
+        if (clanRef != null)
+        {
+            targetChannel = await _channelRepository.FindOrCreateSystem(
+                SystemChannelKind.Clan, clanRef, ClanChannelName(clanRef), now);
+            targetChannelId = targetChannel.Id;
+        }
+
+        // Revocation before grant: if this throws, the connect fails having granted nothing new.
+        foreach (var staleChannelId in existingClanChannelIds.Where(id => id != targetChannelId))
+        {
+            await _membershipRepository.Delete(staleChannelId, identity.BattleTag);
+            Log.Information(
+                "Clan reconcile: removed {BattleTag} from stale clan channel {ChannelId}",
+                identity.BattleTag, staleChannelId);
+        }
+
+        if (targetChannel == null || existingClanChannelIds.Contains(targetChannelId))
+        {
+            return;
+        }
+
+        // FAIL-SOFT JOIN — see the method doc. A miss here costs the user a channel, never wrong access.
         try
         {
-            var clanRef = NormalizeClanRef(resolution.User?.ClanTag);
-
-            // Resolve the clan memberships the user currently holds. LoadForUser is already on the
-            // connect path's hot loop (AssembleAndSeed calls it moments later), so this is a cheap
-            // repeat read against the same BattleTag-prefixed index, not a new access pattern.
-            var memberships = await _membershipRepository.LoadForUser(identity.BattleTag);
-            var existingClanChannelIds = memberships.Count == 0
-                ? Array.Empty<string>()
-                : (await _channelRepository.LoadByIds(memberships.Select(m => m.ChannelId)))
-                    .Where(c => c.Type == ChannelType.System && c.SystemKind == SystemChannelKind.Clan)
-                    .Select(c => c.Id)
-                    .ToArray();
-
-            string targetChannelId = null;
-            if (clanRef != null)
+            // NotificationLevel.All — a clan channel is a primary, non-leavable lane, so it gets the same
+            // default as a match channel (MatchChannelService.AddMemberWithInvariant), NOT JoinChannel's
+            // opt-in Mentions default for rooms a user picked themselves. InsertIfAbsent (not Insert) for
+            // race-safety against ux_channelId_battleTag when two sockets reconcile concurrently.
+            await _membershipRepository.InsertIfAbsent(new ChannelMembership
             {
-                var channel = await _channelRepository.FindOrCreateSystem(
-                    SystemChannelKind.Clan, clanRef, ClanChannelName(clanRef), now);
-                targetChannelId = channel.Id;
-
-                if (!existingClanChannelIds.Contains(channel.Id))
-                {
-                    // NotificationLevel.All — a clan channel is a primary, non-leavable lane, so it gets
-                    // the same default as a match channel (MatchChannelService.AddMemberWithInvariant),
-                    // NOT JoinChannel's opt-in Mentions default for rooms a user picked themselves.
-                    // InsertIfAbsent (not Insert) for race-safety against ux_channelId_battleTag when two
-                    // sockets for the same battleTag reconcile concurrently.
-                    await _membershipRepository.InsertIfAbsent(new ChannelMembership
-                    {
-                        ChannelId = channel.Id,
-                        BattleTag = identity.BattleTag,
-                        Role = MembershipRole.Member,
-                        NotificationLevel = NotificationLevel.All,
-                        JoinedAt = now,
-                    });
-                    Log.Information(
-                        "Clan reconcile: joined {BattleTag} to clan channel {ClanRef}", identity.BattleTag, clanRef);
-                }
-            }
-
-            // NEVER-CLOBBER (see class doc): only a FRESH wb read is authoritative about clan DEPARTURE.
-            // A cached/plain resolution is additive-only — it may join, never evict.
-            if (!resolution.FreshFromWb)
-            {
-                return;
-            }
-
-            foreach (var staleChannelId in existingClanChannelIds.Where(id => id != targetChannelId))
-            {
-                await _membershipRepository.Delete(staleChannelId, identity.BattleTag);
-                Log.Information(
-                    "Clan reconcile: removed {BattleTag} from stale clan channel {ChannelId}",
-                    identity.BattleTag, staleChannelId);
-            }
+                ChannelId = targetChannelId,
+                BattleTag = identity.BattleTag,
+                Role = MembershipRole.Member,
+                NotificationLevel = NotificationLevel.All,
+                JoinedAt = now,
+            });
+            Log.Information(
+                "Clan reconcile: joined {BattleTag} to clan channel {ClanRef}", identity.BattleTag, clanRef);
         }
         catch (Exception ex)
         {
-            // Non-fatal by design — a clan-channel hiccup must never cost the user their chat session.
-            Log.Warning(ex, "Clan-channel reconciliation failed for {BattleTag} — connecting without it", identity.BattleTag);
+            Log.Warning(
+                ex, "Clan-channel join failed for {BattleTag} — connecting without it", identity.BattleTag);
         }
     }
 }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -225,9 +225,14 @@ public partial class ChatHub(
 
         // Clan-channel reconciliation (2026-08-09) — MUST run BEFORE AssembleAndSeed, which reads the
         // membership rows this may write. Reuses the clan id already carried by `resolution` (the same wb
-        // round-trip hoisted above for flair), so it costs no extra network call. Self-contained and
-        // fail-soft — see ChatHub.Clan.cs for the full rationale, including why removal is gated on
-        // resolution.FreshFromWb.
+        // round-trip hoisted above for flair), so it costs no extra network call.
+        //
+        // PARTIALLY FATAL (PR40 review P1) — deliberately NOT fully fail-soft. Revoking a stale clan
+        // membership (and the read that identifies one) throws on failure, because a swallowed failure
+        // would leave the user with live access to a former clan's channel that AssembleAndSeed seeds on
+        // the very next line. Joining is fail-soft internally. So this await can fail the connect for the
+        // same class of Mongo fault that AssembleAndSeed below already treats as fatal — see
+        // ChatHub.Clan.cs for the full rationale.
         await ReconcileClanMembership(identity, resolution, now);
 
         // C3 (Task 8): assemble the SessionState snapshot and seed this connection's fan-out state (the

--- a/W3ChampionsChatService/Chats/WebsiteBackendRepository.cs
+++ b/W3ChampionsChatService/Chats/WebsiteBackendRepository.cs
@@ -37,9 +37,31 @@ public class WebsiteBackendRepository(IHttpClientFactory httpClientFactory) : IW
         httpClient.Timeout = TimeSpan.FromSeconds(2);
         var escapeDataString = Uri.EscapeDataString(battleTag);
         var result = await httpClient.GetAsync($"/api/players/{escapeDataString}/clan-and-picture");
+
+        // PR40 review (P1): FAIL LOUDLY on a non-success response instead of silently degrading to a
+        // default-valued DTO. Without this, a wb 4xx/5xx whose body still happens to deserialize (a JSON
+        // error envelope like {"error":"..."} binds happily to ChatDetailsDto, leaving every property
+        // null) returned a non-null DTO with ClanId == null and NO exception — so
+        // ChatAuthenticationService.GetUserFromIdentity never entered its catch and stamped the result
+        // FreshFromWb: TRUE. Callers that treat freshness as authoritative then acted on fabricated
+        // "absence" data:
+        //   * ChatHub.ReconcileClanMembership read "no clan" as a clan DEPARTURE and deleted the user's
+        //     clan membership — the exact eviction its never-clobber gate exists to prevent (the gate was
+        //     correct; the signal it trusted was not).
+        //   * ChatHub.UpsertDirectory replaced a good cached Profile with the near-null one — a LATENT
+        //     never-clobber violation that predates the clan work and is fixed by the same change.
+        // Throwing routes both back through the intended three-tier fallback (cache, then plain) with
+        // FreshFromWb: false, which is what "we could not reach wb" is supposed to look like.
+        result.EnsureSuccessStatusCode();
+
         var content = await result.Content.ReadAsStringAsync();
         var userDetails = JsonConvert.DeserializeObject<ChatDetailsDto>(content);
-        return userDetails;
+
+        // A 200 carrying an empty/whitespace/`null` body deserializes to a NULL DTO. That is a
+        // malformed response, not a player with no clan, so it must not be reported as fresh truth
+        // either — same reasoning as the status check above.
+        return userDetails ?? throw new InvalidOperationException(
+            $"wb returned a success status with an unusable clan-and-picture body for {battleTag}");
     }
 }
 

--- a/W3ChampionsChatService/Memberships/MembershipRepository.cs
+++ b/W3ChampionsChatService/Memberships/MembershipRepository.cs
@@ -89,7 +89,10 @@ public class MembershipRepository(MongoClient mongoClient, ChannelRepository cha
         return Memberships.Find(m => m.BattleTag == tag).Project(m => m.ChannelId).ToListAsync();
     }
 
-    public Task Delete(string channelId, string battleTag)
+    // Virtual: a test seam, mirroring DeleteOrphanedForUser's existing precedent in this class. PR40
+    // review (P1) made clan-membership REVOCATION fail-closed, and the only way to prove a failed delete
+    // fails the connect (rather than silently leaving the user in a former clan) is a throwing double.
+    public virtual Task Delete(string channelId, string battleTag)
     {
         var tag = NormalizeTag(battleTag);
         return Memberships.DeleteOneAsync(m => m.ChannelId == channelId && m.BattleTag == tag);


### PR DESCRIPTION
Follow-up to **#40**, addressing all four Codex findings. #40 was merged ~3 minutes before the review landed, so this ships as a separate PR against `master` rather than a fix-up commit.

I verified each finding against the code rather than taking them as given. **All four are real**, and the three P1s turned out to share one root theme: *reconciliation decided **private**-channel access from unreliable signals, and failed open.*

---

### P1 — Treat only successful WB responses as authoritative ✅ valid

`GetChatDetails` never called `EnsureSuccessStatusCode`. A wb 4xx/5xx whose body still deserializes — a JSON error envelope like `{"error":"..."}` binds happily to `ChatDetailsDto`, leaving every property null — returned a **non-null DTO with `ClanId == null` and no exception**. So `GetUserFromIdentity` never entered its catch and stamped the result `FreshFromWb: true`.

That made a wb outage **indistinguishable from "this player has no clan"**, which the reconciler read as a clan *departure* and acted on by deleting the membership. The never-clobber gate in #40 was correct; the signal it trusted was not. This is the finding that mattered most — it defeated #40`s headline safety property.

Fixed at the source: a non-success status or an unusable body now throws, routing back through the intended cache/plain tiers with `FreshFromWb: false`.

> [!IMPORTANT]
> **Wider blast radius, deliberately.** `UpsertDirectory` trusts the same flag, so it had the identical latent never-clobber hole — a wb 500 would replace a good cached Profile with near-null flair. That bug predates the clan work and is repaired by the same change. Calling it out because this PR now affects flair behaviour for **all** users, not just clan members.

### P1 — Do not grant clan access from cached flair ✅ valid

The described scenario is exact: directory entries are retained forever (`CleanupJobs.cs:104` — *"entries are kept, never TTL`d"*), while `PruneIdleMemberships` deletes membership rows for users idle > 1 year. A user who left their clan while inactive returns with a cached `ClanId` naming a clan they are no longer in, and **no membership row to contradict it** — so #40`s additive-only rule would have re-admitted them to that channel and its retained history.

Tightened from *"additive-only when not fresh"* to **"no writes at all when not fresh"**. Membership in a private channel is an access-control decision, so both directions — grant and revoke — are now made only from a fresh wb read. A non-fresh connect preserves what the user already had and self-heals on the next fresh one.

### P1 — Fail closed when stale clan removal does not complete ✅ valid

The blanket catch also swallowed a failed *delete*, and `AssembleAndSeed` reloads and seeds that row on the very next line — leaving the user readable **and writable** in a former clan, not merely missing the new one as the fail-soft comment claimed.

Error posture is now **split along the security boundary**:

| Step | Posture | Worst case |
|---|---|---|
| Read + revoke stale membership | **fail closed** (propagates) | connect fails, user retries |
| Join current clan channel | fail soft (caught) | missing channel, self-heals next connect |

Fail-closed is consistent with existing conventions: `AssembleAndSeed` is already fatal for this same collection, and a Mongo fault breaking the delete would very likely fail it on the next line regardless. Revocation is also now ordered **before** the grant, so a failure aborts having granted nothing.

### P2 — Prevent displaced connects from reconciling ✅ valid

Registering a newer connection aborts the older `HubCallerContext` but does not cancel its in-flight `OnConnectedAsync`, which still holds the clan snapshot *it* captured. Across a clan change the loser could finish last and overwrite the winner.

Guarded with `SessionRegistry.TryGetByConnectionId`, which resolves a displaced-but-not-yet-closed connection to nothing — the same fail-closed check the permission filter already relies on. This **narrows rather than eliminates** the window: a residual race remains if a reconnect lands inside the few milliseconds spanning these reads/writes, and it converges on the next connect. Serializing per-battleTag would close it fully; that felt disproportionate here, but say the word.

---

## Test seams

Two small production changes exist purely to make the above testable:

- `MembershipRepository.Delete` is now `virtual` — mirroring the existing `DeleteOrphanedForUser` precedent in the same class — so a throwing double can prove a failed revocation fails the connect.
- `ReconcileClanMembership` is `internal` (the assembly already grants `InternalsVisibleTo` to tests), because the displacement gate is mid-connect by nature and cannot be reached through `OnConnectedAsync`.

## Testing

Adds `WebsiteBackendRepositoryTests` (5 tests) plus 4 tests to `ChatHubClanChannelTests` covering cached-flair denial, no-writes-when-not-fresh, fail-closed revocation, and the displaced-connect guard.

> [!WARNING]
> **Still unrun, same constraint as #40.** Builds clean (0 errors), but the suite is Testcontainers-backed and Docker is unavailable in the authoring environment. The new `WebsiteBackendRepositoryTests` need no Mongo, but the namespace-level fixture gates the whole assembly. **#40 is already on master and its tests have never been executed either** — CI on this PR will be the first real signal for both.