### PR TITLE
fix(chat): enforce lounge mutes in ladder match rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,33 @@ message-history read (below). It is defined exactly once, in
 (`ChannelModeration.IsModeratable`), specifically so the hub and the REST surface can never drift apart
 on what a moderator is allowed to touch.
 
+### Mute scope — where a lounge mute actually bites
+
+There is a **second, narrower** scope wall, defined next to `IsModeratable` in the same file
+(`ChannelModeration.IsMuteEnforced`) and read by exactly one call site — step 6 of `ChatHub.SendMessage`.
+A lounge mute (full or shadow) is enforced on a send iff the channel is:
+
+- **Public**, or
+- a **ladder match room** — `System` + `SystemKind.Match` + `ChatChannel.Ladder`.
+
+Everything else is exempt: SemiPublic, DMs/group DMs, clan and lobby system channels, and — deliberately
+— **custom-game match rooms**. A muted player can still talk in the custom lobby that invited them; they
+cannot talk in a ladder game's in-game or post-game chat.
+
+The two walls are intentionally different sets and must not be collapsed. `IsModeratable` answers "may a
+moderator reach into this room after the fact" (delete/purge/history) and covers SemiPublic and *every*
+match room; `IsMuteEnforced` answers "is a muted user silenced while typing here", which is a product
+decision about competitive-integrity surface.
+
+**`ChatChannel.Ladder` is the only thing separating ladder from custom.** chat-service uses one
+`SystemKind.Match` for both; both refs are a bare `nanoid(10)`, both create through the same endpoint,
+and `detached` is set on *both* (at birth for ladder, at game start for a custom lobby), so `detached`
+cannot be — and must never be made to — answer "is this ladder". The flag is set only from mm's explicit
+`ladder: true` on the internal create/roster-assert calls (below), and is **sticky-true for the life of
+the channel document**: no update ever clears it, so an older mm, a partial rollout, or a retry built
+from a stale payload can never silently un-moderate a live ladder room. It does not survive teardown —
+if a ref is deleted and later recreated, the recreating call must send `ladder: true` again.
+
 ### Shadow-ban model
 
 A shadow-banned user's messages are stored normally (`ChannelMessage.Shadow = true`) but routed
@@ -292,6 +319,16 @@ Optional additive fields (absent ⇒ today's behavior, byte-for-byte):
   on create**: chat-service uses one channel kind for both custom lobbies and ladder matches, and ladder
   refs are never part of mm's live-lobby registry, so without birth-detach the first epoch sync after any
   mm restart would tear down every in-progress ladder game's chat.
+- `ladder` (bool) — declares this ref a **ladder match** rather than a custom-game lobby. Absent/false ⇒
+  custom lobby, today's behavior byte-for-byte. **Ladder matches must send `ladder: true`**: this flag is
+  the sole input to the mute scope described under [Mute scope](#mute-scope--where-a-lounge-mute-actually-bites),
+  so a ladder match created without it lets lounge-muted and shadow-banned players chat freely in its
+  in-game and post-game room. Sticky-true server-side — once set for a ref it is never cleared, so a
+  later call that omits it is a harmless no-op rather than a silent un-moderation.
+
+  It is deliberately **separate from `detached`**, even though mm happens to send both together on the
+  ladder create path. The two answer different questions and their sets are not the same: `detached` is
+  also set on every custom lobby at game start.
 
 ### `PUT /internal/channels/{ref}/roster`
 
@@ -301,7 +338,7 @@ A user-initiated leave (`ChatHub.LeaveChannel`) on a live match channel is re-co
 assertion, by design (2026-08-05 reconciliation review, H4) — mm is authoritative for lobby membership.
 
 ```json
-{ "epoch": "<opaque token>", "seq": 1, "members": ["Tag#1", "Tag#2"], "name": "My Lobby", "detached": false }
+{ "epoch": "<opaque token>", "seq": 1, "members": ["Tag#1", "Tag#2"], "name": "My Lobby", "detached": false, "ladder": false }
 ```
 
 - `epoch` — an **opaque string** (the same character class/length cap as `ref`), mm's authority
@@ -317,6 +354,11 @@ assertion, by design (2026-08-05 reconciliation review, H4) — mm is authoritat
   length/trim/charset validation of its own to a custom-game lobby name before sending it, and a field
   chat cannot store must never be able to reject the entire authoritative roster.
 - `detached` — see below.
+- `ladder` — same meaning as on the create call above. Carried here too because this route is *also* a
+  channel-creating path: mm's ladder create has a retry-on-failure fallback that converges through
+  `PUT .../roster`, and that assertion may be the call that creates the room on demand. Applied **before**
+  the detach-freeze and staleness gates, and independently of both — a discarded assertion discards its
+  *roster*, not the truth about what kind of room this is.
 
 **Staleness — `(epoch, seq)` admission table**, persisted per channel:
 
@@ -385,6 +427,13 @@ only trigger a pointless mm retry), and — unlike the roster assertion — this
 authoritative teardown mm chooses to send.
 
 ### Deploy order
+
+**`ladder` is inert until mm sends it.** The mute gate reads a flag only mm can set, so between this
+service's deploy and mm's, ladder match rooms stay exactly as unmoderated as they are today — this
+half of the change fixes nothing on its own and needs the matching mm release to take effect. It is
+additive and fail-open in that direction by construction: an absent flag reads as "custom lobby". Rooms
+created before mm's deploy are never retro-classified (the flag is only ever written by an incoming
+call), so the gate starts applying to matches created from mm's deploy onward, not to in-flight ones.
 
 **chat-service deploys before (or with) mm.** Until mm's own deploy lands, its still-running deployment
 keeps calling the old membership-delta endpoint this service no longer serves — those calls `404`

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -184,6 +184,23 @@ public class ChatHubSendMessageTests : IntegrationTestBase
         return channel;
     }
 
+    // A System+Match channel — the shape mm's /internal/channels create produces. `ladder` is mm's
+    // own declaration that this ref is a LADDER match (as opposed to a custom-game lobby); it is the
+    // sole discriminator between the two, since both share SystemKind.Match.
+    private async Task<ChatChannel> CreateMatchChannel(string systemRef, bool ladder)
+    {
+        var channel = new ChatChannel
+        {
+            Type = ChannelType.System,
+            SystemKind = SystemChannelKind.Match,
+            SystemRef = systemRef,
+            Name = systemRef,
+            Ladder = ladder,
+        };
+        await _channelRepository.Insert(channel);
+        return channel;
+    }
+
     private static ChatUser FlairUser(string battleTag) =>
         new(battleTag, false, "W3C", new ProfilePicture { Race = AvatarCategory.NE, PictureId = 42, IsClassic = true }, null, null);
 
@@ -462,6 +479,91 @@ public class ChatHubSendMessageTests : IntegrationTestBase
         var persisted = await _messageRepository.Load(result.MessageId);
         Assert.IsNotNull(persisted);
         Assert.IsTrue(persisted.Shadow, "A shadow-muted send must persist with Shadow=true");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Mute gate — LADDER match channels (System+Match with Ladder=true)
+    //
+    // A ladder match's post-game room is moderated exactly like a Public room: a full mute rejects the
+    // send, a shadow ban persists flagged. A CUSTOM-GAME lobby's room is the same channel shape
+    // (System+Match) with Ladder=false and stays exempt — mm's `ladder` flag is the only thing that
+    // separates them.
+    // ---------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Send_FullMuted_LadderMatchChannel_ReturnsMuted()
+    {
+        var channel = await CreateMatchChannel("ladder-ref-1", ladder: true);
+        SeedMember("conn-1", BattleTag, channel.Id, mute: MuteStatus.Full, muteEnd: Now.AddDays(1));
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.SendMessage(channel.Id, "gg ez");
+
+        Assert.AreEqual(ChatResultCode.Muted, result.Code);
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.AreEqual(0L, reloaded.LastSeq, "A full-muted send in a ladder match channel must not persist");
+    }
+
+    [Test]
+    public async Task Send_ShadowMuted_LadderMatchChannel_ReturnsOk_PersistsFlagged()
+    {
+        var channel = await CreateMatchChannel("ladder-ref-2", ladder: true);
+        SeedMember("conn-1", BattleTag, channel.Id, mute: MuteStatus.Shadow, muteEnd: Now.AddDays(1));
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.SendMessage(channel.Id, "shadow whisper");
+
+        // Same illusion as a Public room: Ok to the sender, persisted flagged, delivered to nobody else.
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        var persisted = await _messageRepository.Load(result.MessageId);
+        Assert.IsNotNull(persisted);
+        Assert.IsTrue(persisted.Shadow, "A shadow-muted send in a ladder match channel must persist with Shadow=true");
+    }
+
+    [Test]
+    public async Task Send_Unmuted_LadderMatchChannel_SendsNormally()
+    {
+        var channel = await CreateMatchChannel("ladder-ref-3", ladder: true);
+        SeedMember("conn-1", BattleTag, channel.Id);
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.SendMessage(channel.Id, "gg wp");
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        var persisted = await _messageRepository.Load(result.MessageId);
+        Assert.IsFalse(persisted.Shadow, "An unmuted ladder send is never flagged");
+    }
+
+    [Test]
+    public async Task Send_FullMuted_CustomLobbyMatchChannel_StillSends()
+    {
+        // Custom-game lobby/post-game stays EXEMPT (explicit product decision): same channel shape,
+        // Ladder=false.
+        var channel = await CreateMatchChannel("custom-ref-1", ladder: false);
+        SeedMember("conn-1", BattleTag, channel.Id, mute: MuteStatus.Full, muteEnd: Now.AddDays(1));
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.SendMessage(channel.Id, "lobby chatter");
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        var persisted = await _messageRepository.Load(result.MessageId);
+        Assert.IsNotNull(persisted, "A full-muted send in a custom-lobby match channel must still persist");
+        Assert.IsFalse(persisted.Shadow, "A full-mute is not a shadow flag");
+    }
+
+    [Test]
+    public async Task Send_ShadowMuted_CustomLobbyMatchChannel_PersistsUnflagged()
+    {
+        var channel = await CreateMatchChannel("custom-ref-2", ladder: false);
+        SeedMember("conn-1", BattleTag, channel.Id, mute: MuteStatus.Shadow, muteEnd: Now.AddDays(1));
+        var hub = BuildHub("conn-1");
+
+        var result = await hub.SendMessage(channel.Id, "lobby chatter");
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        var persisted = await _messageRepository.Load(result.MessageId);
+        Assert.IsFalse(persisted.Shadow,
+            "A custom-lobby match channel is outside the mute scope — a shadow ban must not flag the message there");
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
@@ -825,7 +825,8 @@ public class DmGroupIntegrationTests : IntegrationTestBase
         // A FULL mute on the user's live connection (cache-only enforcement, the SendMessage mute gate seam).
         _connectionMapping.SetMute("conn-user", MuteStatus.Full, Now.AddDays(1));
 
-        // Public: gated → Muted (the control). DM + group: the mute gate is PUBLIC-ONLY, so both send Ok.
+        // Public: gated → Muted (the control). DM + group: the mute scope
+        // (ChannelModeration.IsMuteEnforced) covers only Public and LADDER match rooms, so both send Ok.
         Assert.That((await userHub.SendMessage(pub.Id, "public")).Code, Is.EqualTo(ChatResultCode.Muted), "a full mute gates a PUBLIC send");
         var dmSend = await userHub.SendMessage(dm.Channel.Id, "dm while muted");
         Assert.That(dmSend.Code, Is.EqualTo(ChatResultCode.Ok), "a full mute does NOT gate a DM send");

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -500,6 +500,55 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "match-legacy");
         Assert.That(channel.AssertEpoch, Is.Null, "no stamp is written when epoch/seq are omitted — the back-compat pin for today's mm");
         Assert.That(channel.Detached, Is.False);
+        Assert.That(channel.Ladder, Is.False, "and an omitted `ladder` means custom-game lobby — the mute-exempt default");
+    }
+
+    // ── `ladder` — the send-path mute scope's discriminator ─────────────────────────────────────
+
+    [Test]
+    public async Task PostCreate_WithLadderTrue_200_AndChannelIsMarkedLadder()
+    {
+        var request = ValidCreateRequest(@ref: "ladder-1", members: "Peter#123");
+        request.Detached = true;
+        request.Ladder = true;
+
+        var result = await _controller.Create(request) as OkObjectResult;
+
+        Assert.That(result, Is.Not.Null);
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "ladder-1");
+        Assert.That(channel.Ladder, Is.True);
+        Assert.That(ChannelModeration.IsMuteEnforced(channel), Is.True,
+            "which is the whole point: a lounge-muted player is silenced in a ladder match room");
+    }
+
+    [Test]
+    public async Task PostCreate_WithDetachedButNoLadder_200_AndChannelIsNotMuteGated()
+    {
+        // `detached` is NOT a ladder signal — mm sets it on every custom lobby at game start too. A
+        // custom lobby's post-game room must stay mute-exempt.
+        var request = ValidCreateRequest(@ref: "lobby-1", members: "Peter#123");
+        request.Detached = true;
+
+        await _controller.Create(request);
+
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "lobby-1");
+        Assert.That(channel.Detached, Is.True);
+        Assert.That(ChannelModeration.IsMuteEnforced(channel), Is.False,
+            "detach must never be inferred as ladder-ness — the two answer different questions");
+    }
+
+    [Test]
+    public async Task PutRoster_WithLadderTrue_200_AndChannelIsMarkedLadder()
+    {
+        // mm's ladder create-failure fallback lands here, and this assertion may itself create the room.
+        var request = ValidRosterRequest(detached: true, members: "Peter#123");
+        request.Ladder = true;
+
+        var result = await _controller.AssertRoster("ladder-1", request) as OkResult;
+
+        Assert.That(result, Is.Not.Null);
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "ladder-1");
+        Assert.That(channel.Ladder, Is.True);
     }
 
     // ── POST /internal/channels/epoch-sync ──────────────────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -1425,4 +1425,105 @@ public class MatchChannelServiceTests : IntegrationTestBase
         Assert.That(_harness.AllSignals.Count - pushesBefore, Is.EqualTo(1),
             "a channel whose doc vanished between the scan and its turn is skipped, not torn down on stale data");
     }
+
+    // ============================================================================================
+    // LADDER classification — the send-path mute scope's sole discriminator
+    //
+    // chat-service uses ONE SystemKind.Match for both ladder matches and custom-game lobbies, so
+    // ChatChannel.Ladder is what tells ChannelModeration.IsMuteEnforced which is which. These pin the
+    // three properties the gate depends on: it is stamped on BOTH creating routes, it is sticky-true,
+    // and it is applied independently of the detach/staleness gates that guard MEMBERSHIP.
+    // ============================================================================================
+
+    [Test]
+    public async Task CreateOrGet_WithoutLadder_LeavesChannelUnmarked()
+    {
+        var channel = await _service.CreateOrGet("lobby-1", "My Lobby", Members("Alice#1"), focus: false);
+
+        Assert.That(channel.Ladder, Is.False, "a custom-game lobby is the default — the flag must be opt-in");
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.Ladder, Is.False);
+    }
+
+    [Test]
+    public async Task CreateOrGet_WithLadderTrue_MarksChannelLadder()
+    {
+        var channel = await _service.CreateOrGet(
+            "ladder-1", "w3c-20-abc", Members("Alice#1"), focus: false, detached: true, ladder: true);
+
+        Assert.That(channel.Ladder, Is.True, "the returned entity reflects the stamp, not the pre-call read");
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.Ladder, Is.True, "and it is durable");
+    }
+
+    [Test]
+    public async Task CreateOrGet_LadderIsStickyTrue_ALaterCallWithoutTheFlagNeverClearsIt()
+    {
+        var channel = await _service.CreateOrGet(
+            "ladder-1", "w3c-20-abc", Members("Alice#1"), focus: false, ladder: true);
+
+        // An older mm, a half-finished rollout, or a retry rebuilt from a stale payload.
+        await _service.CreateOrGet("ladder-1", "w3c-20-abc", Members("Alice#1"), focus: false);
+
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.Ladder, Is.True,
+            "ladder-ness is immutable for a ref — nothing may un-moderate a ladder room mid-game");
+    }
+
+    [Test]
+    public async Task Assert_WithLadderTrue_OnCreateOnDemand_MarksChannelLadder()
+    {
+        // mm's ladder create-failure fallback: the room is born on the ROSTER route, not the create route.
+        await _service.ApplyRosterAssertion(
+            "ladder-1", "e1", 1, Members("Alice#1"), name: "w3c-20-abc", detached: true, ladder: true);
+
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "ladder-1");
+        Assert.That(channel.Ladder, Is.True,
+            "a ladder room created by the assertion fallback must still be inside the mute scope");
+    }
+
+    [Test]
+    public async Task Assert_LadderIsStickyTrue_ALaterAssertionWithoutTheFlagNeverClearsIt()
+    {
+        await _service.ApplyRosterAssertion(
+            "ladder-1", "e1", 1, Members("Alice#1"), name: null, detached: false, ladder: true);
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "ladder-1");
+
+        await _service.ApplyRosterAssertion("ladder-1", "e1", 2, Members("Alice#1"), name: null, detached: false);
+
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.Ladder, Is.True,
+            "the roster route's stamp is a no-op on absence, never a clear — same rule as the create route");
+    }
+
+    [Test]
+    public async Task Assert_AgainstFrozenChannel_StillStampsLadder_EvenThoughTheRosterIsDiscarded()
+    {
+        var channel = await _service.CreateOrGet("ladder-1", "w3c-20-abc", Members("Alice#1"), focus: false, detached: true);
+
+        var outcome = await _service.ApplyRosterAssertion(
+            "ladder-1", "e1", 1, Members("Bob#2"), name: null, detached: false, ladder: true);
+
+        Assert.That(outcome, Is.EqualTo(RosterAssertionOutcome.DiscardedFrozen), "the roster is still discarded");
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.Ladder, Is.True,
+            "but the classification lands anyway — a discarded assertion discards its ROSTER, not the truth " +
+            "about what kind of room this is");
+        Assert.That(await _membershipRepository.Load(channel.Id, "Bob#2"), Is.Null,
+            "and the freeze still holds for membership");
+    }
+
+    [Test]
+    public async Task Assert_StaleDuplicate_StillStampsLadder_EvenThoughTheRosterIsDiscarded()
+    {
+        await _service.ApplyRosterAssertion("ladder-1", "e1", 5, Members("Alice#1"), name: null, detached: false);
+        var channel = await _channelRepository.LoadBySystemRef(SystemChannelKind.Match, "ladder-1");
+
+        var outcome = await _service.ApplyRosterAssertion(
+            "ladder-1", "e1", 4, Members("Bob#2"), name: null, detached: false, ladder: true);
+
+        Assert.That(outcome, Is.EqualTo(RosterAssertionOutcome.DiscardedStale));
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.Ladder, Is.True, "the staleness gate guards membership, not classification");
+    }
 }

--- a/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
@@ -274,7 +274,8 @@ public class ModerationIntegrationTests : IntegrationTestBase
 
     // ---- Mongo seed helpers ------------------------------------------------------------------------
 
-    private async Task<ChatChannel> CreateChannel(string name, ChannelType type = ChannelType.Public, SystemChannelKind? systemKind = null)
+    private async Task<ChatChannel> CreateChannel(
+        string name, ChannelType type = ChannelType.Public, SystemChannelKind? systemKind = null, bool ladder = false)
     {
         var channel = new ChatChannel
         {
@@ -282,6 +283,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
             Name = name,
             NormalizedName = ChannelNames.Normalize(name),
             SystemKind = systemKind,
+            Ladder = ladder,
             SystemRef = type == ChannelType.System ? "sysref-" + name : null,
         };
         await _channelRepository.Insert(channel);
@@ -380,6 +382,85 @@ public class ModerationIntegrationTests : IntegrationTestBase
     }
 
     private static string EndDate(int daysFromNow) => DateTime.UtcNow.AddDays(daysFromNow).ToString("O");
+
+    // ============================================================================================
+    // Scenario 0 — the LADDER post-game room: the reported bug, end-to-end. A muted or shadow-banned
+    // player could previously type visibly in a ladder match's post-game chat, because the send-path
+    // mute gate keyed on ChannelType.Public alone and a match room is System+Match.
+    //
+    // This asserts the product outcome (what other players SEE), not just the persisted flag, and pairs
+    // each ladder assertion with the custom-lobby control that must stay exempt.
+    // ============================================================================================
+
+    [Test]
+    public async Task LadderPostGameRoom_MutedAndShadowBanned_CannotTypeVisibly_CustomLobbyStillCan()
+    {
+        const string FullTag = "muted#1";
+        const string ShadowTag = "shadow#2";
+        const string PeerTag = "peer#3";
+
+        var ladder = await CreateChannel("w3c-20-abc", ChannelType.System, SystemChannelKind.Match, ladder: true);
+        var custom = await CreateChannel("Bob's Lobby", ChannelType.System, SystemChannelKind.Match);
+        foreach (var channel in new[] { ladder, custom })
+        {
+            await SeedMembership(channel.Id, FullTag);
+            await SeedMembership(channel.Id, ShadowTag);
+            await SeedMembership(channel.Id, PeerTag);
+        }
+
+        // Both bans land through the REST path BEFORE connect, so the connect ceremony resolves them
+        // from Mongo exactly as it would in production.
+        foreach (var (tag, isShadow) in new[] { (FullTag, false), (ShadowTag, true) })
+        {
+            var ban = await _muteController.AddLoungeMute(new LoungeMuteRequest
+            {
+                battleTag = tag,
+                endDate = EndDate(1),
+                author = "moderator#9",
+                reason = "ladder post-game test",
+                isShadowBan = isShadow,
+            });
+            Assert.IsInstanceOf<OkObjectResult>(ban, $"the REST ban POST for {tag} must succeed");
+        }
+
+        var fullHub = await Connect("conn-full", FullTag);
+        var shadowHub = await Connect("conn-shadow", ShadowTag);
+        var peerHub = await Connect("conn-peer", PeerTag);
+        foreach (var (hub, channel) in new[]
+                 {
+                     (fullHub, ladder), (shadowHub, ladder), (peerHub, ladder),
+                     (fullHub, custom), (shadowHub, custom), (peerHub, custom),
+                 })
+        {
+            Assert.AreEqual(ChatResultCode.Ok, (await hub.FocusChannel(channel.Id)).Code);
+        }
+
+        // LADDER — the fix. A full mute is rejected outright; a shadow ban returns the Ok illusion but
+        // reaches nobody else.
+        Assert.AreEqual(ChatResultCode.Muted, (await fullHub.SendMessage(ladder.Id, "gg ez noobs")).Code,
+            "a full-muted player must NOT be able to send in a ladder post-game room");
+
+        var shadowSend = await shadowHub.SendMessage(ladder.Id, "still here though");
+        Assert.AreEqual(ChatResultCode.Ok, shadowSend.Code, "a shadow send still returns Ok (the illusion)");
+        Assert.IsTrue((await _messageRepository.Load(shadowSend.MessageId)).Shadow,
+            "and persists REAL-flagged");
+
+        // The whole point: the peer's client received nothing from either of them.
+        Assert.AreEqual(0, MessageReceivedFor("conn-peer").Count,
+            "a focused peer in the ladder room sees NEITHER the full-muted send (rejected) NOR the " +
+            "shadow send (withheld) — this is the reported bug's acceptance criterion");
+        Assert.AreEqual(1, MessageReceivedFor("conn-shadow").Count,
+            "the shadow author still gets their own echo, so the ban stays invisible to them");
+
+        // CUSTOM LOBBY — the control. Same channel shape, no ladder flag, still exempt.
+        Assert.AreEqual(ChatResultCode.Ok, (await fullHub.SendMessage(custom.Id, "hey")).Code,
+            "a custom-game lobby stays outside the mute scope (explicit product decision)");
+        var customShadowSend = await shadowHub.SendMessage(custom.Id, "hey too");
+        Assert.IsFalse((await _messageRepository.Load(customShadowSend.MessageId)).Shadow,
+            "and a shadow ban does not flag a custom-lobby message either");
+        Assert.AreEqual(2, MessageReceivedFor("conn-peer").Count,
+            "so the peer DOES receive both custom-lobby messages live");
+    }
 
     // ============================================================================================
     // Scenario 1 — brief acceptance 2 (coordinator check 2): the shadow ILLUSION end-to-end, across a

--- a/W3ChampionsChatService.Tests/MutePortTests.cs
+++ b/W3ChampionsChatService.Tests/MutePortTests.cs
@@ -271,7 +271,8 @@ public class MutePortTests : IntegrationTestBase
         _onlineMemberRegistry.Join(channelId, connectionId, new MemberState(battleTag, NotificationLevel.Mentions, 0, type));
     }
 
-    private async Task<ChatChannel> CreateChannel(string name, ChannelType type = ChannelType.Public, SystemChannelKind? systemKind = null)
+    private async Task<ChatChannel> CreateChannel(
+        string name, ChannelType type = ChannelType.Public, SystemChannelKind? systemKind = null, bool ladder = false)
     {
         var channel = new ChatChannel
         {
@@ -279,6 +280,7 @@ public class MutePortTests : IntegrationTestBase
             Name = name,
             NormalizedName = ChannelNames.Normalize(name),
             SystemKind = systemKind,
+            Ladder = ladder,
             SystemRef = type == ChannelType.System ? "sysref-" + name : null,
             // A real Dm always carries a pair-key + request state (FindOrCreateDm invariant) — C5's send-path
             // private-lane gates (step 5.5) resolve the counterpart from the pair-key. Stamp a realistic,
@@ -458,7 +460,7 @@ public class MutePortTests : IntegrationTestBase
         Assert.AreEqual(ChannelType.SemiPublic, created.Channel.Type);
     }
 
-    // ── Send mute-gate matrix (gate keys on ChannelType.Public ONLY) ──────────────
+    // ── Send mute-gate matrix (Public + LADDER System+Match; everything else exempt) ──────────────
 
     [Test]
     // LEGACY: ChatBanRoomScopeTests.SendMessage_CachedBan_Expired_InBannedRoom_Broadcasts @778aec9
@@ -511,26 +513,33 @@ public class MutePortTests : IntegrationTestBase
         Assert.IsNotNull(await _messageRepository.Load(result.MessageId), $"The {type} message must persist");
     }
 
-    [TestCase(ChannelType.Public, ChatResultCode.Muted)]
-    [TestCase(ChannelType.SemiPublic, ChatResultCode.Ok)]
-    [TestCase(ChannelType.System, ChatResultCode.Ok)]
-    [TestCase(ChannelType.Dm, ChatResultCode.Ok)]
-    [TestCase(ChannelType.GroupDm, ChatResultCode.Ok)]
+    // The mute scope is ChannelModeration.IsMuteEnforced: Public, plus a System+Match room that mm
+    // declared a LADDER match. A System+Match room WITHOUT that flag is a custom-game lobby and stays
+    // exempt, which is why `type` alone no longer determines the outcome here — the System row is
+    // parameterised over `ladder` and the two System cases must disagree.
+    [TestCase(ChannelType.Public, false, ChatResultCode.Muted)]
+    [TestCase(ChannelType.SemiPublic, false, ChatResultCode.Ok)]
+    [TestCase(ChannelType.System, true, ChatResultCode.Muted)]
+    [TestCase(ChannelType.System, false, ChatResultCode.Ok)]
+    [TestCase(ChannelType.Dm, false, ChatResultCode.Ok)]
+    [TestCase(ChannelType.GroupDm, false, ChatResultCode.Ok)]
     // LEGACY: ChatBanRoomScopeTests.IsPublicRoom_ClassifiesCorrectly (§16 string matrix → channel-TYPE gate matrix) @778aec9
-    public async Task Send_FullMuted_TypeMatrix_OnlyPublicGated(ChannelType type, ChatResultCode expected)
+    public async Task Send_FullMuted_TypeMatrix_PublicAndLadderMatchGated(ChannelType type, bool ladder, ChatResultCode expected)
     {
-        var channel = await CreateChannel($"chan-{type}", type, type == ChannelType.System ? SystemChannelKind.Match : null);
+        var channel = await CreateChannel(
+            $"chan-{type}-{ladder}", type, type == ChannelType.System ? SystemChannelKind.Match : null, ladder);
         SeedMember("conn-1", BattleTag, channel.Id, mute: MuteStatus.Full, muteEnd: Now.AddDays(1), type: type);
         var hub = BuildHub("conn-1");
 
         var result = await hub.SendMessage(channel.Id, "let me talk");
 
         Assert.AreEqual(expected, result.Code,
-            $"The mute gate must key on ChannelType.Public ONLY — a full mute in a {type} channel must be {expected}");
+            $"The mute gate covers Public and LADDER System+Match rooms only — a full mute in a {type} " +
+            $"channel (ladder={ladder}) must be {expected}");
         var reloaded = await _channelRepository.Load(channel.Id);
         if (expected == ChatResultCode.Muted)
         {
-            Assert.AreEqual(0L, reloaded.LastSeq, "A muted send in a Public channel must not persist");
+            Assert.AreEqual(0L, reloaded.LastSeq, "A muted send in a gated channel must not persist");
         }
         else
         {

--- a/W3ChampionsChatService.Tests/ProtocolContractTests.cs
+++ b/W3ChampionsChatService.Tests/ProtocolContractTests.cs
@@ -387,12 +387,15 @@ public class ProtocolContractTests
     {
         // D6: AssertEpoch/AssertSeq/Detached are mm<->chat reconciliation bookkeeping, never client
         // protocol — the raw entity rides ChannelAddedDto.Channel / ChannelDto.Channel to clients.
+        // Ladder joins them: it is the mm-declared ladder-vs-custom classification the send-path mute
+        // gate reads server-side, not something a client is told or could act on.
         var channel = new ChatChannel
         {
             Id = "c1",
             AssertEpoch = "e1",
             AssertSeq = 5,
             Detached = true,
+            Ladder = true,
         };
 
         var json = JsonSerializer.Serialize(channel);
@@ -403,6 +406,8 @@ public class ProtocolContractTests
         StringAssert.DoesNotContain("AssertSeq", json);
         StringAssert.DoesNotContain("detached", json);
         StringAssert.DoesNotContain("Detached", json);
+        StringAssert.DoesNotContain("ladder", json);
+        StringAssert.DoesNotContain("Ladder", json);
         // Positive control — proves the object really did serialize.
         StringAssert.Contains("Id", json);
     }

--- a/W3ChampionsChatService/Channels/ChannelModeration.cs
+++ b/W3ChampionsChatService/Channels/ChannelModeration.cs
@@ -24,4 +24,27 @@ public static class ChannelModeration
         channel.Type == ChannelType.Public
         || channel.Type == ChannelType.SemiPublic
         || (channel.Type == ChannelType.System && channel.SystemKind == SystemChannelKind.Match);
+
+    /// <summary>
+    /// The MUTE scope wall — the second, deliberately NARROWER wall (<c>ChatHub.SendMessage</c> step 6):
+    /// a lounge mute (full or shadow) is enforced on a send iff the channel is
+    /// <see cref="ChannelType.Public"/>, or it is a LADDER match room
+    /// (<see cref="ChannelType.System"/> + <see cref="SystemChannelKind.Match"/> +
+    /// <see cref="ChatChannel.Ladder"/>). Everything else — SemiPublic, DM/GroupDm, System+Clan,
+    /// System+Lobby, and a CUSTOM-GAME match room — is exempt, preserving the legacy mute scope.
+    /// <para>
+    /// WHY THIS IS NOT <see cref="IsModeratable"/>: the two walls answer different questions and are
+    /// intentionally not the same set. IsModeratable asks "may a moderator reach INTO this room after
+    /// the fact" (delete/purge/read history) and includes SemiPublic and EVERY match room. This asks
+    /// "is a muted user silenced while typing HERE", which is a product decision about where a mute
+    /// bites: ladder chat is competitive-integrity surface and is gated; a custom lobby is the host's
+    /// own room and is not (an explicit product call — a muted player can still talk to the friends
+    /// who invited them). Keeping them separate is the point; do not collapse them.
+    /// </para>
+    /// </summary>
+    public static bool IsMuteEnforced(ChatChannel channel) =>
+        channel.Type == ChannelType.Public
+        || (channel.Type == ChannelType.System
+            && channel.SystemKind == SystemChannelKind.Match
+            && channel.Ladder);
 }

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -303,6 +303,15 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
         Channels.UpdateOneAsync(c => c.Id == channelId, Builders<ChatChannel>.Update.Set(c => c.Detached, true));
 
     /// <summary>
+    /// Marks the room a LADDER match — see <see cref="ChatChannel.Ladder"/> for why the flag exists and
+    /// why it is STICKY-TRUE. Idempotent, and deliberately WRITE-ONLY-TRUE: there is no clearing
+    /// counterpart, so no update can un-moderate a live ladder room. (Deleting the channel does drop the
+    /// flag with the rest of the document — see the Ladder doc for why that is left alone.)
+    /// </summary>
+    public virtual Task SetLadder(string channelId) =>
+        Channels.UpdateOneAsync(c => c.Id == channelId, Builders<ChatChannel>.Update.Set(c => c.Ladder, true));
+
+    /// <summary>
     /// Every System+Match channel eligible for an epoch sync — NOT detached (a detached room is excluded
     /// from every sweep by design, so it is filtered out server-side and never even loaded) AND already
     /// stamped by the assertion protocol (<c>AssertEpoch</c> exists).

--- a/W3ChampionsChatService/Channels/ChatChannel.cs
+++ b/W3ChampionsChatService/Channels/ChatChannel.cs
@@ -27,6 +27,39 @@ public class ChatChannel
     [BsonIgnoreIfNull]
     public string SystemRef { get; set; }
 
+    /// <summary>
+    /// System+Match only — true when mm declared this ref a LADDER match rather than a custom-game
+    /// lobby. chat-service uses ONE <see cref="SystemChannelKind.Match"/> for both, and nothing else in
+    /// the document distinguishes them (both refs are a bare <c>nanoid(10)</c>, both create through the
+    /// same endpoint, and <see cref="Detached"/> is set on BOTH — at birth for ladder, at GAME_STARTED
+    /// for a custom lobby), so this flag is the sole discriminator. It exists for exactly one consumer:
+    /// <see cref="ChannelModeration.IsMuteEnforced"/>, the send-path mute scope — a ladder match's
+    /// in-game/post-game room is moderated like a Public room, a custom lobby's is not.
+    /// <para>
+    /// STICKY-TRUE FOR THE LIFE OF THE DOCUMENT. Set by <c>MatchChannelService</c> when an internal
+    /// create or roster assertion carries <c>ladder: true</c>, and never cleared while the channel
+    /// exists: a later call omitting the flag (an older mm, a partial rollout, a retry built from a
+    /// stale payload) must not be able to silently un-moderate a room mid-game. There is no
+    /// <c>SetLadder(false)</c>, by design.
+    /// </para>
+    /// <para>
+    /// It does NOT survive teardown, and that is the one way a ladder ref can come back unmoderated: an
+    /// explicit <c>DELETE /internal/channels/{ref}</c> or an epoch-sync sweep hard-deletes the document,
+    /// so a subsequent call that RECREATES the same ref starts from a blank document and must send
+    /// <c>ladder: true</c> again. Not defended against here on purpose — a recreated ref is a new room,
+    /// and resurrecting classification from a deleted document would need a tombstone this service has
+    /// no other use for. Unreachable for ladder in practice: mm never sends DELETE for a ladder ref, and
+    /// ladder rooms are born detached, which excludes them from every sweep.
+    /// </para>
+    /// [BsonIgnoreIfDefault] keeps the field ABSENT on every non-ladder doc, so it costs nothing on the
+    /// custom-lobby majority and every pre-existing document reads back as false. [JsonIgnore]: like
+    /// the assertion state below, this is mm↔chat bookkeeping, never client protocol (the raw entity
+    /// rides ChannelAddedDto/ChannelDto).
+    /// </summary>
+    [BsonIgnoreIfDefault]
+    [JsonIgnore]
+    public bool Ladder { get; set; }
+
     /// <summary>Dm only — see DmPairKey.For. Unique partial index (Type == Dm).</summary>
     [BsonIgnoreIfNull]
     public string PairKey { get; set; }

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Serilog;
 using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.Mentions;
 using W3ChampionsChatService.Messages;
@@ -85,9 +86,14 @@ public partial class ChatHub
     /// <see cref="ChannelType.GroupDm"/> ONLY: block/consent/cap handling that may silently short-circuit
     /// with a fabricated <see cref="ChatResultCode.Ok"/> (<c>FakeSendAck</c>) or the one fail-closed
     /// <see cref="ChatResultCode.Throttled"/> — see <see cref="ApplyPrivateLaneGates"/>.</item>
-    /// <item>Mute gate — PUBLIC channels ONLY (guardrail: semiPublic/system/dm are exempt, preserving
-    /// the legacy mute-scope). Reads <see cref="ConnectionMapping.GetEffectiveMuteStatus"/> (cache-only,
-    /// zero DB): <see cref="MuteStatus.Full"/> → <see cref="ChatResultCode.Muted"/>;
+    /// <item>Mute gate — scoped by <see cref="Channels.ChannelModeration.IsMuteEnforced"/>: PUBLIC
+    /// channels and LADDER match rooms (<see cref="ChannelType.System"/> +
+    /// <see cref="SystemChannelKind.Match"/> + <see cref="Channels.ChatChannel.Ladder"/>). semiPublic /
+    /// dm / groupDm / System+Clan / System+Lobby AND custom-game match rooms are exempt — the legacy
+    /// mute scope, widened by exactly the ladder carve-in (a muted player must not be able to talk in a
+    /// ladder game's in-game/post-game room; a custom lobby is the host's own room and stays exempt).
+    /// Reads <see cref="ConnectionMapping.GetEffectiveMuteStatus"/> (cache-only, zero DB):
+    /// <see cref="MuteStatus.Full"/> → <see cref="ChatResultCode.Muted"/>;
     /// <see cref="MuteStatus.Shadow"/> → flag the message and persist (returns Ok — the illusion).</item>
     /// <item>Persist (C1 amendment, mandatory — else the TTL is inert):
     /// <see cref="Channels.ChannelRepository.AllocateSeq"/> atomically $inc LastSeq + $set LastMessageAt,
@@ -251,9 +257,11 @@ public partial class ChatHub
             }
         }
 
-        // 6. Mute gate — PUBLIC channels ONLY (guardrail: never gate semiPublic/system/dm).
+        // 6. Mute gate — the ChannelModeration.IsMuteEnforced scope: Public channels and LADDER match
+        // rooms (System+Match with Ladder=true). semiPublic / dm / groupDm / System+Clan / System+Lobby
+        // and CUSTOM-GAME match rooms stay exempt (the legacy mute scope, minus the ladder carve-in).
         var isShadow = false;
-        if (channel.Type == ChannelType.Public)
+        if (ChannelModeration.IsMuteEnforced(channel))
         {
             var muteStatus = _connections.GetEffectiveMuteStatus(connectionId, now);
             if (muteStatus == MuteStatus.Full)
@@ -503,12 +511,15 @@ public partial class ChatHub
         //
         // This branch does NOT re-apply the {Public, SemiPublic, System+Match} scope wall that
         // single-delete/purge/the REST endpoint enforce — it is safe only emergently, by construction
-        // of the write paths: a shadow==true row can exist ONLY in a Public channel (the shadow flag is
-        // set Public-only at send time), and a deleted!=null row can exist ONLY in a moderatable channel
-        // (both delete paths are themselves scope-walled). So in any DM/GroupDm/System+Clan/System+Lobby
-        // channel a moderator happens to be a member of, ForModerator is byte-identical to
-        // ForUserDelivery — no private content or flag leaks. This safety depends on those write-time
-        // invariants holding in the send path and delete paths; it is not re-verified here.
+        // of the write paths: a shadow==true row can exist ONLY where the send-path mute gate runs, i.e.
+        // ChannelModeration.IsMuteEnforced — Public or a LADDER System+Match room — and a deleted!=null
+        // row can exist ONLY in a moderatable channel (both delete paths are themselves scope-walled).
+        // BOTH of those sets are SUBSETS of IsModeratable, which is what makes this safe: in any
+        // DM/GroupDm/System+Clan/System+Lobby channel a moderator happens to be a member of,
+        // ForModerator is byte-identical to ForUserDelivery — no private content or flag leaks. (The
+        // ladder carve-in did not widen the exposure: System+Match was already inside IsModeratable, so
+        // a ladder room's shadow rows are legitimately moderator-visible.) This safety depends on those
+        // write-time invariants holding in the send path and delete paths; it is not re-verified here.
         if (session.HasPermission(EPermission.Moderation))
         {
             var moderatorPage = aroundSeq.HasValue

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -110,11 +110,15 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
         {
             var channel = await matchChannelService.CreateOrGet(
                 request.Ref, name, request.Members, request.Focus ?? false,
-                request.Epoch, request.Seq, request.Detached ?? false);
+                request.Epoch, request.Seq, request.Detached ?? false, request.Ladder ?? false);
 
+            // `ladder` is logged alongside `detached` because the two are easy to confuse and only one of
+            // them decides whether a muted player can talk in this room — an operator diagnosing "why
+            // could a banned user chat in that ladder game" needs to see which flag mm actually sent.
             Log.Information(
-                "Internal channel create succeeded {Caller} {Verb} {Ref} memberCount={MemberCount} detached={Detached}",
-                InternalHmacAuthFilter.ResolveCaller(HttpContext), "POST", request.Ref, request.Members.Count, request.Detached ?? false);
+                "Internal channel create succeeded {Caller} {Verb} {Ref} memberCount={MemberCount} detached={Detached} ladder={Ladder}",
+                InternalHmacAuthFilter.ResolveCaller(HttpContext), "POST", request.Ref, request.Members.Count,
+                request.Detached ?? false, request.Ladder ?? false);
 
             return Ok(InternalChannelDto.FromChannel(channel));
         }
@@ -179,7 +183,7 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
         {
             var outcome = await matchChannelService.ApplyRosterAssertion(
                 @ref, request.Epoch, request.Seq, request.Members,
-                name, request.Detached ?? false);
+                name, request.Detached ?? false, request.Ladder ?? false);
 
             // 2026-08-05 fix wave (final review M2): the outcome REPLACES the old unconditional
             // "succeeded" wording — a discarded assertion (stale/duplicate or against a frozen channel)
@@ -187,9 +191,9 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
             // line, exactly on the storm paths (an mm retry storm, or mm asserting a frozen lobby) the
             // staleness/detach gates exist to absorb. One line, the real outcome.
             Log.Information(
-                "Internal channel roster-assert {Outcome} {Caller} {Verb} {Ref} epoch={Epoch} seq={Seq} memberCount={MemberCount} detached={Detached}",
+                "Internal channel roster-assert {Outcome} {Caller} {Verb} {Ref} epoch={Epoch} seq={Seq} memberCount={MemberCount} detached={Detached} ladder={Ladder}",
                 outcome, InternalHmacAuthFilter.ResolveCaller(HttpContext), "PUT", @ref,
-                request.Epoch, request.Seq, request.Members.Count, request.Detached ?? false);
+                request.Epoch, request.Seq, request.Members.Count, request.Detached ?? false, request.Ladder ?? false);
 
             // A DISCARDED (stale/detached) assertion is still a 200 — it is a successful no-op, not a
             // failure. mm must not retry a correctly-rejected stale assertion; the domain layer already

--- a/W3ChampionsChatService/Internal/InternalDtos.cs
+++ b/W3ChampionsChatService/Internal/InternalDtos.cs
@@ -44,6 +44,23 @@ public class InternalChannelCreateRequest
     public string Epoch { get; set; }
     public long? Seq { get; set; }
     public bool? Detached { get; set; }
+
+    /// <summary>
+    /// Declares this ref a LADDER match rather than a custom-game lobby. Absent/false ⇒ custom lobby
+    /// (today's behavior, byte-for-byte). The ONLY consumer is the send-path mute scope
+    /// (<see cref="Channels.ChannelModeration.IsMuteEnforced"/>): a lounge-muted or shadow-banned
+    /// player must not be able to talk in a ladder game's in-game/post-game room, while a custom
+    /// lobby stays exempt.
+    /// <para>
+    /// Deliberately SEPARATE from <see cref="Detached"/> even though mm happens to send both together
+    /// on the ladder create path today. Detach means "membership is frozen, sweeps skip this"; it is
+    /// also set on every custom lobby at GAME_STARTED, so it does not — and must never be made to —
+    /// answer "is this ladder". Inferring one from the other would silently un-moderate ladder rooms
+    /// the day mm's detach timing changes.
+    /// </para>
+    /// STICKY-TRUE server-side: see <see cref="Channels.ChatChannel.Ladder"/>.
+    /// </summary>
+    public bool? Ladder { get; set; }
 }
 
 /// <summary>
@@ -72,6 +89,22 @@ public class InternalRosterAssertRequest
     public List<string> Members { get; set; }
     public string Name { get; set; }
     public bool? Detached { get; set; }
+
+    /// <summary>
+    /// Same meaning as <see cref="InternalChannelCreateRequest.Ladder"/>. Carried on this route too
+    /// because the roster endpoint is ALSO a channel-creating path: mm's ladder create has a
+    /// retry-on-failure fallback that converges through <c>PUT .../roster</c> instead, and that
+    /// assertion may well be the call that creates the channel on demand. Without the flag here, a
+    /// ladder room born on the fallback path would be indistinguishable from a custom lobby and would
+    /// silently escape the mute gate.
+    /// <para>
+    /// Applied BEFORE the detach-freeze and staleness gates, and independently of them: it is a
+    /// property assertion about the ref, not a membership mutation, so a stale/duplicate/frozen
+    /// assertion that legitimately discards its ROSTER must still be able to correct the room's
+    /// classification.
+    /// </para>
+    /// </summary>
+    public bool? Ladder { get; set; }
 }
 
 /// <summary>
@@ -112,8 +145,13 @@ public class InternalRelationshipChangeRequest
 /// 9) — System.Text.Json's default camelCase serialization matches the wire contract mm expects, so no
 /// custom naming policy is needed.
 /// </summary>
-public record InternalChannelDto(string Id, string Ref, string Name, DateTime? ExpiresAt)
+/// <para>
+/// <c>Ladder</c> is the STORED classification read back, not an echo of the request: because the flag
+/// is sticky-true, "what mm sent" and "what the channel now holds" diverge on exactly the calls worth
+/// diagnosing (a create omitting the flag against an already-ladder ref). Additive — mm may ignore it.
+/// </para>
+public record InternalChannelDto(string Id, string Ref, string Name, DateTime? ExpiresAt, bool Ladder)
 {
     public static InternalChannelDto FromChannel(ChatChannel channel) =>
-        new(channel.Id, channel.SystemRef, channel.Name, channel.ExpiresAt);
+        new(channel.Id, channel.SystemRef, channel.Name, channel.ExpiresAt, channel.Ladder);
 }

--- a/W3ChampionsChatService/Internal/MatchChannelService.cs
+++ b/W3ChampionsChatService/Internal/MatchChannelService.cs
@@ -118,20 +118,26 @@ public class MatchChannelService(
     /// — they are never in mm's <c>liveLobbyRefs</c> (that registry only holds custom lobbies), so without
     /// birth-detach the FIRST epoch sync after any mm restart would tear down every in-progress ladder
     /// game's chat. Idempotent: a retried detached create with the same members changes nothing further.</item>
+    /// <item><paramref name="ladder"/>: mm's declaration that this ref is a LADDER match, not a
+    /// custom-game lobby — the sole discriminator between the two, and the sole input to the send-path
+    /// mute scope (<see cref="ChannelModeration.IsMuteEnforced"/>). Stamped FIRST, ahead of every gate
+    /// below, and sticky-true — see <c>StampLadder</c>. Deliberately independent of
+    /// <paramref name="detached"/> even though mm sends both on today's ladder create: detach is ALSO set
+    /// on every custom lobby at game start, so it cannot answer "is this ladder".</item>
     /// </list>
     /// </para>
     /// </summary>
     public async Task<ChatChannel> CreateOrGet(
         string systemRef, string name, IReadOnlyList<string> members, bool focus,
-        string epoch = null, long? seq = null, bool detached = false)
+        string epoch = null, long? seq = null, bool detached = false, bool ladder = false)
     {
         using var _ = await _refGate.AcquireAsync(systemRef);
-        return await CreateOrGetLocked(systemRef, name, members, focus, epoch, seq, detached);
+        return await CreateOrGetLocked(systemRef, name, members, focus, epoch, seq, detached, ladder);
     }
 
     private async Task<ChatChannel> CreateOrGetLocked(
         string systemRef, string name, IReadOnlyList<string> members, bool focus,
-        string epoch, long? seq, bool detached)
+        string epoch, long? seq, bool detached, bool ladder)
     {
         var now = timeProvider.GetUtcNow().UtcDateTime;
         // 2026-08-05 fix wave (final review C1): name is nullable — mirrors ApplyRosterAssertion's own
@@ -141,6 +147,13 @@ public class MatchChannelService(
         var trimmedName = string.IsNullOrWhiteSpace(name) ? systemRef : name.Trim();
 
         var channel = await channelRepository.FindOrCreateSystem(SystemChannelKind.Match, systemRef, trimmedName, now);
+
+        // LADDER classification — stamped FIRST, before every gate below (name backfill, the D10 stamp,
+        // the member-add gate, the detach latch). It is the one thing in this method that must land even
+        // when everything else about the call is skipped: a detached-and-therefore-add-skipping retry, or
+        // a create that races a newer assertion, must still be able to establish that this room is
+        // moderated. See StampLadder.
+        await StampLadder(channel, ladder);
 
         // Name backfill (§3.3). Only writes on a genuine difference (idempotent); mutating the in-memory copy
         // too keeps the returned channel — and every ChannelAdded emitted for a member below — carrying the
@@ -184,6 +197,35 @@ public class MatchChannelService(
         }
 
         return channel;
+    }
+
+    /// <summary>
+    /// Applies mm's LADDER declaration to <paramref name="channel"/>, mutating the in-memory copy too so
+    /// the returned entity (and anything derived from it downstream) reflects the stamp rather than the
+    /// pre-call read. Shared by <see cref="CreateOrGet"/> and <see cref="ApplyRosterAssertion"/>; both
+    /// call it IMMEDIATELY after find-or-create, ahead of every other gate.
+    /// <list type="bullet">
+    /// <item>STICKY-TRUE, one direction only: <c>ladder: false</c>/absent is a NO-OP, never a clear. An
+    /// older mm, a half-finished rollout, or a retry rebuilt from a stale payload must not be able to
+    /// un-moderate a ladder room mid-game. See <see cref="ChatChannel.Ladder"/>.</item>
+    /// <item>Only writes on a genuine transition (false → true), so the common paths — every custom
+    /// lobby, and every repeat call on an already-stamped ladder ref — pay ZERO extra Mongo writes.</item>
+    /// <item>NOT gated by <see cref="ChatChannel.Detached"/> or by the (epoch, seq) staleness rules,
+    /// deliberately. Those protect MEMBERSHIP from being rewound by late/duplicate deliveries; this is a
+    /// monotonic property assertion about the ref itself, where a late delivery carries exactly the same
+    /// truth as an early one. Gating it would mean a ladder room that first learns it is a ladder room
+    /// from a discarded assertion stays permanently unmoderated.</item>
+    /// </list>
+    /// </summary>
+    private async Task StampLadder(ChatChannel channel, bool ladder)
+    {
+        if (!ladder || channel.Ladder)
+        {
+            return;
+        }
+
+        await channelRepository.SetLadder(channel.Id);
+        channel.Ladder = true;
     }
 
     /// <summary>
@@ -320,6 +362,11 @@ public class MatchChannelService(
     /// <item>DETACH LAST: when <paramref name="detached"/>, the final member set is applied FIRST, then
     /// the channel is marked detached — so the freeze rule never has to special-case its own trigger.</item>
     /// </list>
+    /// <paramref name="ladder"/> is mm's LADDER declaration for this ref — applied BEFORE steps 3 and 4
+    /// above and independently of both, because a discarded assertion discards its ROSTER, not the truth
+    /// about what kind of room this is. This route carries the flag (not just <see cref="CreateOrGet"/>)
+    /// because mm's ladder create has a retry-on-failure fallback that converges through this endpoint,
+    /// where the assertion may itself be the create-on-demand. See <c>StampLadder</c>.
     /// <paramref name="name"/> is nullable (null ⇒ ref placeholder on create-on-demand). There is NO
     /// <c>focus</c> parameter — mm has never sent focus on any internal call, so adds pass
     /// <c>focus: false</c> to <see cref="AddMemberWithInvariant"/>, byte-identical to today's behavior.
@@ -333,7 +380,8 @@ public class MatchChannelService(
     /// </para>
     /// </summary>
     public async Task<RosterAssertionOutcome> ApplyRosterAssertion(
-        string systemRef, string epoch, long seq, IReadOnlyList<string> members, string name, bool detached)
+        string systemRef, string epoch, long seq, IReadOnlyList<string> members, string name, bool detached,
+        bool ladder = false)
     {
         using var _ = await _refGate.AcquireAsync(systemRef);
 
@@ -342,6 +390,12 @@ public class MatchChannelService(
 
         var channel = await channelRepository.LoadBySystemRef(SystemChannelKind.Match, systemRef)
             ?? await channelRepository.FindOrCreateSystem(SystemChannelKind.Match, systemRef, trimmedName, now);
+
+        // LADDER classification — stamped BEFORE the detach-freeze and staleness gates below, and
+        // independently of both: a discarded assertion discards its ROSTER, not the truth about what kind
+        // of room this is. This route matters for ladder specifically because it is mm's fallback when the
+        // ladder create call fails — the assertion may be the call that creates the room. See StampLadder.
+        await StampLadder(channel, ladder);
 
         if (channel.Detached)
         {


### PR DESCRIPTION
## The bug

Lounge-muted and shadow-banned players can still type visibly in the post-game chat of a ladder game.

`ChatHub.SendMessage` step 6 gated the mute check on `channel.Type == ChannelType.Public`, and a match room is `System` + `SystemKind.Match`. So a full mute was never rejected and a shadow ban never set `ChannelMessage.Shadow`. Everything downstream was already correct and channel-type agnostic — fan-out routing, `UserVisible`, the moderator projections — nothing ever asked the question.

The moderation surface was inconsistent about this too: `ChannelModeration.IsModeratable` *already* included System+Match, so moderators could delete and purge in a room where mutes did not apply.

## Why it needed a new field

Custom-game lobby/post-game rooms stay exempt (product decision — a muted player may still talk to the friends who invited them). But chat-service uses **one** `SystemKind.Match` for both, and mm sent no discriminator: both refs are a bare `nanoid(10)`, both create through the same endpoint, and `detached` is set on **both** — at birth for ladder, at `GAME_STARTED` for a custom lobby — so it cannot answer "is this ladder", and inferring it would un-moderate ladder rooms the day mm's detach timing changed.

## The change

An optional `ladder` boolean on `POST /internal/channels` and `PUT /internal/channels/{ref}/roster`, persisted as `ChatChannel.Ladder`, read by a new `ChannelModeration.IsMuteEnforced` (`Public | System+Match+Ladder`) that replaces the inline type check.

- **Two walls, deliberately different sets.** `IsModeratable` answers "may a moderator reach into this room after the fact"; `IsMuteEnforced` answers "is a muted user silenced while typing here". They sit side by side in one file with a comment saying not to collapse them.
- **The roster route carries the flag too** — mm's ladder create has a retry fallback that converges there, and that assertion may itself be the create-on-demand.
- **Stamped ahead of every other gate.** A frozen or stale assertion discards its *roster*, not the truth about what kind of room this is.
- **Sticky-true for the life of the document.** No update clears it, so an older mm, a partial rollout, or a retry built from a stale payload cannot silently un-moderate a live ladder room. (Teardown drops it with the rest of the document; documented, and unreachable for ladder in practice.)
- **Shadow mirrors Public exactly**: persisted flagged, echoed to its author, visible to moderators, withheld from everyone else.

Also corrects the now-stale "a shadow row can exist ONLY in a Public channel" invariant comment in `GetMessages`. Both the shadow set and the deleted set remain subsets of `IsModeratable`, which is what keeps the moderator projection safe.

## Deploy

**Inert until matchmaking-service ships the flag** — an absent `ladder` reads as custom lobby, so this half is additive and behaviour-preserving on its own. Companion PR: w3champions/matchmaking-service (`feat(chat): declare ladder matches to chat-service so mutes apply`). Order does not matter.

Rooms created before mm's deploy are never retro-classified, so the gate applies to matches created from mm's deploy onward, not to in-flight ones.

## Testing

1347 tests pass (was 1344). New coverage:

- `ChatHubSendMessageTests` — ladder × {full, shadow, unmuted}, plus the custom-lobby control in both mute modes.
- `ModerationIntegrationTests.LadderPostGameRoom_MutedAndShadowBanned_CannotTypeVisibly_CustomLobbyStillCan` — the end-to-end product claim: a focused peer receives *neither* the rejected send nor the shadow send, and *does* receive both custom-lobby messages.
- `MatchChannelServiceTests` — stamping on both creating routes, sticky-true on both, and that a frozen/stale assertion still lands the classification while its roster is correctly discarded.
- `InternalChannelsControllerTests` — wire-level, including that `detached` alone does **not** gate.
- `MutePortTests` — the type matrix is now parameterised over `ladder`; its two System rows must disagree. (Its old header claimed "gate keys on ChannelType.Public ONLY" while its System case silently became a custom-lobby test — fixed.)

Mutation-tested: reverting the gate to `Public`-only fails exactly the ladder-gating tests and leaves every exemption test green.
