### PR TITLE
feat(chat): serve each conversation's last message from the channel doc

### DIFF
--- a/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
+++ b/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
@@ -418,4 +418,74 @@ public class ActivityCoalescerTests
         engine.OnConnectionClosed(MemberConn);
         Assert.AreEqual(0, coalescer.TrackedChannelCount(MemberConn), "OnConnectionClosed must evict the connection's coalescing state");
     }
+
+    // ------------------------------------------------------------------------------------------------
+    // SentAt — the message timestamp that makes ChannelActivity usable as a conversation-list sort key
+    // ------------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task Offer_CarriesSentAtOnTheImmediateEmit()
+    {
+        var (harness, _, coalescer) = NewCoalescer();
+        var sentAt = new DateTime(2026, 8, 9, 22, 47, 0, DateTimeKind.Utc);
+
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 5, T0, preview: null, sentAt: sentAt);
+
+        var dto = harness.PayloadFor(MemberConn, ChatEvents.ChannelActivity) as ChannelActivityDto;
+        Assert.AreEqual(sentAt, dto.SentAt,
+            "without this the client has no live ordering signal at all — LastMessageAt only refreshes on a snapshot or a GetConversations page");
+    }
+
+    [Test]
+    public async Task Offer_WithoutSentAt_LeavesItNull()
+    {
+        var (harness, _, coalescer) = NewCoalescer();
+
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 5, T0);
+
+        var dto = harness.PayloadFor(MemberConn, ChatEvents.ChannelActivity) as ChannelActivityDto;
+        Assert.IsNull(dto.SentAt, "absence must stay distinguishable from a zero timestamp — a client reads it as 'no ordering information'");
+    }
+
+    [Test]
+    public async Task CoalescedBurst_FlushesTheLatestOfferedSentAt()
+    {
+        var (harness, _, coalescer) = NewCoalescer();
+        var first = new DateTime(2026, 8, 9, 22, 47, 0, DateTimeKind.Utc);
+        var latest = new DateTime(2026, 8, 9, 22, 49, 0, DateTimeKind.Utc);
+
+        // Opens the window (emits immediately), then two more within it collapse into the pending.
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 5, T0, preview: null, sentAt: first);
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 6, T0.AddSeconds(1), preview: null, sentAt: first.AddMinutes(1));
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 7, T0.AddSeconds(2), preview: null, sentAt: latest);
+
+        await coalescer.FlushDue(T0.AddSeconds(11));
+
+        var payloads = ActivityPayloads(harness, MemberConn);
+        Assert.AreEqual(2, payloads.Count, "one immediate emit plus one flushed pending");
+        Assert.AreEqual(first, payloads[0].SentAt);
+        Assert.AreEqual(latest, payloads[1].SentAt,
+            "the drained burst must carry the LATEST offered timestamp, mirroring the latest-offered-preview discipline beside it");
+        Assert.AreEqual(7, payloads[1].LastSeq);
+    }
+
+    [Test]
+    public async Task SentAt_TravelsWithItsOwnPreview()
+    {
+        // The pair describes ONE message. If they were written or drained independently a client could
+        // render one message's text against another message's timestamp.
+        var (harness, _, coalescer) = NewCoalescer();
+        var olderSentAt = new DateTime(2026, 8, 9, 22, 47, 0, DateTimeKind.Utc);
+        var newerSentAt = new DateTime(2026, 8, 9, 22, 49, 0, DateTimeKind.Utc);
+        var older = new DmActivityPreviewDto("peter#123", "peter", "older text");
+        var newer = new DmActivityPreviewDto("peter#123", "peter", "newer text");
+
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 5, T0, older, olderSentAt);
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 6, T0.AddSeconds(1), newer, newerSentAt);
+        await coalescer.FlushDue(T0.AddSeconds(11));
+
+        var flushed = ActivityPayloads(harness, MemberConn)[1];
+        Assert.AreEqual("newer text", ((DmActivityPreviewDto)flushed.Preview).Excerpt);
+        Assert.AreEqual(newerSentAt, flushed.SentAt, "the flushed timestamp must belong to the same message as the flushed preview");
+    }
 }

--- a/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
+++ b/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
@@ -470,6 +470,32 @@ public class ActivityCoalescerTests
     }
 
     [Test]
+    public async Task OutOfOrderOffer_DoesNotPairTheHigherSeqWithTheLowerMessagesTextAndTimestamp()
+    {
+        // Concurrent same-channel sends reach the lock in either order, and the emitted seq is the MAX of
+        // what was offered. If (Preview, SentAt) were kept latest-ARRIVED rather than highest-SEQ, a
+        // delayed lower offer would ride out under the higher seq — the row would show the second-newest
+        // message pinned at a seq the newest message can no longer replace (the client's projection merge
+        // is monotonic on exactly that seq).
+        var (harness, _, coalescer) = NewCoalescer();
+        var newerSentAt = new DateTime(2026, 8, 9, 22, 49, 0, DateTimeKind.Utc);
+        var newer = new DmActivityPreviewDto("peter#123", "peter", "the newest message");
+        var older = new DmActivityPreviewDto("peter#123", "peter", "the delayed older message");
+
+        // seq 7 opens the window and emits; the delayed seq 6 then lands inside it.
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 7, T0, preview: newer, sentAt: newerSentAt);
+        await coalescer.Offer(MemberConn, ChannelId, lastSeq: 6, T0.AddSeconds(1), preview: older, sentAt: newerSentAt.AddMinutes(-1));
+        await coalescer.FlushDue(T0.AddSeconds(11));
+
+        var payloads = ActivityPayloads(harness, MemberConn);
+        Assert.AreEqual(2, payloads.Count, "one immediate emit plus one flushed pending");
+        Assert.AreEqual(7, payloads[1].LastSeq, "the emitted seq stays at the max, as before");
+        Assert.AreEqual("the newest message", ((DmActivityPreviewDto)payloads[1].Preview).Excerpt,
+            "the text must belong to the seq being emitted, not to whichever offer arrived last");
+        Assert.AreEqual(newerSentAt, payloads[1].SentAt, "and so must the timestamp beside it");
+    }
+
+    [Test]
     public async Task SentAt_TravelsWithItsOwnPreview()
     {
         // The pair describes ONE message. If they were written or drained independently a client could

--- a/W3ChampionsChatService.Tests/ChannelRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelRepositoryTests.cs
@@ -318,4 +318,94 @@ public class ChannelRepositoryTests : IntegrationTestBase
             "LoadModeratableChannels' Mongo filter must select EXACTLY the channels ChannelModeration.IsModeratable " +
             "agrees are moderatable — the two scope-wall expressions must never drift apart");
     }
+
+    // ----------------------------------------------------------------------------------------------
+    // ChannelLastMessage — the conversation-list projection's compare-and-set write
+    // ----------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task TryAdvanceLastMessage_FirstWrite_SetsProjection()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Accepted, LastSeq = 0 };
+        await repo.Insert(channel);
+
+        var advanced = await repo.TryAdvanceLastMessage(channel.Id, NewProjection(seq: 1, "hello"));
+
+        Assert.IsTrue(advanced, "the first projection write must land — a missing field matches the null leg of the filter");
+        var loaded = await repo.Load(channel.Id);
+        Assert.AreEqual(1L, loaded.LastMessage.Seq);
+        Assert.AreEqual("hello", loaded.LastMessage.Excerpt);
+        Assert.AreEqual("peter#123", loaded.LastMessage.SenderBattleTag);
+    }
+
+    [Test]
+    public async Task TryAdvanceLastMessage_LowerSeq_DoesNotRegressProjection()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Accepted, LastSeq = 0 };
+        await repo.Insert(channel);
+        await repo.TryAdvanceLastMessage(channel.Id, NewProjection(seq: 7, "newest"));
+
+        // Concurrent same-channel sends reach this write serialized only by Mongo, so a lower seq can
+        // genuinely land after a higher one. It must lose.
+        var advanced = await repo.TryAdvanceLastMessage(channel.Id, NewProjection(seq: 6, "older"));
+
+        Assert.IsFalse(advanced, "an out-of-order lower seq must report that it did not advance the projection");
+        var loaded = await repo.Load(channel.Id);
+        Assert.AreEqual(7L, loaded.LastMessage.Seq, "the projection must never regress to an older message");
+        Assert.AreEqual("newest", loaded.LastMessage.Excerpt);
+    }
+
+    [Test]
+    public async Task TryAdvanceLastMessage_SameSeqTwice_IsIdempotent()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Accepted, LastSeq = 0 };
+        await repo.Insert(channel);
+        await repo.TryAdvanceLastMessage(channel.Id, NewProjection(seq: 3, "first write"));
+
+        // A retried/duplicated fan-out for the SAME message must not rewrite the row (strictly-greater CAS).
+        var advanced = await repo.TryAdvanceLastMessage(channel.Id, NewProjection(seq: 3, "second write"));
+
+        Assert.IsFalse(advanced);
+        Assert.AreEqual("first write", (await repo.Load(channel.Id)).LastMessage.Excerpt);
+    }
+
+    [Test]
+    public async Task LastMessage_RoundTripsAndIsOmittedWhenAbsent()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var without = new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Pending, LastSeq = 0 };
+        await repo.Insert(without);
+
+        var raw = await MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName)
+            .GetCollection<BsonDocument>(ChatCollections.Channels)
+            .Find(new BsonDocument("_id", without.Id)).FirstAsync();
+        Assert.IsFalse(raw.Contains("LastMessage"), "a channel with no projection must omit the field entirely, not store a null");
+
+        var sentAt = new DateTime(2026, 8, 9, 22, 47, 0, DateTimeKind.Utc);
+        await repo.TryAdvanceLastMessage(without.Id, new ChannelLastMessage
+        {
+            Seq = 4,
+            SenderBattleTag = "peter#123",
+            SenderName = "peter",
+            Excerpt = "round trip",
+            SentAt = sentAt,
+        });
+
+        var loaded = await repo.Load(without.Id);
+        Assert.AreEqual(4L, loaded.LastMessage.Seq);
+        Assert.AreEqual("peter", loaded.LastMessage.SenderName);
+        Assert.AreEqual(sentAt, loaded.LastMessage.SentAt, "SentAt must survive the Mongo round trip as the same UTC instant");
+    }
+
+    private static ChannelLastMessage NewProjection(long seq, string excerpt) => new()
+    {
+        Seq = seq,
+        SenderBattleTag = "peter#123",
+        SenderName = "peter",
+        Excerpt = excerpt,
+        SentAt = new DateTime(2026, 8, 9, 22, 0, 0, DateTimeKind.Utc),
+    };
 }

--- a/W3ChampionsChatService.Tests/ChannelRepositoryTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelRepositoryTests.cs
@@ -373,10 +373,60 @@ public class ChannelRepositoryTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task TryAdvanceLastMessage_PendingDm_IsANoOp_ConsentWall()
+    {
+        var repo = new ChannelRepository(MongoClient);
+        var channel = new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Pending, LastSeq = 0 };
+        await repo.Insert(channel);
+
+        var advanced = await repo.TryAdvanceLastMessage(channel.Id, NewProjection(seq: 1, "hi, do you know me?"));
+
+        Assert.IsFalse(advanced, "a pending Dm is outside the projected scope — the write must simply not match");
+        Assert.IsNull((await repo.Load(channel.Id)).LastMessage, "a recipient must not see a stranger's text before accepting");
+    }
+
+    [Test]
+    public async Task TryAdvanceLastMessage_ReadsConsentFromTheDurableDoc_NotTheCallersSnapshot()
+    {
+        // The send path decides scope from a channel it loaded BEFORE the write. If a concurrent
+        // AcceptRequest commits in that window, the durable doc is what must decide — otherwise the
+        // projection is skipped for a conversation that IS accepted, and the row stays stale until the
+        // next message. Same channel, same call, opposite outcome purely from the durable state.
+        var repo = new ChannelRepository(MongoClient);
+        var channel = new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Pending, LastSeq = 0 };
+        await repo.Insert(channel);
+        Assert.IsFalse(await repo.TryAdvanceLastMessage(channel.Id, NewProjection(seq: 1, "before consent")));
+
+        await repo.SetRequestAccepted(channel.Id, DateTime.UtcNow);
+        var advanced = await repo.TryAdvanceLastMessage(channel.Id, NewProjection(seq: 2, "after consent"));
+
+        Assert.IsTrue(advanced, "once the durable doc says Accepted the very same write must land");
+        Assert.AreEqual("after consent", (await repo.Load(channel.Id)).LastMessage.Excerpt);
+    }
+
+    [Test]
+    public async Task TryAdvanceLastMessage_GroupDm_AdvancesWithoutAnyRequestState()
+    {
+        // A group has no consent machine at all — RequestState is null on the doc, so the accepted leg of
+        // the filter can never match it and the type leg is what admits it.
+        var repo = new ChannelRepository(MongoClient);
+        var group = new ChatChannel { Type = ChannelType.GroupDm, Name = "squad", LastSeq = 0 };
+        await repo.Insert(group);
+
+        var advanced = await repo.TryAdvanceLastMessage(group.Id, NewProjection(seq: 1, "all tinkers in one place"));
+
+        Assert.IsTrue(advanced);
+        Assert.AreEqual("all tinkers in one place", (await repo.Load(group.Id)).LastMessage.Excerpt);
+    }
+
+    [Test]
     public async Task LastMessage_RoundTripsAndIsOmittedWhenAbsent()
     {
         var repo = new ChannelRepository(MongoClient);
-        var without = new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Pending, LastSeq = 0 };
+        // Accepted: this test is about SERIALIZATION, and a pending Dm is outside the projected scope
+        // entirely (TryAdvanceLastMessage_PendingDm_IsANoOp_ConsentWall covers that), so it would have
+        // nothing to round-trip.
+        var without = new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Accepted, LastSeq = 0 };
         await repo.Insert(without);
 
         var raw = await MongoClient.GetDatabase(MongoDbRepositoryBase.DatabaseName)

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -891,6 +891,74 @@ public class ChatHubDmSendTests : IntegrationTestBase
         }
     }
 
+    [Test]
+    public async Task DmSend_AckCarriesTheServerSentAt()
+    {
+        // The sender is the one participant BOTH fan-out paths skip for their own message: no activity
+        // ping (senderConnectionId is skipped explicitly), and MessageReceived only if they happen to be
+        // focused on the channel — which SendMessage does not require. So the ack is the only carrier of
+        // the server's timestamp for their own send, and without it a client would have to stamp the
+        // optimistic echo from the local clock, which is exactly what conversation ordering (and the
+        // keyset paging coordinate derived from it) must never be built on.
+        var channel = await CreateDm(DmRequestState.Accepted);
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        var hub = BuildHub(InitiatorConn);
+
+        var result = await hub.SendMessage(channel.Id, "no fan-out will tell me when this happened");
+
+        Assert.That(result.SentAt, Is.Not.Null, "an Ok ack must carry the send instant");
+        var persisted = (await _messageRepository.LoadForUser(channel.Id, Initiator)).Single();
+        Assert.That(result.SentAt, Is.EqualTo(persisted.SentAt),
+            "and it must be the SAME instant the message was stamped with, not a second reading of the clock");
+        var projection = (await _channelRepository.Load(channel.Id)).LastMessage;
+        Assert.That(result.SentAt, Is.EqualTo(projection.SentAt),
+            "so the sender's own row sorts on exactly the value everyone else's does");
+    }
+
+    [Test]
+    public async Task BlockedDmSend_FakeAckCarriesASentAtToo_SilentDropUniformity()
+    {
+        // The silent-drop ack must stay byte-shaped like a real one — a null SentAt where a real send has
+        // one would leak the block just as surely as a null MessageId would.
+        var channel = await CreateDm(DmRequestState.Accepted);
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        SetBlocked(Recipient, Initiator);
+        var hub = BuildHub(InitiatorConn);
+
+        var result = await hub.SendMessage(channel.Id, "they blocked me and must not learn that I know");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        Assert.That(result.SentAt, Is.Not.Null, "a fabricated ack must carry a fabricated instant, same shape as a real one");
+        Assert.That((await _channelRepository.Load(channel.Id)).LastMessage, Is.Null, "while nothing is actually persisted or projected");
+    }
+
+    [Test]
+    public async Task DmSend_ReAnnouncedShell_CarriesTheProjectionItJustWrote()
+    {
+        // A snapshot-excluded shell is re-announced by MaterializeDmRecipientAndNotify using the SAME
+        // in-memory channel the send loaded. The projection write only touches Mongo, so unless it is
+        // mirrored back the recipient is handed a conversation row with no text — and a recipient on
+        // Mentions/None, or one whose activity is unread-suppressed, gets no second chance at it.
+        var channel = await CreateDm(DmRequestState.Accepted);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = channel.Id,
+            BattleTag = Recipient,
+            NotificationLevel = NotificationLevel.All,
+            JoinedAt = Now,
+        });
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        RegisterSession(RecipientConn, Recipient);   // online but NOT registry-seeded → triggers the re-announce
+        var hub = BuildHub(InitiatorConn);
+
+        await hub.SendMessage(channel.Id, "are you still there?");
+
+        var added = _harness.PayloadFor(RecipientConn, ChatEvents.ChannelAdded) as ChannelAddedDto;
+        Assert.That(added, Is.Not.Null);
+        Assert.That(added.Channel.LastMessage, Is.Not.Null, "the re-announced shell must carry the projection this very send wrote");
+        Assert.That(added.Channel.LastMessage.Excerpt, Is.EqualTo("are you still there?"));
+    }
+
     // --- Invariants this projection silently depends on, pinned so that widening either scope fails loudly ---
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -725,4 +725,163 @@ public class ChatHubDmSendTests : IntegrationTestBase
         Assert.That((await _messageRepository.LoadForModerator(channel.Id)).Count, Is.EqualTo(1),
             "message 2 is NOT persisted — only message 1 remains stored");
     }
+
+    // ------------------------------------------------------------------------------------------------
+    // ChannelLastMessage — the conversation-list projection maintained on the channel doc at send time
+    // ------------------------------------------------------------------------------------------------
+
+    [Test]
+    public async Task DmSend_AcceptedDm_ProjectsLastMessageOntoTheChannel()
+    {
+        var channel = await CreateDm(DmRequestState.Accepted);
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        var hub = BuildHub(InitiatorConn);
+
+        var result = await hub.SendMessage(channel.Id, "tinker goblin");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        var projection = (await _channelRepository.Load(channel.Id)).LastMessage;
+        Assert.That(projection, Is.Not.Null, "an accepted Dm send must leave the conversation-list projection on the channel doc");
+        Assert.That(projection.Seq, Is.EqualTo(result.Seq));
+        Assert.That(projection.SenderBattleTag, Is.EqualTo(Initiator));
+        Assert.That(projection.Excerpt, Is.EqualTo("tinker goblin"));
+        Assert.That(projection.SentAt, Is.EqualTo(Now), "SentAt must be the message's own server instant, so it stays comparable with LastMessageAt");
+    }
+
+    [Test]
+    public async Task DmSend_SecondMessage_AdvancesProjectionToTheNewerOne()
+    {
+        var channel = await CreateDm(DmRequestState.Accepted);
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        var hub = BuildHub(InitiatorConn);
+
+        await hub.SendMessage(channel.Id, "first");
+        var second = await hub.SendMessage(channel.Id, "second");
+
+        var projection = (await _channelRepository.Load(channel.Id)).LastMessage;
+        Assert.That(projection.Seq, Is.EqualTo(second.Seq));
+        Assert.That(projection.Excerpt, Is.EqualTo("second"), "the projection tracks the conversation's LAST message, not its first");
+    }
+
+    [Test]
+    public async Task DmSend_PendingDm_ProjectsNothing_ConsentWall()
+    {
+        // The recipient has not accepted yet. They can already see this shell in their tray (D4 dual
+        // listing), so projecting the initiator's text here would show a stranger's message before
+        // consent — the same wall that already suppresses the recipient's ChannelActivity.
+        var channel = await CreateDm(DmRequestState.Pending);
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        var hub = BuildHub(InitiatorConn);
+
+        var result = await hub.SendMessage(channel.Id, "hi, do you know me?");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.LastSeq, Is.EqualTo(1L), "the message itself is persisted as usual");
+        Assert.That(reloaded.LastMessage, Is.Null, "a PENDING Dm must never carry a last-message projection");
+    }
+
+    [Test]
+    public async Task GroupDmSend_ProjectsLastMessage()
+    {
+        var group = new ChatChannel { Type = ChannelType.GroupDm, Name = "squad", LastSeq = 0, LastMessageAt = Now, ExpiresAt = Now.AddDays(365) };
+        await _channelRepository.Insert(group);
+        SeedMember(InitiatorConn, Initiator, group.Id, ChannelType.GroupDm);
+        var hub = BuildHub(InitiatorConn);
+
+        await hub.SendMessage(group.Id, "all tinkers in one place");
+
+        var projection = (await _channelRepository.Load(group.Id)).LastMessage;
+        Assert.That(projection, Is.Not.Null, "groups list in the same tray as 1:1 conversations and carry the projection too");
+        Assert.That(projection.Excerpt, Is.EqualTo("all tinkers in one place"));
+    }
+
+    [Test]
+    public async Task PublicSend_ProjectsNothing_BecauseTheCatalogShipsToNonMembers()
+    {
+        // PublicCatalog ships the raw ChatChannel for rooms the caller has NOT joined, so a projection
+        // here would publish room content to non-members.
+        var channel = new ChatChannel { Type = ChannelType.Public, Name = "general", NormalizedName = ChannelNames.Normalize("general") };
+        await _channelRepository.Insert(channel);
+        SeedMember(InitiatorConn, Initiator, channel.Id, ChannelType.Public);
+        var hub = BuildHub(InitiatorConn);
+
+        await hub.SendMessage(channel.Id, "hello lounge");
+
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.LastSeq, Is.EqualTo(1L));
+        Assert.That(reloaded.LastMessage, Is.Null, "a public room must never carry a last-message projection");
+    }
+
+    [Test]
+    public async Task DmSend_LongContent_ProjectionExcerptMatchesTheLiveEventExcerpt()
+    {
+        var channel = await CreateDm(DmRequestState.Accepted);
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        var hub = BuildHub(InitiatorConn);
+        var content = new string('x', ChatLimits.DmPreviewExcerptLength + 50);
+
+        await hub.SendMessage(channel.Id, content);
+
+        var projection = (await _channelRepository.Load(channel.Id)).LastMessage;
+        Assert.That(projection.Excerpt.Length, Is.EqualTo(ChatLimits.DmPreviewExcerptLength));
+        Assert.That(projection.Excerpt, Is.EqualTo(Excerpts.Bounded(content)),
+            "the projection and the live ChannelActivity preview must come from the SAME excerpt helper, or a "
+            + "client would see the same message's text differ between the snapshot and the live event");
+    }
+
+    // --- Invariants this projection silently depends on, pinned so that widening either scope fails loudly ---
+
+    [Test]
+    public void ProjectedChannels_AreDisjointFromModeratableChannels()
+    {
+        // WHY THIS MATTERS: there is no deletion invalidation for ChannelLastMessage, and none is needed
+        // ONLY because a projected channel can never have a message deleted — ChannelModeration.IsModeratable
+        // gates both ChatHub.DeleteMessage and ChatHub.PurgeMessagesFromUser. If moderation is ever widened
+        // to reach Dm/GroupDm, this projection starts serving soft-deleted text to every member of the
+        // conversation, forever: a moderation hole, not a cosmetic bug. Whoever widens it must also add the
+        // recompute-on-delete that this assertion is standing in for.
+        foreach (var channel in AllChannelShapes())
+        {
+            Assert.That(
+                ChatHub.CarriesLastMessageProjection(channel) && ChannelModeration.IsModeratable(channel),
+                Is.False,
+                $"{Describe(channel)} is BOTH projected and moderatable — deleted text would stay pinned in every member's conversation list");
+        }
+    }
+
+    [Test]
+    public void ProjectedChannels_AreDisjointFromMuteEnforcedChannels()
+    {
+        // The send path skips the projection for shadow messages, which today is defence in depth rather
+        // than a live code path: a shadow message can only be produced where a mute is enforced, and that
+        // set is disjoint from the projected set. If mute enforcement is ever widened to DMs/groups, that
+        // !isShadow guard silently becomes load-bearing — this pins the relationship so the guard is not
+        // "simplified away" as dead code first.
+        foreach (var channel in AllChannelShapes())
+        {
+            Assert.That(
+                ChatHub.CarriesLastMessageProjection(channel) && ChannelModeration.IsMuteEnforced(channel),
+                Is.False,
+                $"{Describe(channel)} is BOTH projected and mute-enforced — a shadow author's text could reach every member");
+        }
+    }
+
+    private static IEnumerable<ChatChannel> AllChannelShapes()
+    {
+        yield return new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Accepted };
+        yield return new ChatChannel { Type = ChannelType.Dm, RequestState = DmRequestState.Pending };
+        yield return new ChatChannel { Type = ChannelType.GroupDm };
+        yield return new ChatChannel { Type = ChannelType.Public };
+        yield return new ChatChannel { Type = ChannelType.SemiPublic };
+        yield return new ChatChannel { Type = ChannelType.System, SystemKind = SystemChannelKind.Match, Ladder = true };
+        yield return new ChatChannel { Type = ChannelType.System, SystemKind = SystemChannelKind.Match, Ladder = false };
+        yield return new ChatChannel { Type = ChannelType.System, SystemKind = SystemChannelKind.Clan };
+        yield return new ChatChannel { Type = ChannelType.System, SystemKind = SystemChannelKind.Lobby };
+    }
+
+    private static string Describe(ChatChannel channel) =>
+        channel.Type == ChannelType.System ? $"System+{channel.SystemKind}(ladder={channel.Ladder})"
+        : channel.Type == ChannelType.Dm ? $"Dm({channel.RequestState})"
+        : channel.Type.ToString();
 }

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -959,6 +959,51 @@ public class ChatHubDmSendTests : IntegrationTestBase
         Assert.That(added.Channel.LastMessage.Excerpt, Is.EqualTo("are you still there?"));
     }
 
+    [Test]
+    public async Task DmSend_ThatLosesTheProjectionCas_StillReAnnouncesTheWinningProjection()
+    {
+        // A concurrent same-channel send can write a HIGHER seq before this one reaches the CAS. This
+        // send may nonetheless be the one that materializes the recipient — the send that WON the CAS
+        // finds the registry already seeded and re-announces nothing — so the single ChannelAdded that
+        // will ever be sent must still carry the winning projection, not this send's stale copy.
+        var channel = await CreateDm(DmRequestState.Accepted);
+        await _membershipRepository.Insert(new ChannelMembership
+        {
+            ChannelId = channel.Id,
+            BattleTag = Recipient,
+            NotificationLevel = NotificationLevel.All,
+            JoinedAt = Now,
+        });
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        RegisterSession(RecipientConn, Recipient);   // online but NOT registry-seeded → triggers the re-announce
+        var hub = BuildHub(InitiatorConn, new ConcurrentWinnerChannelRepository(MongoClient));
+
+        await hub.SendMessage(channel.Id, "mine loses the race");
+
+        var added = _harness.PayloadFor(RecipientConn, ChatEvents.ChannelAdded) as ChannelAddedDto;
+        Assert.That(added, Is.Not.Null);
+        Assert.That(added.Channel.LastMessage, Is.Not.Null, "a lost CAS must not leave the announcement without a projection");
+        Assert.That(added.Channel.LastMessage.Excerpt, Is.EqualTo("the concurrent winner"),
+            "and it must carry the message that actually won, not this send's own");
+    }
+
+    // Simulates a concurrent send that wrote a strictly higher seq first, so this send's CAS loses.
+    private sealed class ConcurrentWinnerChannelRepository(MongoClient client) : ChannelRepository(client)
+    {
+        public override async Task<bool> TryAdvanceLastMessage(string channelId, ChannelLastMessage lastMessage)
+        {
+            await base.TryAdvanceLastMessage(channelId, new ChannelLastMessage
+            {
+                Seq = lastMessage.Seq + 1,
+                SenderBattleTag = "someone#9999",
+                SenderName = "someone",
+                Excerpt = "the concurrent winner",
+                SentAt = lastMessage.SentAt.AddSeconds(1),
+            });
+            return await base.TryAdvanceLastMessage(channelId, lastMessage);
+        }
+    }
+
     // --- Invariants this projection silently depends on, pinned so that widening either scope fails loudly ---
 
     [Test]

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Time.Testing;
+using MongoDB.Driver;
 using Moq;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
@@ -129,7 +130,7 @@ public class ChatHubDmSendTests : IntegrationTestBase
             new MentionInboxRepository(MongoClient));
     }
 
-    private ChatHub BuildHub(string connectionId)
+    private ChatHub BuildHub(string connectionId, ChannelRepository channelRepository = null)
     {
         var hub = new ChatHub(
             _connectionMapping,
@@ -143,7 +144,7 @@ public class ChatHubDmSendTests : IntegrationTestBase
             _messageRateLimiter,
             _readRateLimiter,
             _time,
-            _channelRepository,
+            channelRepository ?? _channelRepository,
             _membershipRepository,
             _channelCreationRateLimiter,
             _messageRepository,
@@ -828,6 +829,66 @@ public class ChatHubDmSendTests : IntegrationTestBase
         Assert.That(projection.Excerpt, Is.EqualTo(Excerpts.Bounded(content)),
             "the projection and the live ChannelActivity preview must come from the SAME excerpt helper, or a "
             + "client would see the same message's text differ between the snapshot and the live event");
+    }
+
+    [Test]
+    public async Task DmSend_ProjectionWriteThrows_SendStillAcksAndDelivers()
+    {
+        // The projection is a SECOND post-persist write. If it could propagate, a message that is already
+        // durable would come back as an error, the caller would get no ack, and a client retry would
+        // persist a duplicate. Best-effort is the only acceptable shape for post-persist work — the same
+        // rule the fan-out below it already follows.
+        var channel = await CreateDm(DmRequestState.Accepted);
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        var hub = BuildHub(InitiatorConn, new ThrowingLastMessageChannelRepository(MongoClient));
+
+        var result = await hub.SendMessage(channel.Id, "the projection write is about to fail");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok), "a failed projection must not turn a persisted send into an error");
+        Assert.That(result.Seq, Is.EqualTo(1L), "the ack still carries the allocated seq");
+        var stored = await _messageRepository.LoadForUser(channel.Id, Initiator);
+        Assert.That(stored.Count, Is.EqualTo(1), "the message is durable regardless");
+        var reloaded = await _channelRepository.Load(channel.Id);
+        Assert.That(reloaded.LastMessage, Is.Null, "and the row simply stays on the previous message until the next send");
+    }
+
+    [Test]
+    public async Task DmSend_AcceptedConcurrentlyWithTheSend_StillProjects()
+    {
+        // The send loads the channel BEFORE it writes. If the recipient accepts in that window, the
+        // in-memory snapshot still says Pending — deciding consent from it would skip the projection for a
+        // conversation that is accepted by the time the write lands, stranding the row until the next
+        // message. The decision belongs to the durable doc, so this send projects even though the hub's
+        // own copy of the channel says otherwise.
+        var channel = await CreateDm(DmRequestState.Pending);
+        SeedMember(InitiatorConn, Initiator, channel.Id);
+        var hub = BuildHub(InitiatorConn, new AcceptOnProjectionChannelRepository(MongoClient));
+
+        var result = await hub.SendMessage(channel.Id, "accepted while this was in flight");
+
+        Assert.That(result.Code, Is.EqualTo(ChatResultCode.Ok));
+        var projection = (await _channelRepository.Load(channel.Id)).LastMessage;
+        Assert.That(projection, Is.Not.Null, "the durable state was Accepted when the write ran, so the projection belongs there");
+        Assert.That(projection.Excerpt, Is.EqualTo("accepted while this was in flight"));
+    }
+
+    // Fails the conversation-list projection write and nothing else.
+    private sealed class ThrowingLastMessageChannelRepository(MongoClient client) : ChannelRepository(client)
+    {
+        public override Task<bool> TryAdvanceLastMessage(string channelId, ChannelLastMessage lastMessage) =>
+            throw new MongoException("projection write failed");
+    }
+
+    // Commits the acceptance the instant the projection write runs — i.e. AFTER the send loaded the
+    // channel as Pending — reproducing the accept-races-send window from the durable side, through the
+    // same SetRequestAccepted transition AcceptRequest itself uses.
+    private sealed class AcceptOnProjectionChannelRepository(MongoClient client) : ChannelRepository(client)
+    {
+        public override async Task<bool> TryAdvanceLastMessage(string channelId, ChannelLastMessage lastMessage)
+        {
+            await SetRequestAccepted(channelId, DateTime.UtcNow);
+            return await base.TryAdvanceLastMessage(channelId, lastMessage);
+        }
     }
 
     // --- Invariants this projection silently depends on, pinned so that widening either scope fails loudly ---

--- a/W3ChampionsChatService/Channels/ChannelLastMessage.cs
+++ b/W3ChampionsChatService/Channels/ChannelLastMessage.cs
@@ -1,0 +1,78 @@
+using System;
+
+namespace W3ChampionsChatService.Channels;
+
+/// <summary>
+/// Denormalized projection of a channel's newest USER-VISIBLE message, maintained on the channel doc
+/// so a conversation list can render "who said what, and when" WITHOUT reading the message collection.
+/// <para>
+/// WHY this exists: before it, "the last message in this conversation" was only ever knowable from a
+/// live event — <c>ChannelActivity</c> (unfocused channels only, and coalesced/suppressed) or
+/// <c>MessageReceived</c> (focused channels only). Neither <c>SessionState</c> nor
+/// <c>GetConversations</c> carried the text at all, so a client had no way to render a conversation
+/// list at rest and no way to recover one after a reconnect: whatever it had cached from live events
+/// was simply lost. Clients were reconstructing this projection from event fragments, which cannot be
+/// made correct — see the launcher-e investigation in w3champions/launcher-e#848.
+/// </para>
+/// <para>
+/// SCOPE (deliberately narrow, mirroring <c>DmActivityPreviewDto</c>'s own scope rules):
+/// <list type="bullet">
+/// <item>Only <c>Dm</c> (once <see cref="Domain.DmRequestState.Accepted"/>) and <c>GroupDm</c> channels
+/// carry it. A PENDING Dm never does — the recipient must not see a stranger's message text before
+/// accepting, which is the same consent wall that already suppresses their <c>ChannelActivity</c>.
+/// Public/SemiPublic/System channels never do either: <c>PublicCatalog</c> ships the raw
+/// <see cref="ChatChannel"/> for rooms the caller has NOT joined, and a preview there would publish
+/// room content to non-members.</item>
+/// <item>SHADOW messages never populate it. A shadow-banned author's text must never surface to anyone
+/// else, and this projection is channel-global (no per-viewer filtering is possible on it) — so the
+/// shadow illusion is preserved by simply never projecting one. <see cref="ChatChannel.LastSeq"/> and
+/// <see cref="ChatChannel.LastMessageAt"/> still advance for a shadow message, exactly as before, so
+/// the two can legitimately disagree: <see cref="Seq"/> is the newest NON-shadow message. Always trust
+/// <see cref="Seq"/> over <see cref="ChatChannel.LastSeq"/> when rendering this.</item>
+/// </list>
+/// </para>
+/// <para>
+/// NO DELETION INVALIDATION EXISTS, AND NONE IS NEEDED — but only because of an invariant that lives in
+/// another file: <see cref="ChannelModeration.IsModeratable"/> (Public / SemiPublic / System+Match) is
+/// DISJOINT from the projected set above, and it gates BOTH <c>ChatHub.DeleteMessage</c> and
+/// <c>ChatHub.PurgeMessagesFromUser</c>. A projected message therefore cannot be deleted. If moderation
+/// is ever widened to reach Dm/GroupDm, this projection silently starts serving deleted text to every
+/// member of the conversation, forever — a moderation hole, not a cosmetic bug. <c>ChannelLastMessageTests</c>
+/// pins the disjointness so that change fails loudly here instead of shipping.
+/// </para>
+/// <para>
+/// Message TTL is a knowingly accepted staleness: <c>ExpiryCalculator.ForChannelMessage</c> can reap the
+/// projected message while the (message-anchored, longer) shell TTL keeps the channel alive, leaving an
+/// excerpt for a row that no longer exists. It is a bounded string on the channel doc, read by clients
+/// that never dereference it back to a message, and the alternative — a TTL-aware sweep over every shell —
+/// buys nothing a user can perceive.
+/// </para>
+/// </summary>
+public class ChannelLastMessage
+{
+    /// <summary>
+    /// The projected message's per-channel sequence number. Also the concurrency token: the advance is a
+    /// compare-and-set on this field (<see cref="ChannelRepository.TryAdvanceLastMessage"/>), so
+    /// concurrent sends that reach the write out of order can never regress the projection.
+    /// </summary>
+    public long Seq { get; set; }
+
+    public string SenderBattleTag { get; set; }
+
+    public string SenderName { get; set; }
+
+    /// <summary>
+    /// The message content bounded by <see cref="Protocol.Excerpts.Bounded"/> — the SAME helper (and so
+    /// the same <see cref="Domain.ChatLimits.DmPreviewExcerptLength"/> cap and the same surrogate-pair
+    /// safety) that builds <c>DmActivityPreviewDto.Excerpt</c>, so a client that renders one from the
+    /// live event and one from the snapshot can never see the two disagree on the same message.
+    /// </summary>
+    public string Excerpt { get; set; }
+
+    /// <summary>
+    /// The projected message's <see cref="Messages.ChannelMessage.SentAt"/> — a SERVER instant, which is
+    /// what makes this usable as a conversation-list sort key. (<see cref="ChatChannel.LastMessageAt"/>
+    /// is the same clock but advances for shadow messages too.)
+    /// </summary>
+    public DateTime SentAt { get; set; }
+}

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -102,6 +102,34 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
     }
 
     /// <summary>
+    /// Advances <see cref="ChatChannel.LastMessage"/> to <paramref name="lastMessage"/>, but ONLY if it is
+    /// strictly newer than whatever is stored — a compare-and-set on <see cref="ChannelLastMessage.Seq"/>.
+    /// <para>
+    /// WHY a second write instead of folding this into <see cref="AllocateSeq"/>'s atomic $inc: the
+    /// projection needs the seq that call allocates, so setting it there would mean rewriting the service's
+    /// most concurrency-critical write as an aggregation-pipeline update. The seq is also not the only
+    /// reason — the projection must be skipped for shadow messages, which <see cref="AllocateSeq"/> has no
+    /// business knowing about. This costs one extra by-_id update per non-shadow Dm/GroupDm message, and in
+    /// exchange the seq allocator stays untouched and this write is monotonic by construction: two
+    /// concurrent sends that reach it out of order settle on the higher seq no matter which lands last.
+    /// </para>
+    /// Returns true iff this call actually advanced the field.
+    /// </summary>
+    public async Task<bool> TryAdvanceLastMessage(string channelId, ChannelLastMessage lastMessage)
+    {
+        var filterBuilder = Builders<ChatChannel>.Filter;
+        var filter = filterBuilder.And(
+            filterBuilder.Eq(c => c.Id, channelId),
+            filterBuilder.Or(
+                // A missing field matches Eq(..., null) in Mongo — this is the never-projected-yet case.
+                filterBuilder.Eq(c => c.LastMessage, null),
+                filterBuilder.Lt(c => c.LastMessage.Seq, lastMessage.Seq)));
+
+        var result = await Channels.UpdateOneAsync(filter, Builders<ChatChannel>.Update.Set(c => c.LastMessage, lastMessage));
+        return result.ModifiedCount == 1;
+    }
+
+    /// <summary>
     /// Implicit find-or-create for semiPublic channels (join resolution — acceptance 9a):
     /// $setOnInsert upsert keyed (Type=SemiPublic, NormalizedName), mirroring
     /// PublicChannelSeeder's idempotent pattern. Backed by the unique partial index

--- a/W3ChampionsChatService/Channels/ChannelRepository.cs
+++ b/W3ChampionsChatService/Channels/ChannelRepository.cs
@@ -113,13 +113,24 @@ public class ChannelRepository(MongoClient mongoClient) : MongoDbRepositoryBase(
     /// exchange the seq allocator stays untouched and this write is monotonic by construction: two
     /// concurrent sends that reach it out of order settle on the higher seq no matter which lands last.
     /// </para>
+    /// <para>
+    /// The CONSENT half of the scope is enforced here rather than by the caller: a 1:1 Dm is projected only
+    /// once its request is <see cref="DmRequestState.Accepted"/>, and that is read from the durable doc in
+    /// the same command that writes. The caller decides scope from a channel it loaded BEFORE the send, and
+    /// a concurrent <c>AcceptRequest</c> can commit in between — deciding there would skip the projection
+    /// for a conversation that is accepted by the time the write runs, stranding the row on an older message
+    /// until the next send. A pending Dm is a no-op here, not an error: same shape as losing the seq CAS.
+    /// </para>
     /// Returns true iff this call actually advanced the field.
     /// </summary>
-    public async Task<bool> TryAdvanceLastMessage(string channelId, ChannelLastMessage lastMessage)
+    public virtual async Task<bool> TryAdvanceLastMessage(string channelId, ChannelLastMessage lastMessage)
     {
         var filterBuilder = Builders<ChatChannel>.Filter;
         var filter = filterBuilder.And(
             filterBuilder.Eq(c => c.Id, channelId),
+            filterBuilder.Or(
+                filterBuilder.Eq(c => c.Type, ChannelType.GroupDm),
+                filterBuilder.Eq(c => c.RequestState, DmRequestState.Accepted)),
             filterBuilder.Or(
                 // A missing field matches Eq(..., null) in Mongo — this is the never-projected-yet case.
                 filterBuilder.Eq(c => c.LastMessage, null),

--- a/W3ChampionsChatService/Channels/ChatChannel.cs
+++ b/W3ChampionsChatService/Channels/ChatChannel.cs
@@ -84,6 +84,16 @@ public class ChatChannel
     [BsonIgnoreIfNull]
     public DateTime? LastMessageAt { get; set; }
 
+    /// <summary>
+    /// Dm (accepted) / GroupDm only — the newest user-visible message, denormalized for conversation-list
+    /// rendering at rest. Rides the raw <see cref="ChatChannel"/> in <c>ChannelDto</c>/<c>ChannelAddedDto</c>/
+    /// <c>GetConversations</c> like every other field here. Absent means "nothing to show yet" (a fresh or
+    /// pending shell, a channel whose only messages are shadow or deleted, or a doc written before this
+    /// field existed — see <see cref="ChannelLastMessage"/> for the full scope and shadow rules).
+    /// </summary>
+    [BsonIgnoreIfNull]
+    public ChannelLastMessage LastMessage { get; set; }
+
     /// <summary>Absolute expiry instant (TTL index, expireAfterSeconds 0). Absent = permanent.</summary>
     [BsonIgnoreIfNull]
     public DateTime? ExpiresAt { get; set; }

--- a/W3ChampionsChatService/Chats/ChatHub.Dm.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Dm.cs
@@ -365,8 +365,8 @@ public partial class ChatHub
     /// (the next real seq a client would expect); clients dedupe by messageId, so the never-persisted id is
     /// harmless (D6 documented residuals).
     /// </summary>
-    private static SendMessageResult FakeSendAck(ChatChannel channel) =>
-        new SendMessageResult(ChatResultCode.Ok, MessageId: ObjectId.GenerateNewId().ToString(), Seq: channel.LastSeq + 1);
+    private static SendMessageResult FakeSendAck(ChatChannel channel, DateTime now) =>
+        new SendMessageResult(ChatResultCode.Ok, MessageId: ObjectId.GenerateNewId().ToString(), Seq: channel.LastSeq + 1, SentAt: now);
 
     /// <summary>
     /// Resolves the COUNTERPART battleTag of a 1:1 <see cref="ChannelType.Dm"/> from its
@@ -466,7 +466,7 @@ public partial class ChatHub
         {
             // Blocked: silent non-delivery. Nothing is persisted, delivered, or materialized (SendMessage
             // returns this before the persist/materialize/fan-out steps).
-            return FakeSendAck(channel);
+            return FakeSendAck(channel, now);
         }
 
         // (2) Pending machine.
@@ -492,13 +492,13 @@ public partial class ChatHub
                 var recipientSettings = await _userSettings.LoadOrDefault(counterpart);
                 if (recipientSettings.DmPrivacy is not DmPrivacy.Everyone)
                 {
-                    return FakeSendAck(channel);
+                    return FakeSendAck(channel, now);
                 }
 
                 // Pending-depth cap: only the initiator grows a pending conversation, so LastSeq is the depth.
                 if (channel.LastSeq >= ChatLimits.PendingConversationMaxMessages)
                 {
-                    return FakeSendAck(channel);
+                    return FakeSendAck(channel, now);
                 }
             }
         }

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -351,7 +351,18 @@ public partial class ChatHub
         {
             try
             {
-                await _channelRepository.TryAdvanceLastMessage(channelId, BuildLastMessageProjection(message));
+                var projection = BuildLastMessageProjection(message);
+                if (await _channelRepository.TryAdvanceLastMessage(channelId, projection))
+                {
+                    // Mirror the successful write onto the in-memory channel: step 7.5 below re-announces
+                    // this same instance via ChannelAdded (MaterializeDmRecipientAndNotify), and a recipient
+                    // whose notification level is Mentions/None — or whose activity is unread-suppressed —
+                    // has no second chance to learn the projection. Announcing the copy we just wrote is
+                    // free; re-reading the doc would be another round-trip. A false return means a
+                    // concurrent newer message won the CAS, and the announcement carries the older
+                    // projection until the next send — the same self-healing staleness as a lost CAS.
+                    channel.LastMessage = projection;
+                }
             }
             catch (Exception ex)
             {
@@ -422,7 +433,9 @@ public partial class ChatHub
         }
 
         // 9. Typed ack.
-        return new SendMessageResult(ChatResultCode.Ok, MessageId: message.Id, Seq: seq);
+        // SentAt: the sender is skipped by BOTH fan-out paths for their own message, so this ack is the
+        // only place the server's timestamp reaches them — see SendMessageResult for why that matters.
+        return new SendMessageResult(ChatResultCode.Ok, MessageId: message.Id, Seq: seq, SentAt: message.SentAt);
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -358,10 +358,24 @@ public partial class ChatHub
                     // this same instance via ChannelAdded (MaterializeDmRecipientAndNotify), and a recipient
                     // whose notification level is Mentions/None — or whose activity is unread-suppressed —
                     // has no second chance to learn the projection. Announcing the copy we just wrote is
-                    // free; re-reading the doc would be another round-trip. A false return means a
-                    // concurrent newer message won the CAS, and the announcement carries the older
-                    // projection until the next send — the same self-healing staleness as a lost CAS.
+                    // free; re-reading the doc would be another round-trip.
                     channel.LastMessage = projection;
+                }
+                else if (channel.Type == ChannelType.Dm)
+                {
+                    // Lost the CAS: a concurrent same-channel send already wrote a HIGHER seq, and this
+                    // instance still holds whatever it was loaded with. Normally that costs nothing — but
+                    // THIS send may still be the one that materializes the recipient below, while the send
+                    // that won the CAS finds the registry already seeded and re-announces nothing. So the
+                    // one announcement that will ever be made would carry a stale or absent projection.
+                    // Re-read for the winner. Scoped to Dm because that is the only type step 7.5 re-
+                    // announces, and to the lost-CAS branch, which requires genuinely concurrent sends in
+                    // one conversation — this is not a per-message read.
+                    var winner = await _channelRepository.Load(channelId);
+                    if (winner?.LastMessage != null)
+                    {
+                        channel.LastMessage = winner.LastMessage;
+                    }
                 }
             }
             catch (Exception ex)

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -334,9 +334,33 @@ public partial class ChatHub
         // that reach it out of order settle on the higher seq regardless of arrival order — the same
         // monotonic discipline AllocateSeq gives the counter itself. A false return means a concurrent
         // newer message already won, which is the correct outcome and not an error.
+        //
+        // BEST-EFFORT, exactly like the fan-out below it: the message is already durable by this point,
+        // so a failure here must never propagate and turn a completed send into an error — the caller
+        // would get no ack for a message that exists, and a client retry would persist a duplicate.
+        // Introducing a second post-persist Mongo write is only acceptable on that condition. The cost
+        // of swallowing it is bounded and self-healing: the conversation row renders the previous
+        // message until the next one in that channel advances the projection.
+        //
+        // The ACCEPTED half of the scope is re-decided inside TryAdvanceLastMessage, against the durable
+        // channel doc rather than this in-memory snapshot — `channel` was loaded before the send and a
+        // concurrent AcceptRequest can commit in between, which would otherwise skip the projection for
+        // a conversation that is accepted by the time this runs. Only the shape gate (Dm/GroupDm) and
+        // the shadow rule, neither of which any concurrent write can change, are decided here.
         if (!isShadow && CarriesLastMessageProjection(channel))
         {
-            await _channelRepository.TryAdvanceLastMessage(channelId, BuildLastMessageProjection(message));
+            try
+            {
+                await _channelRepository.TryAdvanceLastMessage(channelId, BuildLastMessageProjection(message));
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(
+                    ex,
+                    "Conversation-list projection failed for channel {ChannelId} seq {Seq} — message is persisted and delivery continues; the row stays on the previous message until the next send",
+                    channelId,
+                    message.Seq);
+            }
         }
 
         // 7.5 Dm recipient materialization + RequestReceived (C5 Task 4, D4) — post-persist, BEFORE fan-out.
@@ -669,24 +693,26 @@ public partial class ChatHub
     }
 
     /// <summary>
-    /// Which channels carry the <see cref="ChannelLastMessage"/> conversation-list projection: GroupDm
-    /// always, Dm only once ACCEPTED, nothing else. See <see cref="ChannelLastMessage"/> for why the set is
-    /// this narrow — the pending-Dm exclusion is the consent wall (a recipient must not see a stranger's
-    /// text before accepting, the same rule that suppresses their <c>ChannelActivity</c>), and the
-    /// public/system exclusion keeps room content out of the <c>PublicCatalog</c> shells that ship to
-    /// NON-members.
+    /// Which channels carry the <see cref="ChannelLastMessage"/> conversation-list projection: the two
+    /// conversation shapes, nothing else. See <see cref="ChannelLastMessage"/> for why the set is this
+    /// narrow — the public/system exclusion keeps room content out of the <c>PublicCatalog</c> shells that
+    /// ship to NON-members.
+    /// <para>
+    /// This is the TYPE half of the scope only. The consent wall — a pending Dm is not projected, so a
+    /// recipient never sees a stranger's text before accepting, the same rule that suppresses their
+    /// <c>ChannelActivity</c> — is enforced inside
+    /// <see cref="ChannelRepository.TryAdvanceLastMessage"/>'s own filter instead, because it is the half
+    /// a concurrent write can change between the send loading this channel and the projection landing.
+    /// A channel's TYPE is immutable, so deciding that here is safe by construction.
+    /// </para>
     /// <para>
     /// A Dm accepted AFTER messages already exist is not backfilled: the projection appears with the
     /// conversation's next message. Backfilling would mean reading the message collection on the accept
     /// path to publish text the recipient has, until that moment, deliberately not been shown.
     /// </para>
     /// </summary>
-    internal static bool CarriesLastMessageProjection(ChatChannel channel) => channel.Type switch
-    {
-        ChannelType.GroupDm => true,
-        ChannelType.Dm => channel.RequestState == DmRequestState.Accepted,
-        _ => false,
-    };
+    internal static bool CarriesLastMessageProjection(ChatChannel channel) =>
+        channel.Type is ChannelType.Dm or ChannelType.GroupDm;
 
     /// <summary>
     /// The single message→projection mapping. <see cref="Excerpts.Bounded"/> is the SAME helper that builds

--- a/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Messaging.cs
@@ -318,6 +318,27 @@ public partial class ChatHub
         };
         await _messageRepository.Insert(message);
 
+        // 7.25 Conversation-list projection (ChannelLastMessage): denormalize this message onto the channel
+        // doc so SessionState/GetConversations/ChannelAdded can render "who said what, and when" without
+        // reading the message collection. Before it, that text only ever existed in a live event, so a
+        // client had nothing to render a conversation list from at rest and no way to recover one after a
+        // reconnect (w3champions/launcher-e#848).
+        //
+        // Runs post-insert (the projection describes a durable message, so it must never precede it) and
+        // pre-fan-out (a client that reacts to the event by calling GetConversations must not race a
+        // not-yet-written projection). Skipped entirely for shadow — a shadow author's text must never
+        // reach a non-author, and this projection is channel-global with no per-viewer filtering, so the
+        // ONLY safe treatment is to not write one. Scope (accepted Dm + GroupDm) is CarriesLastMessageProjection.
+        //
+        // The write is a compare-and-set on seq (TryAdvanceLastMessage), so concurrent same-channel sends
+        // that reach it out of order settle on the higher seq regardless of arrival order — the same
+        // monotonic discipline AllocateSeq gives the counter itself. A false return means a concurrent
+        // newer message already won, which is the correct outcome and not an error.
+        if (!isShadow && CarriesLastMessageProjection(channel))
+        {
+            await _channelRepository.TryAdvanceLastMessage(channelId, BuildLastMessageProjection(message));
+        }
+
         // 7.5 Dm recipient materialization + RequestReceived (C5 Task 4, D4) — post-persist, BEFORE fan-out.
         // Lazily creates the counterpart's membership on first delivery (seeding their registry via
         // PushChannelAdded(focus:false)) and fires the targeted RequestReceived consent transition for a
@@ -646,4 +667,38 @@ public partial class ChatHub
             Flair = ChatProfileMapper.FromChatUser(chatUser),
         };
     }
+
+    /// <summary>
+    /// Which channels carry the <see cref="ChannelLastMessage"/> conversation-list projection: GroupDm
+    /// always, Dm only once ACCEPTED, nothing else. See <see cref="ChannelLastMessage"/> for why the set is
+    /// this narrow — the pending-Dm exclusion is the consent wall (a recipient must not see a stranger's
+    /// text before accepting, the same rule that suppresses their <c>ChannelActivity</c>), and the
+    /// public/system exclusion keeps room content out of the <c>PublicCatalog</c> shells that ship to
+    /// NON-members.
+    /// <para>
+    /// A Dm accepted AFTER messages already exist is not backfilled: the projection appears with the
+    /// conversation's next message. Backfilling would mean reading the message collection on the accept
+    /// path to publish text the recipient has, until that moment, deliberately not been shown.
+    /// </para>
+    /// </summary>
+    internal static bool CarriesLastMessageProjection(ChatChannel channel) => channel.Type switch
+    {
+        ChannelType.GroupDm => true,
+        ChannelType.Dm => channel.RequestState == DmRequestState.Accepted,
+        _ => false,
+    };
+
+    /// <summary>
+    /// The single message→projection mapping. <see cref="Excerpts.Bounded"/> is the SAME helper that builds
+    /// <see cref="DmActivityPreviewDto.Excerpt"/>, so the excerpt a client renders from the live event and
+    /// the one it renders from the snapshot can never disagree about the same message.
+    /// </summary>
+    private static ChannelLastMessage BuildLastMessageProjection(ChannelMessage message) => new()
+    {
+        Seq = message.Seq,
+        SenderBattleTag = message.Sender.BattleTag,
+        SenderName = message.Sender.Name,
+        Excerpt = Excerpts.Bounded(message.Content),
+        SentAt = message.SentAt,
+    };
 }

--- a/W3ChampionsChatService/FanOut/ActivityCoalescer.cs
+++ b/W3ChampionsChatService/FanOut/ActivityCoalescer.cs
@@ -100,13 +100,20 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
                 channels[channelId] = entry;
             }
 
-            // Latest-offered-preview: overwritten unconditionally on every Offer, regardless of which
-            // branch fires below — a coalesced burst's pending always reflects the MOST RECENT preview.
-            // SentAt rides the exact same latest-wins discipline: it describes the same offered message as
-            // the preview beside it, so the two must be written and drained together or a client would pair
-            // one message's text with another's timestamp.
-            entry.Preview = preview;
-            entry.SentAt = sentAt;
+            // Highest-offered-preview. (Preview, SentAt) describe ONE message and are written and drained
+            // together, or a client would pair one message's text with another's timestamp. They are kept
+            // for the HIGHEST seq offered rather than the most recently offered, because that is the seq
+            // the emit below selects: concurrent same-channel sends can reach this lock out of order, and
+            // a latest-arrival-wins rule would then emit the higher seq carrying the LOWER message's text
+            // and timestamp — a row showing the second-newest message, pinned at a seq the newest message
+            // can no longer replace. Coalescing a burst still keeps the newest of it, since a burst that
+            // arrives in order offers ascending seqs.
+            if (lastSeq >= entry.PreviewSeq)
+            {
+                entry.Preview = preview;
+                entry.SentAt = sentAt;
+                entry.PreviewSeq = lastSeq;
+            }
 
             if (now - entry.LastSentAt >= ChatLimits.ChannelActivityCoalesce)
             {
@@ -272,5 +279,8 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
         internal long LastEmittedSeq;
         internal object Preview;
         internal DateTime? SentAt;
+        /// <summary>The seq the current <see cref="Preview"/>/<see cref="SentAt"/> pair describes — keeps
+        /// them aligned with the highest offered seq when offers arrive out of order.</summary>
+        internal long PreviewSeq;
     }
 }

--- a/W3ChampionsChatService/FanOut/ActivityCoalescer.cs
+++ b/W3ChampionsChatService/FanOut/ActivityCoalescer.cs
@@ -80,11 +80,12 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
     /// message's preview, exactly mirroring the latest-seq-only coalescing.
     /// </para>
     /// </summary>
-    public async Task Offer(string connectionId, string channelId, long lastSeq, DateTime now, object preview = null)
+    public async Task Offer(string connectionId, string channelId, long lastSeq, DateTime now, object preview = null, DateTime? sentAt = null)
     {
         bool emit;
         long emitSeq = 0;
         object emitPreview = null;
+        DateTime? emitSentAt = null;
 
         lock (_lock)
         {
@@ -101,7 +102,11 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
 
             // Latest-offered-preview: overwritten unconditionally on every Offer, regardless of which
             // branch fires below — a coalesced burst's pending always reflects the MOST RECENT preview.
+            // SentAt rides the exact same latest-wins discipline: it describes the same offered message as
+            // the preview beside it, so the two must be written and drained together or a client would pair
+            // one message's text with another's timestamp.
             entry.Preview = preview;
+            entry.SentAt = sentAt;
 
             if (now - entry.LastSentAt >= ChatLimits.ChannelActivityCoalesce)
             {
@@ -116,6 +121,7 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
                 entry.PendingLastSeq = 0;
                 entry.LastEmittedSeq = emitSeq;
                 emitPreview = entry.Preview;
+                emitSentAt = entry.SentAt;
                 emit = true;
             }
             else
@@ -131,7 +137,7 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
 
         if (emit)
         {
-            await EmitIfNotSuppressed(connectionId, channelId, emitSeq, emitPreview);
+            await EmitIfNotSuppressed(connectionId, channelId, emitSeq, emitPreview, emitSentAt);
         }
     }
 
@@ -146,7 +152,7 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
     /// </summary>
     public async Task FlushDue(DateTime now)
     {
-        List<(string ConnectionId, string ChannelId, long LastSeq, object Preview)> toEmit = null;
+        List<(string ConnectionId, string ChannelId, long LastSeq, object Preview, DateTime? SentAt)> toEmit = null;
 
         lock (_lock)
         {
@@ -164,8 +170,8 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
                         entry.PendingLastSeq = 0;
                         entry.LastEmittedSeq = seq;
 
-                        (toEmit ??= new List<(string, string, long, object)>())
-                            .Add((connectionId, channelId, seq, entry.Preview));
+                        (toEmit ??= new List<(string, string, long, object, DateTime?)>())
+                            .Add((connectionId, channelId, seq, entry.Preview, entry.SentAt));
                     }
                 }
             }
@@ -176,9 +182,9 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
             return;
         }
 
-        foreach (var (connectionId, channelId, lastSeq, preview) in toEmit)
+        foreach (var (connectionId, channelId, lastSeq, preview, sentAt) in toEmit)
         {
-            await EmitIfNotSuppressed(connectionId, channelId, lastSeq, preview);
+            await EmitIfNotSuppressed(connectionId, channelId, lastSeq, preview, sentAt);
         }
     }
 
@@ -219,7 +225,7 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
     /// fault-isolated delivery. <paramref name="preview"/> (C5, Task 9/D15) rides straight onto the
     /// payload — null for every non-Dm channel and for C3-era callers that never pass one.
     /// </summary>
-    private async Task EmitIfNotSuppressed(string connectionId, string channelId, long lastSeq, object preview = null)
+    private async Task EmitIfNotSuppressed(string connectionId, string channelId, long lastSeq, object preview = null, DateTime? sentAt = null)
     {
         // A connection with no live membership entry for the channel (left/disconnected between offer
         // and emit) is not a valid recipient — skip. The window was already advanced by the caller.
@@ -235,7 +241,7 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
             return;
         }
 
-        var payload = new ChannelActivityDto(channelId, lastSeq, preview);
+        var payload = new ChannelActivityDto(channelId, lastSeq, preview, sentAt);
 
         try
         {
@@ -265,5 +271,6 @@ public class ActivityCoalescer(IHubContext<ChatHub> hubContext, OnlineMemberRegi
         internal long PendingLastSeq;
         internal long LastEmittedSeq;
         internal object Preview;
+        internal DateTime? SentAt;
     }
 }

--- a/W3ChampionsChatService/FanOut/FanOutEngine.cs
+++ b/W3ChampionsChatService/FanOut/FanOutEngine.cs
@@ -251,7 +251,13 @@ public class FanOutEngine(
                 continue;
             }
 
-            await _activityCoalescer.Offer(connectionId, channel.Id, message.Seq, now, dmPreview);
+            // `message.SentAt`, not `now`: they are the same instant on the send path today, but the
+            // client uses this to ORDER conversations against `LastMessageAt`/`ChannelLastMessage.SentAt`,
+            // both of which are stamped from the message itself. Passing the message's own timestamp keeps
+            // all three the same value for the same message by construction rather than by coincidence.
+            // Offered for EVERY channel type (unlike `dmPreview`, which is Dm-only): a group conversation
+            // needs its sort position updated just as much as a 1:1 one, and a timestamp carries no content.
+            await _activityCoalescer.Offer(connectionId, channel.Id, message.Seq, now, dmPreview, message.SentAt);
         }
     }
 

--- a/W3ChampionsChatService/Protocol/ChannelActivityDto.cs
+++ b/W3ChampionsChatService/Protocol/ChannelActivityDto.cs
@@ -1,3 +1,6 @@
+using System;
+using W3ChampionsChatService.Channels;
+
 namespace W3ChampionsChatService.Protocol;
 
 /// <summary>
@@ -14,5 +17,23 @@ namespace W3ChampionsChatService.Protocol;
 /// scope — groups get plain activity). Typed <c>object</c> deliberately: the wire contract does not
 /// commit to a single preview shape, and a null serializes identically regardless of the type.
 /// </para>
+/// <para>
+/// <see cref="SentAt"/> is the <c>SentAt</c> of the message this activity is reporting — the missing
+/// half of the conversation-list contract. <see cref="ChatChannel.LastMessageAt"/> only ever refreshes
+/// on a snapshot or a <c>GetConversations</c> page, so a client sorting its conversation list by it had
+/// no live signal at all and had to invent one (w3champions/launcher-e#848 sorts on a client-side
+/// ordinal precisely because this field did not exist). It is the same server clock as
+/// <c>LastMessageAt</c> and <see cref="ChannelLastMessage.SentAt"/>, so the three are directly
+/// comparable. Null only on a coalesced push assembled before this field existed — treat absence as
+/// "no ordering information", never as a zero timestamp.
+/// </para>
+/// <para>
+/// COALESCING: like <see cref="Preview"/>, this is latest-offered-wins. Under a burst the emitted pair
+/// is the most recent OFFER's, which under concurrent same-channel sends is not necessarily the highest
+/// <see cref="LastSeq"/> (that one takes a MAX). The two can therefore describe different messages a few
+/// hundred milliseconds apart. That imprecision is pre-existing and deliberate — see
+/// <see cref="FanOut.ActivityCoalescer.Offer"/> — and is invisible at the only resolution this feeds: a
+/// conversation-list row's text and sort position.
+/// </para>
 /// </summary>
-public record ChannelActivityDto(string ChannelId, long LastSeq, object Preview = null);
+public record ChannelActivityDto(string ChannelId, long LastSeq, object Preview = null, DateTime? SentAt = null);

--- a/W3ChampionsChatService/Protocol/Results.cs
+++ b/W3ChampionsChatService/Protocol/Results.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Memberships;
@@ -16,11 +17,23 @@ namespace W3ChampionsChatService.Protocol;
 /// <see cref="ChatChannel"/>/<see cref="ChannelMembership"/> directly instead of inventing parallel
 /// DTOs.
 /// </summary>
+/// <summary>
+/// <paramref name="SentAt"/> is the sender's own copy of the SERVER instant the message was stamped
+/// with — the same value every other recipient learns from <c>MessageReceived.SentAt</c> or
+/// <c>ChannelActivity.SentAt</c>. It is here because the sender is the one participant the fan-out
+/// deliberately skips: they receive no activity ping for their own message, and no
+/// <c>MessageReceived</c> either unless they happen to be focused on the channel they sent to (which
+/// <c>SendMessage</c> does not require). Without it a sender's own conversation could not take its new
+/// sort position from a server clock, and a client would have to invent one from the local clock —
+/// the one thing conversation ordering must never be built on, since it is also the keyset paging
+/// coordinate. Non-Ok results leave it null, exactly like MessageId/Seq.
+/// </summary>
 public record SendMessageResult(
     ChatResultCode Code,
     double? RetryAfterSeconds = null,
     string MessageId = null,
-    long? Seq = null);
+    long? Seq = null,
+    DateTime? SentAt = null);
 
 public record JoinChannelResult(
     ChatResultCode Code,


### PR DESCRIPTION
Companion to **w3champions/launcher-e#848**, which fixes the user-visible symptoms client-side. This is the actual fix.

## The problem

"What is the last message in this conversation" is answerable from three sources, none of which can answer it alone:

| Source | Text | Timestamp | Covers |
|---|---|---|---|
| `SessionState` / `GetConversations` (`ChatChannel`) | ✗ | `LastMessageAt` | every conversation, but only as of the fetch |
| `ChannelActivity` | `Preview` | ✗ | UNFOCUSED channels only — and coalesced at 10s, dropped above 100 unread |
| `MessageReceived` | `Content` | `SentAt` | FOCUSED channels only |

There is no state at rest, so a conversation list can only be reconstructed from live event fragments — and the fragments have complementary holes. launcher-e#848 documents what that produces for users: a tray row frozen on whatever text happened to arrive while the window was closed, blank rows after any reconnect, and a list that never reorders because `LastMessageAt` has no live counterpart.

That client PR closes the symptoms as far as a client can, and explicitly cannot close two of them without this.

## What this adds

**`ChatChannel.LastMessage`** — `{Seq, SenderBattleTag, SenderName, Excerpt, SentAt}`, maintained at send time. It rides the raw `ChatChannel` already embedded in `ChannelDto` / `ChannelAddedDto` / `GetConversations`, so every existing read path serves it with **no new query and no new round-trip on read**.

**`ChannelActivityDto.SentAt`** — the reported message's own timestamp, threaded through the coalescer beside the existing preview slot, same latest-offered-wins discipline. Offered for **every** channel type, not just Dm: a group's sort position needs updating as much as a 1:1's, and a timestamp carries no content.

`Excerpt` comes from the same `Excerpts.Bounded` helper that builds `DmActivityPreviewDto.Excerpt`, so a client can never see the same message's text differ between the snapshot and the live event.

## Scope, and why it is this narrow

Mirrors the rules `DmActivityPreviewDto` already follows:

- **Accepted Dm + GroupDm only.** A PENDING Dm never projects — the recipient must not see a stranger's text before accepting, the same consent wall that already suppresses their `ChannelActivity`. Public/SemiPublic/System never project either: `PublicCatalog` ships raw `ChatChannel` docs for rooms the caller has **not joined**, so a preview there would publish room content to non-members.
- **Shadow messages never project.** The projection is channel-global with no per-viewer filtering, so the only safe treatment of a shadow author's text is to never write it. `LastSeq`/`LastMessageAt` still advance exactly as before, so the two can legitimately disagree — `LastMessage.Seq` is the newest *non-shadow* message and is the field to trust when rendering.

## Two design calls worth reviewing

**The write is a compare-and-set, not a fold into `AllocateSeq`.** The projection needs the seq that `AllocateSeq` allocates, so setting it there would mean rewriting the service's most concurrency-critical write as an aggregation-pipeline update — and `AllocateSeq` has no business knowing about shadow. This costs **one extra by-_id update per non-shadow Dm/GroupDm message**; in exchange the seq allocator is untouched and the projection is monotonic by construction (concurrent same-channel sends settle on the higher seq regardless of arrival order). If that extra write is not acceptable on the send path, the pipeline-update alternative is the thing to argue for.

**No deletion invalidation — because none is reachable.** `ChannelModeration.IsModeratable` (Public / SemiPublic / System+Match) gates both `DeleteMessage` and `PurgeMessagesFromUser`, and is **disjoint** from the projected set, so a projected message cannot be deleted.

That is an invariant living in a different file, and it is load-bearing: if moderation is ever widened to reach Dm/GroupDm, this projection silently starts serving soft-deleted text to every member of the conversation, forever — a moderation hole, not a cosmetic bug. So it is pinned by a test (`ProjectedChannels_AreDisjointFromModeratableChannels`), as is the sibling assumption behind the `!isShadow` guard (`…AreDisjointFromMuteEnforcedChannels` — that guard is currently unreachable, and the test exists so it is not "simplified away" as dead code before it becomes load-bearing).

## Compatibility

Additive and optional in both directions. Existing clients ignore both fields. A client that reads them must tolerate absence: a channel whose last message predates this change projects nothing until its next message, and a Dm accepted with history already in it is likewise not backfilled — backfilling would mean reading the message collection on the accept path to publish text the recipient has deliberately not been shown until then.

No migration, no index change, no rollout ordering constraint against the client.

## Tests

**1347 → 1363, all passing.**

- projection presence/absence per channel type and consent state (accepted Dm, pending Dm, GroupDm, Public)
- advance-to-newer; excerpt agreement with the live event's own helper at the 120-char bound
- repository CAS: first write lands, a lower seq does not regress, an equal seq is idempotent, field omitted (not null) when absent, `SentAt` survives the Mongo round trip
- `SentAt` on the immediate emit, absent when not offered, latest-wins through a coalesced flush, and travelling with its own preview
- the two scope-disjointness invariants above

Disabling the send-path write fails exactly the four tests that assert a projection exists.

## After this merges

launcher-e can delete most of #848: the client-side activity ordinal, the clock-skew reasoning behind it, the rebuild-clearing rule, and both of that PR's known gaps. What remains is one `lastMessage` map with two writers, monotonic on seq — with #848's derivation kept only as the fallback for servers that predate this.
