### PR TITLE
fix(chat): carry viewer flair on the channel roster

### DIFF
--- a/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
+++ b/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using W3ChampionsChatService.Channels;
-using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Messages;

--- a/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
+++ b/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Messages;
@@ -72,7 +73,7 @@ public class ActivityCoalescerTests
         var focus = new FocusRegistry();
         var members = new OnlineMemberRegistry();
         var coalescer = new ActivityCoalescer(harness.HubContext, members);
-        var engine = new FanOutEngine(harness.HubContext, focus, members, coalescer, new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focus), TimeProvider.System);
+        var engine = new FanOutEngine(harness.HubContext, focus, members, coalescer, new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
         return (harness, focus, members, engine);
     }
 
@@ -408,7 +409,7 @@ public class ActivityCoalescerTests
         var members = new OnlineMemberRegistry();
         members.Join(ChannelId, MemberConn, new MemberState(MemberTag, NotificationLevel.All, LastReadSeq: 0, ChannelType: ChannelType.Public));
         var coalescer = new ActivityCoalescer(harness.HubContext, members);
-        var engine = new FanOutEngine(harness.HubContext, new FocusRegistry(), members, coalescer, new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, new FocusRegistry()), TimeProvider.System);
+        var engine = new FanOutEngine(harness.HubContext, new FocusRegistry(), members, coalescer, new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, new FocusRegistry(), new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
 
         // A send routes an offer to the unfocused level-All member, creating coalescing state.
         await engine.OnMessagePersisted(Channel(), Message(seq: 5), AuthorConn, isShadow: false, T0);

--- a/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
+++ b/W3ChampionsChatService.Tests/ActivityCoalescerTests.cs
@@ -73,7 +73,7 @@ public class ActivityCoalescerTests
         var focus = new FocusRegistry();
         var members = new OnlineMemberRegistry();
         var coalescer = new ActivityCoalescer(harness.HubContext, members);
-        var engine = new FanOutEngine(harness.HubContext, focus, members, coalescer, new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+        var engine = new FanOutEngine(harness.HubContext, focus, members, coalescer, new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focus, ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
         return (harness, focus, members, engine);
     }
 
@@ -409,7 +409,7 @@ public class ActivityCoalescerTests
         var members = new OnlineMemberRegistry();
         members.Join(ChannelId, MemberConn, new MemberState(MemberTag, NotificationLevel.All, LastReadSeq: 0, ChannelType: ChannelType.Public));
         var coalescer = new ActivityCoalescer(harness.HubContext, members);
-        var engine = new FanOutEngine(harness.HubContext, new FocusRegistry(), members, coalescer, new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, new FocusRegistry(), new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+        var engine = new FanOutEngine(harness.HubContext, new FocusRegistry(), members, coalescer, new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, new FocusRegistry(), ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
 
         // A send routes an offer to the unfocused level-All member, creating coalescing state.
         await engine.OnMessagePersisted(Channel(), Message(seq: 5), AuthorConn, isShadow: false, T0);

--- a/W3ChampionsChatService.Tests/ChannelEventEmitterTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelEventEmitterTests.cs
@@ -47,7 +47,10 @@ public class ChannelEventEmitterTests
         var members = new OnlineMemberRegistry();
         var sessions = new SessionRegistry();
         var coalescer = new ActivityCoalescer(harness.HubContext, members);
-        var engine = new FanOutEngine(harness.HubContext, focus, members, coalescer, sessions, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+        // The accumulator's resolver shares the SAME SessionRegistry seeded via RegisterOnline below, so a
+        // roster delta's display name matches what a real session would resolve to (no ConnectionMapping
+        // exists in this pure in-memory fixture, so flair is always null here — no test asserts on it).
+        var engine = new FanOutEngine(harness.HubContext, focus, members, coalescer, sessions, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(sessions, new ConnectionMapping())), TimeProvider.System);
         return (harness, focus, members, sessions, engine);
     }
 

--- a/W3ChampionsChatService.Tests/ChannelEventEmitterTests.cs
+++ b/W3ChampionsChatService.Tests/ChannelEventEmitterTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Memberships;
@@ -46,7 +47,7 @@ public class ChannelEventEmitterTests
         var members = new OnlineMemberRegistry();
         var sessions = new SessionRegistry();
         var coalescer = new ActivityCoalescer(harness.HubContext, members);
-        var engine = new FanOutEngine(harness.HubContext, focus, members, coalescer, sessions, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focus), TimeProvider.System);
+        var engine = new FanOutEngine(harness.HubContext, focus, members, coalescer, sessions, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
         return (harness, focus, members, sessions, engine);
     }
 

--- a/W3ChampionsChatService.Tests/ChatHubBanUserTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubBanUserTests.cs
@@ -61,6 +61,7 @@ public class ChatHubBanUserTests : IntegrationTestBase
         _messageRepository = new MessageRepository(MongoClient);
         _sessionRegistry = new SessionRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
 
         _chatHub = new ChatHub(
             _connectionMapping,
@@ -95,7 +96,8 @@ public class ChatHubBanUserTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         _clients = new Mock<IHubCallerClients>();
         var callerProxy = new Mock<ISingleClientProxy>();

--- a/W3ChampionsChatService.Tests/ChatHubClanChannelTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubClanChannelTests.cs
@@ -115,6 +115,7 @@ public class ChatHubClanChannelTests : IntegrationTestBase
 
     private ChatHub BuildConnection(string connectionId, string accessToken)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileService,
@@ -141,7 +142,8 @@ public class ChatHubClanChannelTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConnectionTests.cs
@@ -116,6 +116,7 @@ public class ChatHubConnectionTests : IntegrationTestBase
 
     private (ChatHub Hub, Mock<HubCallerContext> Context) BuildConnection(string connectionId, string accessToken)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileService,
@@ -142,7 +143,8 @@ public class ChatHubConnectionTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubConsentTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubConsentTests.cs
@@ -143,6 +143,7 @@ public class ChatHubConsentTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -169,7 +170,8 @@ public class ChatHubConsentTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingProxy(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDeletionTests.cs
@@ -88,6 +88,8 @@ public class ChatHubDeletionTests : IntegrationTestBase
             _connectionMapping,
             new MentionInboxRepository(MongoClient));
 
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+
         _chatHub = new ChatHub(
             _connectionMapping,
             new MuteReconciliationTestHarness(_connectionMapping, _muteRepository).Service,
@@ -114,7 +116,8 @@ public class ChatHubDeletionTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         _clients.Setup(c => c.All).Returns(_mockAllProxy.Object);
         _clients.Setup(c => c.AllExcept(It.IsAny<System.Collections.Generic.IReadOnlyList<string>>())).Returns(_mockAllExceptProxy.Object);

--- a/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
@@ -49,6 +49,7 @@ public class ChatHubDmFocusTests : IntegrationTestBase
     private FakeTimeProvider _time;
     private HubPushCaptureHarness _harness;
     private ViewersAccumulator _accumulator;
+    private ViewerResolver _viewerResolver;
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private SessionRegistry _sessionRegistry;
@@ -78,8 +79,8 @@ public class ChatHubDmFocusTests : IntegrationTestBase
         // (RecordChange) and current-state read (FlushDue) see the live roster the hubs produce. It also
         // shares the SAME session/connection registries the hubs register into, so a joined entry's
         // display name/flair reflect the live ChatUser each test seeds.
-        _accumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _accumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
 
         _userDirectory = new UserDirectoryRepository(MongoClient);
         _muteRepository = new MuteRepository(MongoClient);
@@ -134,7 +135,8 @@ public class ChatHubDmFocusTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            _viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
         var context = new Mock<HubCallerContext>();

--- a/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
@@ -71,14 +71,16 @@ public class ChatHubDmFocusTests : IntegrationTestBase
         _time = new FakeTimeProvider(new DateTimeOffset(T0, TimeSpan.Zero));
         _harness = new HubPushCaptureHarness();
         _focusRegistry = new FocusRegistry();
-        // The accumulator shares the SAME FocusRegistry the hubs mutate — its baseline capture
-        // (RecordChange) and current-state read (FlushDue) see the live roster the hubs produce.
-        _accumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
-
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _sessionRegistry = new SessionRegistry();
         _connectionMapping = new ConnectionMapping();
+        // The accumulator shares the SAME FocusRegistry the hubs mutate — its baseline capture
+        // (RecordChange) and current-state read (FlushDue) see the live roster the hubs produce. It also
+        // shares the SAME session/connection registries the hubs register into, so a joined entry's
+        // display name/flair reflect the live ChatUser each test seeds.
+        _accumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+
         _userDirectory = new UserDirectoryRepository(MongoClient);
         _muteRepository = new MuteRepository(MongoClient);
         _reconcileService = new MuteReconciliationTestHarness(_connectionMapping, _muteRepository).Service;

--- a/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmFocusTests.cs
@@ -73,7 +73,8 @@ public class ChatHubDmFocusTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         // The accumulator shares the SAME FocusRegistry the hubs mutate — its baseline capture
         // (RecordChange) and current-state read (FlushDue) see the live roster the hubs produce.
-        _accumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _accumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
 
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _sessionRegistry = new SessionRegistry();

--- a/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubDmSendTests.cs
@@ -131,6 +131,7 @@ public class ChatHubDmSendTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -157,7 +158,8 @@ public class ChatHubDmSendTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingProxy(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
@@ -87,6 +87,7 @@ public class ChatHubFocusTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileService,
@@ -113,7 +114,8 @@ public class ChatHubFocusTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFocusTests.cs
@@ -361,4 +361,61 @@ public class ChatHubFocusTests : IntegrationTestBase
         Assert.That(_focusRegistry.GetRoster(channel.Id), Is.EquivalentTo(new[] { BattleTag }));
         Assert.That(_focusRegistry.GetFocusedConnections(channel.Id), Is.EquivalentTo(new[] { "conn-1" }));
     }
+
+    [Test]
+    public async Task FocusChannel_Roster_CarriesEachViewersFlair()
+    {
+        var channel = await CreateChannel();
+
+        RegisterSession("conn-peter", BattleTag, "Peter");
+        RegisterSession("conn-alice", OtherBattleTag, "Alice");
+        SeedMembership("conn-peter", channel.Id, BattleTag);
+        SeedMembership("conn-alice", channel.Id, OtherBattleTag);
+
+        // ConnectionMapping is what BuildSenderSnapshot reads for message flair, so seeding it here
+        // pins that the roster resolves from the SAME source — the two can never disagree.
+        _connectionMapping.RegisterUser("conn-alice", new ChatUser(
+            OtherBattleTag,
+            false,
+            "W3C",
+            new ProfilePicture { Race = AvatarCategory.NE, PictureId = 7, IsClassic = false },
+            new ChatColor("chat_color_purple"),
+            [new ChatIcon("chat_icon_crown")]));
+
+        var aliceHub = BuildHub("conn-alice");
+        await aliceHub.FocusChannel(channel.Id);
+
+        var peterHub = BuildHub("conn-peter");
+        var result = await peterHub.FocusChannel(channel.Id);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        var alice = result.Viewers.Single(v => v.BattleTag == OtherBattleTag);
+        Assert.IsNotNull(alice.Profile, "A roster entry for an online, focused viewer must carry flair");
+        Assert.AreEqual(AvatarCategory.NE, alice.Profile.ProfilePicture.Race);
+        Assert.AreEqual(7, alice.Profile.ProfilePicture.PictureId);
+        Assert.AreEqual("W3C", alice.Profile.ClanId);
+        Assert.AreEqual("chat_color_purple", alice.Profile.ChatColor.ColorId);
+        Assert.AreEqual("chat_icon_crown", alice.Profile.ChatIcons.Single().IconId);
+    }
+
+    [Test]
+    public async Task FocusChannel_Roster_ViewerWithNoConnectionMappingEntry_YieldsNullProfile_NotAnException()
+    {
+        // Teardown race: a session exists but its ConnectionMapping entry is already gone. The entry
+        // must survive with a null Profile (the client falls back to its default avatar) rather than
+        // being dropped or throwing — mirroring the pre-existing battleTag name fallback.
+        var channel = await CreateChannel();
+
+        RegisterSession("conn-peter", BattleTag, "Peter");
+        SeedMembership("conn-peter", channel.Id, BattleTag);
+
+        var hub = BuildHub("conn-peter");
+        var result = await hub.FocusChannel(channel.Id);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        var peter = result.Viewers.Single();
+        Assert.AreEqual(BattleTag, peter.BattleTag);
+        Assert.AreEqual("Peter", peter.Name, "The display name must still resolve from the live session");
+        Assert.IsNull(peter.Profile);
+    }
 }

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -75,6 +75,7 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
     private ViewersAccumulator _viewersAccumulator;
+    private ViewerResolver _viewerResolver;
     private PresenceInterestRegistry _presenceInterestRegistry;
     private UserDirectoryRepository _userDirectory;
     private MuteRepository _muteRepository;
@@ -144,8 +145,8 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         // The engine shares the SAME SessionRegistry every hub registers into — PushFriendPresenceChanged
         // resolves each friend's live connection through it.
-        _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }
@@ -183,7 +184,8 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             _presenceInterestRegistry,
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            _viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -145,7 +145,7 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
         // The engine shares the SAME SessionRegistry every hub registers into — PushFriendPresenceChanged
         // resolves each friend's live connection through it.
         _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }

--- a/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubFriendPresenceTests.cs
@@ -144,7 +144,8 @@ public class ChatHubFriendPresenceTests : IntegrationTestBase
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         // The engine shares the SAME SessionRegistry every hub registers into — PushFriendPresenceChanged
         // resolves each friend's live connection through it.
-        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _viewersAccumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }

--- a/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetConversationsTests.cs
@@ -114,6 +114,7 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -140,7 +141,8 @@ public class ChatHubGetConversationsTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGetMessagesTests.cs
@@ -101,6 +101,7 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -127,7 +128,8 @@ public class ChatHubGetMessagesTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubGroupCreateTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupCreateTests.cs
@@ -120,6 +120,7 @@ public class ChatHubGroupCreateTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -146,7 +147,8 @@ public class ChatHubGroupCreateTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
@@ -103,7 +103,8 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
         // A REAL FanOutEngine + a REAL ViewersAccumulator sharing the hubs' registries, both wired to one
         // capture harness so ChannelAdded/ChannelRemoved pushes AND any stray ViewersChanged are observable.
         _harness = new HubPushCaptureHarness();
-        _accumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _accumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _coalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         _fanOutEngine = new FanOutEngine(_harness.HubContext, _focusRegistry, _onlineMemberRegistry, _coalescer, _sessionRegistry, new PresenceInterestRegistry(), _accumulator, _time);
 

--- a/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
@@ -47,6 +47,7 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
     private FakeTimeProvider _time;
     private HubPushCaptureHarness _harness;
     private ViewersAccumulator _accumulator;
+    private ViewerResolver _viewerResolver;
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private SessionRegistry _sessionRegistry;
@@ -103,8 +104,8 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
         // A REAL FanOutEngine + a REAL ViewersAccumulator sharing the hubs' registries, both wired to one
         // capture harness so ChannelAdded/ChannelRemoved pushes AND any stray ViewersChanged are observable.
         _harness = new HubPushCaptureHarness();
-        _accumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _accumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
         _coalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         _fanOutEngine = new FanOutEngine(_harness.HubContext, _focusRegistry, _onlineMemberRegistry, _coalescer, _sessionRegistry, new PresenceInterestRegistry(), _accumulator, _time);
 
@@ -157,7 +158,8 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            _viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubGroupManagementTests.cs
@@ -104,7 +104,7 @@ public class ChatHubGroupManagementTests : IntegrationTestBase
         // capture harness so ChannelAdded/ChannelRemoved pushes AND any stray ViewersChanged are observable.
         _harness = new HubPushCaptureHarness();
         _accumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _coalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         _fanOutEngine = new FanOutEngine(_harness.HubContext, _focusRegistry, _onlineMemberRegistry, _coalescer, _sessionRegistry, new PresenceInterestRegistry(), _accumulator, _time);
 

--- a/W3ChampionsChatService.Tests/ChatHubMarkReadTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMarkReadTests.cs
@@ -100,6 +100,7 @@ public class ChatHubMarkReadTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -126,7 +127,8 @@ public class ChatHubMarkReadTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMembershipTests.cs
@@ -95,6 +95,7 @@ public class ChatHubMembershipTests : IntegrationTestBase
         NotificationPreferenceRepository notificationPreferenceRepository = null,
         ChannelRepository channelRepository = null)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileService,
@@ -121,7 +122,8 @@ public class ChatHubMembershipTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            notificationPreferenceRepository ?? _notificationPreferenceRepository);
+            notificationPreferenceRepository ?? _notificationPreferenceRepository,
+            viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMentionInboxTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionInboxTests.cs
@@ -96,6 +96,7 @@ public class ChatHubMentionInboxTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -122,7 +123,8 @@ public class ChatHubMentionInboxTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             _mentionInboxRepository,
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMentionSearchScopingTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionSearchScopingTests.cs
@@ -96,6 +96,7 @@ public class ChatHubMentionSearchScopingTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId, MembershipRepository membershipRepository = null)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -122,7 +123,8 @@ public class ChatHubMentionSearchScopingTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             _mentionInboxRepository,
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMentionSearchTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionSearchTests.cs
@@ -96,6 +96,7 @@ public class ChatHubMentionSearchTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId, IChatAuthenticationService authService = null)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -122,7 +123,8 @@ public class ChatHubMentionSearchTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             _mentionInboxRepository,
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
 

--- a/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubMentionValidationTests.cs
@@ -124,6 +124,7 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId, UserDirectoryRepository userDirectory = null)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -150,7 +151,8 @@ public class ChatHubMentionValidationTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         var callerProxy = new Mock<ISingleClientProxy>();

--- a/W3ChampionsChatService.Tests/ChatHubOpenDmTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubOpenDmTests.cs
@@ -110,6 +110,7 @@ public class ChatHubOpenDmTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -136,7 +137,8 @@ public class ChatHubOpenDmTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubPresenceReadTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceReadTests.cs
@@ -124,6 +124,7 @@ public class ChatHubPresenceReadTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId, string accessToken = null)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -150,7 +151,8 @@ public class ChatHubPresenceReadTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
@@ -120,7 +120,8 @@ public class ChatHubPresenceTests : IntegrationTestBase
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         // The engine shares the SAME presence-interest registry the hubs mutate — so RegisterFocus (hub)
         // and GetInterestedConnections (engine's PushPresenceChanged) see one consistent index.
-        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _viewersAccumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }

--- a/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
@@ -121,7 +121,7 @@ public class ChatHubPresenceTests : IntegrationTestBase
         // The engine shares the SAME presence-interest registry the hubs mutate — so RegisterFocus (hub)
         // and GetInterestedConnections (engine's PushPresenceChanged) see one consistent index.
         _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }

--- a/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubPresenceTests.cs
@@ -61,6 +61,7 @@ public class ChatHubPresenceTests : IntegrationTestBase
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
     private ViewersAccumulator _viewersAccumulator;
+    private ViewerResolver _viewerResolver;
     private PresenceInterestRegistry _presenceInterestRegistry; // the shared index under test
     private UserDirectoryRepository _userDirectory;
     private MuteRepository _muteRepository;
@@ -120,8 +121,8 @@ public class ChatHubPresenceTests : IntegrationTestBase
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         // The engine shares the SAME presence-interest registry the hubs mutate — so RegisterFocus (hub)
         // and GetInterestedConnections (engine's PushPresenceChanged) see one consistent index.
-        _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }
@@ -159,7 +160,8 @@ public class ChatHubPresenceTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             _presenceInterestRegistry, // SHARED — same instance the engine reads
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            _viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSendMessageTests.cs
@@ -120,6 +120,7 @@ public class ChatHubSendMessageTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -146,7 +147,8 @@ public class ChatHubSendMessageTests : IntegrationTestBase
             _mentionFanOut,
             new PresenceInterestRegistry(),
             _mentionInboxRepository,
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         var callerProxy = new Mock<ISingleClientProxy>();

--- a/W3ChampionsChatService.Tests/ChatHubSettingsTests.cs
+++ b/W3ChampionsChatService.Tests/ChatHubSettingsTests.cs
@@ -86,6 +86,7 @@ public class ChatHubSettingsTests : IntegrationTestBase
 
     private ChatHub BuildHub(string connectionId)
     {
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -112,7 +113,8 @@ public class ChatHubSettingsTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(new Mock<ISingleClientProxy>().Object);

--- a/W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs
+++ b/W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs
@@ -137,33 +137,37 @@ public class ChatJsonProtocolTests
     }
 
     [Test]
-    public void Configure_PresenceDetails_OmitsNullLastSeenAt_SafeBecauseClientUsesNullishCoalescing()
+    public void Configure_PresenceDetails_OmitsNullLastSeenAt()
     {
         var detail = new PresenceDetailsDto("Peter#123", Online: true, LastSeenAt: null);
 
         var json = JsonSerializer.Serialize(detail, ConfiguredOptions());
 
-        // Safe: presence-source.ts reads `detail?.lastSeenAt ?? null` and ManageFriends.tsx guards with
-        // `lastSeenAt && (...)` — both treat an absent key and an explicit null identically, so omitting
-        // a null lastSeenAt changes nothing observable.
+        // This assertion only pins that omission happens — it does NOT guarantee client safety, and
+        // would keep passing even if a client reader regressed to a strict `=== null` check. Safety
+        // today rests entirely on the client: presence-source.ts reads `detail?.lastSeenAt ?? null`
+        // and ManageFriends.tsx guards with `lastSeenAt && (...)` — both treat an absent key and an
+        // explicit null identically, so omitting a null lastSeenAt changes nothing observable there.
         Assert.That(json, Does.Not.Contain("lastSeenAt"));
     }
 
     [Test]
-    public void Configure_ChannelActivity_OmitsNullPreview_SafeBecauseClientUsesTruthyCheck()
+    public void Configure_ChannelActivity_OmitsNullPreview()
     {
         var activity = new ChannelActivityDto("chan1", LastSeq: 5, Preview: null);
 
         var json = JsonSerializer.Serialize(activity, ConfiguredOptions());
 
-        // Safe: chat-messages.ts gates every read with `if (activity.preview) { ... }` /
-        // `if (!activity.preview) return;` — truthy checks, so an absent key and an explicit null are
-        // indistinguishable to every reader.
+        // This assertion only pins that omission happens — it does NOT guarantee client safety, and
+        // would keep passing even if a client reader regressed to a strict `=== null` check. Safety
+        // today rests entirely on the client: chat-messages.ts gates every read with
+        // `if (activity.preview) { ... }` / `if (!activity.preview) return;` — truthy checks, so an
+        // absent key and an explicit null are indistinguishable to every reader there.
         Assert.That(json, Does.Not.Contain("preview"));
     }
 
     [Test]
-    public void Configure_SessionState_OmitsNullMuteState_SafeBecauseClientUsesTruthyCheck()
+    public void Configure_SessionState_OmitsNullMuteState()
     {
         var ownProfile = new OwnProfileDto("Peter#123", "Peter", IsAdmin: false, Flair: new ChatProfile(), Permissions: Array.Empty<string>());
         var session = new SessionStateDto(
@@ -176,8 +180,11 @@ public class ChatJsonProtocolTests
 
         var json = JsonSerializer.Serialize(session, ConfiguredOptions());
 
-        // Safe: chat-core.ts's applySessionState guards with `if (snapshot.muteState) { ... }` — a
-        // truthy check, so an absent key and an explicit null behave identically there.
+        // This assertion only pins that omission happens — it does NOT guarantee client safety, and
+        // would keep passing even if a client reader regressed to a strict `=== null` check. Safety
+        // today rests entirely on the client: chat-core.ts's applySessionState guards with
+        // `if (snapshot.muteState) { ... }` — a truthy check, so an absent key and an explicit null
+        // behave identically there.
         Assert.That(json, Does.Not.Contain("muteState"));
     }
 }

--- a/W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs
+++ b/W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs
@@ -1,6 +1,11 @@
+using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using W3ChampionsChatService.Channels;
 using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.Protocol;
@@ -72,5 +77,107 @@ public class ChatJsonProtocolTests
         Assert.That(json, Does.Contain("\"pictureId\":0"));
         Assert.That(json, Does.Contain("\"isClassic\":false"));
         Assert.That(json, Does.Contain("\"race\":0"));
+    }
+
+    // ── Final-review Finding 2a — the config must actually be wired into the app ──────────────────
+    //
+    // The three tests above build a FRESH JsonHubProtocolOptions and call ChatJsonProtocol.Configure
+    // directly — they stay green even if `.AddJsonProtocol(ChatJsonProtocol.Configure)` were deleted
+    // from Startup.ConfigureServices. This test instead runs the REAL composition root (mirrors
+    // StartupDependencyInjectionTests.BuildProvider) and resolves the JSON hub protocol's options
+    // straight from the container, so it fails if the wiring is ever removed.
+    //
+    // RED/GREEN verified by hand: temporarily deleting the `.AddJsonProtocol(ChatJsonProtocol.Configure)`
+    // line from Startup.cs made this test fail with
+    //   Expected: WhenWritingNull
+    //   But was:  Never
+    // (SignalR's own unconfigured JsonHubProtocolOptions default). Restoring the line made it pass again.
+    [Test]
+    public void Configure_IsWiredIntoStartup()
+    {
+        var services = new ServiceCollection();
+        // AddSignalR needs ILoggerFactory to construct during resolution — mirrors
+        // StartupDependencyInjectionTests.BuildProvider.
+        services.AddLogging();
+        new Startup().ConfigureServices(services);
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+
+        var options = provider.GetRequiredService<IOptions<JsonHubProtocolOptions>>().Value;
+
+        Assert.AreEqual(
+            JsonIgnoreCondition.WhenWritingNull,
+            options.PayloadSerializerOptions.DefaultIgnoreCondition,
+            "Startup.ConfigureServices MUST wire ChatJsonProtocol.Configure via .AddJsonProtocol — " +
+            "deleting that call leaves this option at SignalR's unconfigured default");
+    }
+
+    // ── Final-review Finding 2b — a nullable-field sweep beyond ChannelViewerDto ───────────────────
+    //
+    // ChannelViewerDto was the only type ever round-tripped through the configured options anywhere in
+    // the suite — the structural gap that let Finding 1 (MentionInboxEntryDto.ReadAt) ship unnoticed.
+    // Each test below round-trips a DTO with a meaningful-when-null field and records, in a comment,
+    // why omission is (or is not) safe for that field's client reader.
+
+    [Test]
+    public void Configure_MentionInboxEntry_KeepsReadAtOnWireEvenWhenNull_RegressionForFinding1()
+    {
+        // Finding-1 regression test. Unlike every other DTO in this sweep, omission here is NOT safe:
+        // the launcher's chat-mentions.ts / MentionInboxTray.tsx originally used strict `=== null` /
+        // `!== null` comparisons against `readAt`, which silently broke (unread badge stuck at 0, toasts
+        // suppressed, auto-ack a no-op) once null properties stopped riding the wire. MentionInboxEntryDto
+        // now pins ReadAt with [JsonIgnore(Condition = Never)] specifically so a null keeps meaning
+        // "unread" ON the wire, in addition to the client now also tolerating an absent key (belt + braces).
+        var entry = new MentionInboxEntryDto(
+            "id1", "chan1", "msg1", 1, "Peter#123", "Peter", "hi", DateTime.UtcNow, ReadAt: null);
+
+        var json = JsonSerializer.Serialize(entry, ConfiguredOptions());
+
+        Assert.That(json, Does.Contain("\"readAt\":null"),
+            "an unread entry's readAt must stay ON the wire as an explicit null, never be omitted");
+    }
+
+    [Test]
+    public void Configure_PresenceDetails_OmitsNullLastSeenAt_SafeBecauseClientUsesNullishCoalescing()
+    {
+        var detail = new PresenceDetailsDto("Peter#123", Online: true, LastSeenAt: null);
+
+        var json = JsonSerializer.Serialize(detail, ConfiguredOptions());
+
+        // Safe: presence-source.ts reads `detail?.lastSeenAt ?? null` and ManageFriends.tsx guards with
+        // `lastSeenAt && (...)` — both treat an absent key and an explicit null identically, so omitting
+        // a null lastSeenAt changes nothing observable.
+        Assert.That(json, Does.Not.Contain("lastSeenAt"));
+    }
+
+    [Test]
+    public void Configure_ChannelActivity_OmitsNullPreview_SafeBecauseClientUsesTruthyCheck()
+    {
+        var activity = new ChannelActivityDto("chan1", LastSeq: 5, Preview: null);
+
+        var json = JsonSerializer.Serialize(activity, ConfiguredOptions());
+
+        // Safe: chat-messages.ts gates every read with `if (activity.preview) { ... }` /
+        // `if (!activity.preview) return;` — truthy checks, so an absent key and an explicit null are
+        // indistinguishable to every reader.
+        Assert.That(json, Does.Not.Contain("preview"));
+    }
+
+    [Test]
+    public void Configure_SessionState_OmitsNullMuteState_SafeBecauseClientUsesTruthyCheck()
+    {
+        var ownProfile = new OwnProfileDto("Peter#123", "Peter", IsAdmin: false, Flair: new ChatProfile(), Permissions: Array.Empty<string>());
+        var session = new SessionStateDto(
+            Channels: Array.Empty<ChannelDto>(),
+            PublicCatalog: Array.Empty<ChatChannel>(),
+            PendingDmRequests: Array.Empty<PendingDmRequestDto>(),
+            MentionUnreadCount: 0,
+            OwnProfile: ownProfile,
+            MuteState: null);
+
+        var json = JsonSerializer.Serialize(session, ConfiguredOptions());
+
+        // Safe: chat-core.ts's applySessionState guards with `if (snapshot.muteState) { ... }` — a
+        // truthy check, so an absent key and an explicit null behave identically there.
+        Assert.That(json, Does.Not.Contain("muteState"));
     }
 }

--- a/W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs
+++ b/W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using NUnit.Framework;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Protocol;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Pins the hub's JSON payload contract. Flair is the dominant payload on the wire (a roster can be
+/// several hundred entries, each carrying a ChatProfile), and most users have null clan/colour/icons
+/// and null rank — with nulls serialized, the KEY NAMES alone dominate the payload. Null omission is
+/// therefore load-bearing for payload size, not cosmetic.
+/// </summary>
+public class ChatJsonProtocolTests
+{
+    private static JsonSerializerOptions ConfiguredOptions()
+    {
+        var options = new JsonHubProtocolOptions();
+        ChatJsonProtocol.Configure(options);
+        return options.PayloadSerializerOptions;
+    }
+
+    [Test]
+    public void Configure_OmitsNullFlairFields()
+    {
+        var viewer = new ChannelViewerDto("peter#123", "Peter", new ChatProfile
+        {
+            ProfilePicture = new ProfilePicture { Race = AvatarCategory.HU, PictureId = 2, IsClassic = false },
+        });
+
+        var json = JsonSerializer.Serialize(viewer, ConfiguredOptions());
+
+        Assert.That(json, Does.Not.Contain("clanId"), "A null clanId must not occupy wire bytes");
+        Assert.That(json, Does.Not.Contain("chatColor"));
+        Assert.That(json, Does.Not.Contain("chatIcons"));
+        Assert.That(json, Does.Not.Contain("leagueName"));
+        Assert.That(json, Does.Not.Contain("gamesPlayed"));
+    }
+
+    [Test]
+    public void Configure_PreservesNonNullFields()
+    {
+        var viewer = new ChannelViewerDto("peter#123", "Peter", new ChatProfile
+        {
+            ClanId = "W3C",
+            ProfilePicture = new ProfilePicture { Race = AvatarCategory.NE, PictureId = 7, IsClassic = true },
+            ChatColor = new ChatColor("chat_color_purple"),
+        });
+
+        var json = JsonSerializer.Serialize(viewer, ConfiguredOptions());
+
+        Assert.That(json, Does.Contain("\"clanId\":\"W3C\""));
+        Assert.That(json, Does.Contain("\"pictureId\":7"));
+        Assert.That(json, Does.Contain("\"isClassic\":true"));
+        Assert.That(json, Does.Contain("chat_color_purple"));
+    }
+
+    [Test]
+    public void Configure_OmittingNullsDoesNotDropFalseOrZero()
+    {
+        // WhenWritingNull must not be confused with WhenWritingDefault: `isClassic: false` and
+        // `pictureId: 0` are MEANINGFUL values the client renders, not absences.
+        var viewer = new ChannelViewerDto("peter#123", "Peter", new ChatProfile
+        {
+            ProfilePicture = new ProfilePicture { Race = AvatarCategory.RnD, PictureId = 0, IsClassic = false },
+        });
+
+        var json = JsonSerializer.Serialize(viewer, ConfiguredOptions());
+
+        Assert.That(json, Does.Contain("\"pictureId\":0"));
+        Assert.That(json, Does.Contain("\"isClassic\":false"));
+        Assert.That(json, Does.Contain("\"race\":0"));
+    }
+}

--- a/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
@@ -77,6 +77,7 @@ public class DmGroupIntegrationTests : IntegrationTestBase
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
     private ViewersAccumulator _viewersAccumulator;
+    private ViewerResolver _viewerResolver;
     private UserDirectoryRepository _userDirectory;
     private MuteRepository _muteRepository;
     private MuteReconciliationTestHarness _reconcileHarness;
@@ -130,8 +131,8 @@ public class DmGroupIntegrationTests : IntegrationTestBase
         // The three fan-out sinks ALL push through the ONE shared harness and read the SHARED registries
         // the hubs mutate, so every push lands in a single ordered capture.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
 
@@ -205,7 +206,8 @@ public class DmGroupIntegrationTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            _viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
@@ -130,7 +130,8 @@ public class DmGroupIntegrationTests : IntegrationTestBase
         // The three fan-out sinks ALL push through the ONE shared harness and read the SHARED registries
         // the hubs mutate, so every push lands in a single ordered capture.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _viewersAccumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
 

--- a/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/DmGroupIntegrationTests.cs
@@ -131,7 +131,7 @@ public class DmGroupIntegrationTests : IntegrationTestBase
         // the hubs mutate, so every push lands in a single ordered capture.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
 

--- a/W3ChampionsChatService.Tests/FanOutEngineTestFactory.cs
+++ b/W3ChampionsChatService.Tests/FanOutEngineTestFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Sessions;
 

--- a/W3ChampionsChatService.Tests/FanOutEngineTestFactory.cs
+++ b/W3ChampionsChatService.Tests/FanOutEngineTestFactory.cs
@@ -32,7 +32,7 @@ internal static class FanOutEngineTestFactory
             new ActivityCoalescer(harness.HubContext, members),
             new SessionRegistry(),
             new PresenceInterestRegistry(),
-            new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())),
+            new ViewersAccumulator(harness.HubContext, focus, ViewersAccumulatorTestFactory.EmptyViewerResolver()),
             TimeProvider.System);
     }
 }

--- a/W3ChampionsChatService.Tests/FanOutEngineTestFactory.cs
+++ b/W3ChampionsChatService.Tests/FanOutEngineTestFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Sessions;
 
@@ -31,7 +32,7 @@ internal static class FanOutEngineTestFactory
             new ActivityCoalescer(harness.HubContext, members),
             new SessionRegistry(),
             new PresenceInterestRegistry(),
-            new ViewersAccumulator(harness.HubContext, focus),
+            new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())),
             TimeProvider.System);
     }
 }

--- a/W3ChampionsChatService.Tests/FanOutEngineTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutEngineTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Messages;
@@ -69,7 +70,7 @@ public class FanOutEngineTests
     {
         var onlineMemberRegistry = new OnlineMemberRegistry();
         var coalescer = new ActivityCoalescer(harness.HubContext, onlineMemberRegistry);
-        return new FanOutEngine(harness.HubContext, focusRegistry, onlineMemberRegistry, coalescer, sessionRegistry, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry), TimeProvider.System);
+        return new FanOutEngine(harness.HubContext, focusRegistry, onlineMemberRegistry, coalescer, sessionRegistry, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
     }
 
     // A SessionRegistry seeded with the given (connection, battleTag, isModerator) entries. A moderator
@@ -118,7 +119,7 @@ public class FanOutEngineTests
         var members = new OnlineMemberRegistry();
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
         return (harness, engine);
     }
 
@@ -368,7 +369,7 @@ public class FanOutEngineTests
         // UNFOCUSED level-All member who, for a NON-shadow message, WOULD receive a ChannelActivity.
         var members = new OnlineMemberRegistry();
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), sessions, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), sessions, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
 
         focusRegistry.Focus(AuthorConnection, ChannelId, AuthorBattleTag);
         focusRegistry.Focus(ModeratorConnection, ChannelId, ModeratorBattleTag);
@@ -554,7 +555,7 @@ public class FanOutEngineTests
         members.Join(ChannelId, InitiatorConnection, new MemberState(DmInitiator, NotificationLevel.All, 0, ChannelType.Dm));
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
 
         await engine.OnMessagePersisted(DmChannel(DmRequestState.Pending), Message(), InitiatorConnection, isShadow: false, Now);
 
@@ -576,7 +577,7 @@ public class FanOutEngineTests
         // An unfocused level-All recipient of an ACCEPTED Dm — suppression is lifted, so activity resumes.
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
 
         await engine.OnMessagePersisted(DmChannel(DmRequestState.Accepted), Message(), InitiatorConnection, isShadow: false, Now);
 
@@ -594,7 +595,7 @@ public class FanOutEngineTests
         var members = new OnlineMemberRegistry();
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
 
         await engine.OnMessagePersisted(DmChannel(DmRequestState.Pending), Message(), InitiatorConnection, isShadow: false, Now);
 
@@ -706,7 +707,7 @@ public class FanOutEngineTests
         var groupMembers = new OnlineMemberRegistry();
         groupMembers.Join(ChannelId, GroupMemberConn, new MemberState(GroupMemberTag, NotificationLevel.All, 0, ChannelType.GroupDm));
         var groupEngine = new FanOutEngine(
-            groupHarness.HubContext, groupFocus, groupMembers, new ActivityCoalescer(groupHarness.HubContext, groupMembers), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(groupHarness.HubContext, groupFocus), TimeProvider.System);
+            groupHarness.HubContext, groupFocus, groupMembers, new ActivityCoalescer(groupHarness.HubContext, groupMembers), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(groupHarness.HubContext, groupFocus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
         var groupChannel = new ChatChannel { Id = ChannelId, Type = ChannelType.GroupDm };
 
         await groupEngine.OnMessagePersisted(groupChannel, Message(), AuthorConnection, isShadow: false, Now);
@@ -722,7 +723,7 @@ public class FanOutEngineTests
         var publicMembers = new OnlineMemberRegistry();
         publicMembers.Join(ChannelId, PublicMemberConn, new MemberState(PublicMemberTag, NotificationLevel.All, 0, ChannelType.Public));
         var publicEngine = new FanOutEngine(
-            publicHarness.HubContext, publicFocus, publicMembers, new ActivityCoalescer(publicHarness.HubContext, publicMembers), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(publicHarness.HubContext, publicFocus), TimeProvider.System);
+            publicHarness.HubContext, publicFocus, publicMembers, new ActivityCoalescer(publicHarness.HubContext, publicMembers), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(publicHarness.HubContext, publicFocus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
 
         await publicEngine.OnMessagePersisted(Channel(), Message(), AuthorConnection, isShadow: false, Now);
 
@@ -741,7 +742,7 @@ public class FanOutEngineTests
         members.Join(ChannelId, InitiatorConnection, new MemberState(DmInitiator, NotificationLevel.All, 0, ChannelType.Dm));
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
 
         await engine.OnMessagePersisted(DmChannel(DmRequestState.Pending), Message(content: "a pending message"), InitiatorConnection, isShadow: false, Now);
 
@@ -782,7 +783,7 @@ public class FanOutEngineTests
         var focus = new FocusRegistry();
         var members = new OnlineMemberRegistry();
         var sessions = new SessionRegistry();
-        var accumulator = new ViewersAccumulator(harness.HubContext, focus);
+        var accumulator = new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         var time = new FakeTimeProvider(new DateTimeOffset(Now, TimeSpan.Zero));
         var engine = new FanOutEngine(
             harness.HubContext, focus, members, new ActivityCoalescer(harness.HubContext, members), sessions, new PresenceInterestRegistry(), accumulator, time);

--- a/W3ChampionsChatService.Tests/FanOutEngineTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutEngineTests.cs
@@ -70,7 +70,10 @@ public class FanOutEngineTests
     {
         var onlineMemberRegistry = new OnlineMemberRegistry();
         var coalescer = new ActivityCoalescer(harness.HubContext, onlineMemberRegistry);
-        return new FanOutEngine(harness.HubContext, focusRegistry, onlineMemberRegistry, coalescer, sessionRegistry, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+        // The accumulator's resolver shares the SAME sessionRegistry the caller passed in (SessionsWith(...)
+        // for the moderator-flagged tests, or a throwaway from the 2-arg overload) — no ConnectionMapping
+        // exists in this pure in-memory fixture, so flair is always null; no test here asserts on it.
+        return new FanOutEngine(harness.HubContext, focusRegistry, onlineMemberRegistry, coalescer, sessionRegistry, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(sessionRegistry, new ConnectionMapping())), TimeProvider.System);
     }
 
     // A SessionRegistry seeded with the given (connection, battleTag, isModerator) entries. A moderator
@@ -119,7 +122,7 @@ public class FanOutEngineTests
         var members = new OnlineMemberRegistry();
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
         return (harness, engine);
     }
 
@@ -368,8 +371,10 @@ public class FanOutEngineTests
         // Explicit construction so we can seed the OnlineMemberRegistry the engine actually uses: an
         // UNFOCUSED level-All member who, for a NON-shadow message, WOULD receive a ChannelActivity.
         var members = new OnlineMemberRegistry();
+        // The accumulator's resolver shares the SAME sessions registry (SessionsWith(...) above) the engine
+        // itself uses.
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), sessions, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), sessions, new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(sessions, new ConnectionMapping())), TimeProvider.System);
 
         focusRegistry.Focus(AuthorConnection, ChannelId, AuthorBattleTag);
         focusRegistry.Focus(ModeratorConnection, ChannelId, ModeratorBattleTag);
@@ -555,7 +560,7 @@ public class FanOutEngineTests
         members.Join(ChannelId, InitiatorConnection, new MemberState(DmInitiator, NotificationLevel.All, 0, ChannelType.Dm));
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
 
         await engine.OnMessagePersisted(DmChannel(DmRequestState.Pending), Message(), InitiatorConnection, isShadow: false, Now);
 
@@ -577,7 +582,7 @@ public class FanOutEngineTests
         // An unfocused level-All recipient of an ACCEPTED Dm — suppression is lifted, so activity resumes.
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
 
         await engine.OnMessagePersisted(DmChannel(DmRequestState.Accepted), Message(), InitiatorConnection, isShadow: false, Now);
 
@@ -595,7 +600,7 @@ public class FanOutEngineTests
         var members = new OnlineMemberRegistry();
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
 
         await engine.OnMessagePersisted(DmChannel(DmRequestState.Pending), Message(), InitiatorConnection, isShadow: false, Now);
 
@@ -707,7 +712,7 @@ public class FanOutEngineTests
         var groupMembers = new OnlineMemberRegistry();
         groupMembers.Join(ChannelId, GroupMemberConn, new MemberState(GroupMemberTag, NotificationLevel.All, 0, ChannelType.GroupDm));
         var groupEngine = new FanOutEngine(
-            groupHarness.HubContext, groupFocus, groupMembers, new ActivityCoalescer(groupHarness.HubContext, groupMembers), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(groupHarness.HubContext, groupFocus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+            groupHarness.HubContext, groupFocus, groupMembers, new ActivityCoalescer(groupHarness.HubContext, groupMembers), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(groupHarness.HubContext, groupFocus, ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
         var groupChannel = new ChatChannel { Id = ChannelId, Type = ChannelType.GroupDm };
 
         await groupEngine.OnMessagePersisted(groupChannel, Message(), AuthorConnection, isShadow: false, Now);
@@ -723,7 +728,7 @@ public class FanOutEngineTests
         var publicMembers = new OnlineMemberRegistry();
         publicMembers.Join(ChannelId, PublicMemberConn, new MemberState(PublicMemberTag, NotificationLevel.All, 0, ChannelType.Public));
         var publicEngine = new FanOutEngine(
-            publicHarness.HubContext, publicFocus, publicMembers, new ActivityCoalescer(publicHarness.HubContext, publicMembers), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(publicHarness.HubContext, publicFocus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+            publicHarness.HubContext, publicFocus, publicMembers, new ActivityCoalescer(publicHarness.HubContext, publicMembers), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(publicHarness.HubContext, publicFocus, ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
 
         await publicEngine.OnMessagePersisted(Channel(), Message(), AuthorConnection, isShadow: false, Now);
 
@@ -742,7 +747,7 @@ public class FanOutEngineTests
         members.Join(ChannelId, InitiatorConnection, new MemberState(DmInitiator, NotificationLevel.All, 0, ChannelType.Dm));
         members.Join(ChannelId, RecipientConnection, new MemberState(DmRecipient, NotificationLevel.All, 0, ChannelType.Dm));
         var engine = new FanOutEngine(
-            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping())), TimeProvider.System);
+            harness.HubContext, focusRegistry, members, new ActivityCoalescer(harness.HubContext, members), new SessionRegistry(), new PresenceInterestRegistry(), new ViewersAccumulator(harness.HubContext, focusRegistry, ViewersAccumulatorTestFactory.EmptyViewerResolver()), TimeProvider.System);
 
         await engine.OnMessagePersisted(DmChannel(DmRequestState.Pending), Message(content: "a pending message"), InitiatorConnection, isShadow: false, Now);
 
@@ -783,7 +788,10 @@ public class FanOutEngineTests
         var focus = new FocusRegistry();
         var members = new OnlineMemberRegistry();
         var sessions = new SessionRegistry();
-        var accumulator = new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+        // The comment above this fixture claims "real registries drive FlushDue directly" — the resolver
+        // must share this SAME sessions registry (seeded via Register just below) for that to hold, even
+        // though these forced-removal assertions only check Left/Joined battleTags, not display name/flair.
+        var accumulator = new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(sessions, new ConnectionMapping()));
         var time = new FakeTimeProvider(new DateTimeOffset(Now, TimeSpan.Zero));
         var engine = new FanOutEngine(
             harness.HubContext, focus, members, new ActivityCoalescer(harness.HubContext, members), sessions, new PresenceInterestRegistry(), accumulator, time);

--- a/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
@@ -5,11 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
-using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Protocol;
-using W3ChampionsChatService.Sessions;
 
 namespace W3ChampionsChatService.Tests;
 

--- a/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
@@ -5,9 +5,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
 
 namespace W3ChampionsChatService.Tests;
 
@@ -62,7 +64,7 @@ public class FanOutFlushServiceTests
         // --- Arm the accumulator: RecordChange BEFORE the Focus captures a not-viewing baseline; the Focus
         // makes it viewing, so a due FlushDue (>= T0+5s) emits a `joined` to the focused viewer.
         var focus = new FocusRegistry();
-        var accumulator = new ViewersAccumulator(harness.HubContext, focus);
+        var accumulator = new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         accumulator.RecordChange(ChannelId, ViewerTag, T0);
         focus.Focus(ViewerConn, ChannelId, ViewerTag);
 
@@ -115,7 +117,7 @@ public class FanOutFlushServiceTests
         // The accumulator's join flushed via the same timer path.
         var batches = ViewersChangedFor(harness, ViewerConn);
         Assert.AreEqual(1, batches.Count, "the accumulated join must flush exactly once via the timer");
-        Assert.IsTrue(batches[0].Joined.Any(t => string.Equals(t, ViewerTag, StringComparison.OrdinalIgnoreCase)),
+        Assert.IsTrue(batches[0].Joined.Any(v => string.Equals(v.BattleTag, ViewerTag, StringComparison.OrdinalIgnoreCase)),
             "the timer-driven ViewersChanged batch must report the viewer as joined");
         Assert.IsEmpty(batches[0].Left);
     }

--- a/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
@@ -64,7 +64,7 @@ public class FanOutFlushServiceTests
         // --- Arm the accumulator: RecordChange BEFORE the Focus captures a not-viewing baseline; the Focus
         // makes it viewing, so a due FlushDue (>= T0+5s) emits a `joined` to the focused viewer.
         var focus = new FocusRegistry();
-        var accumulator = new ViewersAccumulator(harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+        var accumulator = new ViewersAccumulator(harness.HubContext, focus, ViewersAccumulatorTestFactory.EmptyViewerResolver());
         accumulator.RecordChange(ChannelId, ViewerTag, T0);
         focus.Focus(ViewerConn, ChannelId, ViewerTag);
 

--- a/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
@@ -131,7 +131,8 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
         // registries the hubs mutate — so every push lands in a single ordered capture and the
         // coalescer/accumulator see the live roster/membership/read-state the hubs produce.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _viewersAccumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
     }
@@ -304,6 +305,9 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
     private static bool Contains(IEnumerable<string> tags, string battleTag) =>
         tags.Any(t => string.Equals(t, battleTag, StringComparison.OrdinalIgnoreCase));
 
+    private static bool Contains(IEnumerable<ChannelViewerDto> viewers, string battleTag) =>
+        viewers.Any(v => string.Equals(v.BattleTag, battleTag, StringComparison.OrdinalIgnoreCase));
+
     // ============================================================================================
     // Scenario 1 — acceptance 1: the focused/unfocused fan-out split, end-to-end across 3 clients.
     // ============================================================================================
@@ -456,7 +460,7 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
 
         // Flush the establishing window so alpha+bravo are the baseline-VIEWING set of the next window.
         await _viewersAccumulator.FlushDue(T0.AddSeconds(5));
-        Assert.That(ViewersChangedFor("conn-alpha").SelectMany(v => v.Joined),
+        Assert.That(ViewersChangedFor("conn-alpha").SelectMany(v => v.Joined).Select(j => j.BattleTag),
             Is.EquivalentTo(new[] { AlphaTag, BravoTag }), "the establishing flush announces alpha+bravo joined");
 
         // Charlie joins mid the next window.

--- a/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
@@ -76,6 +76,7 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
     private ViewersAccumulator _viewersAccumulator;
+    private ViewerResolver _viewerResolver;
     private UserDirectoryRepository _userDirectory;
     private MuteRepository _muteRepository;
     private MuteReconciliationService _reconcileService;
@@ -131,8 +132,8 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
         // registries the hubs mutate — so every push lands in a single ordered capture and the
         // coalescer/accumulator see the live roster/membership/read-state the hubs produce.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
     }
@@ -175,7 +176,8 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            _viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/HubProtocolIntegrationTests.cs
@@ -132,7 +132,7 @@ public class HubProtocolIntegrationTests : IntegrationTestBase
         // coalescer/accumulator see the live roster/membership/read-state the hubs produce.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
     }

--- a/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
@@ -139,9 +139,10 @@ public class InternalApiIntegrationTests : IntegrationTestBase
         _sessionRegistry = new SessionRegistry();
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
+        _connectionMapping = new ConnectionMapping();
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext,
             _focusRegistry,
@@ -174,7 +175,6 @@ public class InternalApiIntegrationTests : IntegrationTestBase
 
         // The offline half of acceptance 3 — a real SessionStateAssembler over the SAME repositories/registries.
         _muteRepository = new MuteRepository(MongoClient);
-        _connectionMapping = new ConnectionMapping();
         _mentionInboxRepository = new MentionInboxRepository(MongoClient);
         _sessionStateAssembler = new SessionStateAssembler(
             _membershipRepository,

--- a/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/InternalApiIntegrationTests.cs
@@ -140,7 +140,8 @@ public class InternalApiIntegrationTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _viewersAccumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext,
             _focusRegistry,

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -59,7 +59,10 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         var focusRegistry = new FocusRegistry();
         var onlineMemberRegistry = new OnlineMemberRegistry();
         var activityCoalescer = new ActivityCoalescer(harness.HubContext, onlineMemberRegistry);
-        var viewersAccumulator = new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+        // The accumulator's resolver shares the SAME sessionRegistry passed to the engine below (no test
+        // in this file ever registers a session or asserts on ViewersChanged content, so this is currently
+        // inert either way — wired for parity with the fixture's other real-registry sharing).
+        var viewersAccumulator = new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(sessionRegistry, new ConnectionMapping()));
         var fanOutEngine = new FanOutEngine(
             harness.HubContext,
             focusRegistry,

--- a/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalChannelsControllerTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Internal;
@@ -58,7 +59,7 @@ public class InternalChannelsControllerTests : IntegrationTestBase
         var focusRegistry = new FocusRegistry();
         var onlineMemberRegistry = new OnlineMemberRegistry();
         var activityCoalescer = new ActivityCoalescer(harness.HubContext, onlineMemberRegistry);
-        var viewersAccumulator = new ViewersAccumulator(harness.HubContext, focusRegistry);
+        var viewersAccumulator = new ViewersAccumulator(harness.HubContext, focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         var fanOutEngine = new FanOutEngine(
             harness.HubContext,
             focusRegistry,

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Time.Testing;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Internal;
@@ -55,7 +56,8 @@ public class MatchChannelServiceTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _viewersAccumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext,
             _focusRegistry,

--- a/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
+++ b/W3ChampionsChatService.Tests/MatchChannelServiceTests.cs
@@ -56,8 +56,11 @@ public class MatchChannelServiceTests : IntegrationTestBase
         _focusRegistry = new FocusRegistry();
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
+        // The accumulator's resolver shares the SAME SessionRegistry RegisterOnline seeds below, so a
+        // roster delta's display name matches a real session's (no ConnectionMapping exists in this
+        // fixture — no hub ever connects — so flair is always null here; no test asserts on it).
         _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext,
             _focusRegistry,

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -180,7 +180,8 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         // SAME PresenceInterestRegistry the hubs mutate, so RegisterFocus (hub) and GetInterestedConnections
         // (engine's PushPresenceChanged) see one consistent index.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _viewersAccumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -181,7 +181,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         // (engine's PushPresenceChanged) see one consistent index.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }

--- a/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/MentionPresenceIntegrationTests.cs
@@ -77,6 +77,7 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
     private ViewersAccumulator _viewersAccumulator;
+    private ViewerResolver _viewerResolver;
     private PresenceInterestRegistry _presenceInterestRegistry; // the shared index under test
     private UserDirectoryRepository _userDirectory;
     private MuteRepository _muteRepository;
@@ -180,8 +181,8 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
         // SAME PresenceInterestRegistry the hubs mutate, so RegisterFocus (hub) and GetInterestedConnections
         // (engine's PushPresenceChanged) see one consistent index.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, _presenceInterestRegistry, _viewersAccumulator, _time);
     }
@@ -233,7 +234,8 @@ public class MentionPresenceIntegrationTests : IntegrationTestBase
             _mentionFanOut,                     // REAL fan-out through the shared harness
             _presenceInterestRegistry,          // SHARED — same instance the engine reads
             _mentionInboxRepository,            // SHARED — the read/ack store
-            _notificationPreferenceRepository); // SHARED — same instance _mentionFanOut reads (fix round 1, F9)
+            _notificationPreferenceRepository,  // SHARED — same instance _mentionFanOut reads (fix round 1, F9)
+            _viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
@@ -71,6 +71,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
     private ActivityCoalescer _activityCoalescer;
     private FanOutEngine _fanOutEngine;
     private ViewersAccumulator _viewersAccumulator;
+    private ViewerResolver _viewerResolver;
     private UserDirectoryRepository _userDirectory;
     private MuteRepository _muteRepository;
     private MuteReconciliationTestHarness _reconcileHarness;
@@ -142,8 +143,8 @@ public class ModerationIntegrationTests : IntegrationTestBase
         // The three fan-out sinks ALL push through the ONE shared harness and read the SHARED registries
         // the hubs mutate, so every push lands in a single ordered capture.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
 
@@ -197,7 +198,8 @@ public class ModerationIntegrationTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            _viewerResolver);
 
         var clients = new Mock<IHubCallerClients>();
         clients.Setup(c => c.Caller).Returns(CapturingSingle(connectionId));

--- a/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
@@ -142,7 +142,8 @@ public class ModerationIntegrationTests : IntegrationTestBase
         // The three fan-out sinks ALL push through the ONE shared harness and read the SHARED registries
         // the hubs mutate, so every push lands in a single ordered capture.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
-        _viewersAccumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
+        _viewersAccumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
 

--- a/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
+++ b/W3ChampionsChatService.Tests/ModerationIntegrationTests.cs
@@ -143,7 +143,7 @@ public class ModerationIntegrationTests : IntegrationTestBase
         // the hubs mutate, so every push lands in a single ordered capture.
         _activityCoalescer = new ActivityCoalescer(_harness.HubContext, _onlineMemberRegistry);
         _viewersAccumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _fanOutEngine = new FanOutEngine(
             _harness.HubContext, _focusRegistry, _onlineMemberRegistry, _activityCoalescer, _sessionRegistry, new PresenceInterestRegistry(), _viewersAccumulator, _time);
 

--- a/W3ChampionsChatService.Tests/MutePortTests.cs
+++ b/W3ChampionsChatService.Tests/MutePortTests.cs
@@ -77,6 +77,7 @@ public class MutePortTests : IntegrationTestBase
     // SAME FocusRegistry the hubs mutate, and pushes through the capture harness (NOT the hub's Clients).
     private HubPushCaptureHarness _pushHarness;
     private ViewersAccumulator _accumulator;
+    private ViewerResolver _viewerResolver;
 
     // Connections that had Context.Abort() invoked (join/send no-abort pins). Connect-path sends/aborts
     // are captured separately in _connectSends (target, method | "ABORT").
@@ -113,8 +114,8 @@ public class MutePortTests : IntegrationTestBase
         _assembler = NewAssembler(_muteRepository);
 
         _pushHarness = new HubPushCaptureHarness();
-        _accumulator = new ViewersAccumulator(
-            _pushHarness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _accumulator = new ViewersAccumulator(_pushHarness.HubContext, _focusRegistry, _viewerResolver);
     }
 
     // ── Hub construction ─────────────────────────────────────────────────────────
@@ -123,8 +124,15 @@ public class MutePortTests : IntegrationTestBase
         new(_membershipRepository, _channelRepository, _messageRepository, muteRepository, _onlineMemberRegistry, _connectionMapping,
             new MentionInboxRepository(MongoClient));
 
+    // The ViewerResolver is deliberately paired with `viewers`, not always _viewerResolver: passing
+    // _viewerResolver alongside a throwaway ViewersAccumulatorTestFactory.CreateIgnored() would resolve a
+    // display name/flair from the SHARED real registries into a hub whose accumulator can never observe
+    // it — same-instance sharing only makes sense when `viewers` IS the real, shared _accumulator.
     private ChatHub NewHub(SessionStateAssembler assembler, ViewersAccumulator viewers, IHubCallerClients clients, HubCallerContext context)
     {
+        var viewerResolver = ReferenceEquals(viewers, _accumulator)
+            ? _viewerResolver
+            : ViewersAccumulatorTestFactory.EmptyViewerResolver();
         var hub = new ChatHub(
             _connectionMapping,
             _reconcileHarness.Service,
@@ -151,7 +159,8 @@ public class MutePortTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient))
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver)
         {
             Clients = clients,
             Context = context,

--- a/W3ChampionsChatService.Tests/MutePortTests.cs
+++ b/W3ChampionsChatService.Tests/MutePortTests.cs
@@ -114,7 +114,7 @@ public class MutePortTests : IntegrationTestBase
 
         _pushHarness = new HubPushCaptureHarness();
         _accumulator = new ViewersAccumulator(
-            _pushHarness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            _pushHarness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
     }
 
     // ── Hub construction ─────────────────────────────────────────────────────────

--- a/W3ChampionsChatService.Tests/MutePortTests.cs
+++ b/W3ChampionsChatService.Tests/MutePortTests.cs
@@ -113,7 +113,8 @@ public class MutePortTests : IntegrationTestBase
         _assembler = NewAssembler(_muteRepository);
 
         _pushHarness = new HubPushCaptureHarness();
-        _accumulator = new ViewersAccumulator(_pushHarness.HubContext, _focusRegistry);
+        _accumulator = new ViewersAccumulator(
+            _pushHarness.HubContext, _focusRegistry, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
     }
 
     // ── Hub construction ─────────────────────────────────────────────────────────
@@ -320,6 +321,9 @@ public class MutePortTests : IntegrationTestBase
 
     private static bool ContainsTag(IEnumerable<string> tags, string battleTag) =>
         tags.Any(t => string.Equals(t, battleTag, StringComparison.OrdinalIgnoreCase));
+
+    private static bool ContainsTag(IEnumerable<ChannelViewerDto> viewers, string battleTag) =>
+        viewers.Any(v => string.Equals(v.BattleTag, battleTag, StringComparison.OrdinalIgnoreCase));
 
     // ── Connect: full ban never aborts (G1) ──────────────────────────────────────
 

--- a/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
+++ b/W3ChampionsChatService.Tests/MuteReconciliationTests.cs
@@ -62,6 +62,7 @@ public class MuteReconciliationTests : IntegrationTestBase
         _channelRepository = new ChannelRepository(MongoClient);
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _sessionRegistry = new SessionRegistry();
+        var viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
         _chatHub = new ChatHub(
             _connectionMapping,
             _harness.Service,
@@ -95,7 +96,8 @@ public class MuteReconciliationTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            viewerResolver);
 
         _clients = new Mock<IHubCallerClients>();
         _callerProxy = new Mock<ISingleClientProxy>();

--- a/W3ChampionsChatService.Tests/ProtocolContractTests.cs
+++ b/W3ChampionsChatService.Tests/ProtocolContractTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text.Json;
 using NUnit.Framework;
 using W3ChampionsChatService.Channels;
+using W3ChampionsChatService.Chats;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.Memberships;
 using W3ChampionsChatService.Messages;
@@ -112,13 +113,24 @@ public class ProtocolContractTests
     [Test]
     public void FocusChannelResult_CarriesViewerRoster()
     {
-        var viewers = new[] { new ChannelViewerDto("Peter#123", "Peter") };
+        // Explicit Profile (Finding 3: ChannelViewerDto's Profile ctor arg no longer defaults to
+        // null — every construction site states its intent). Also asserts Profile itself rides the
+        // roster (Finding 4): a regression that stopped populating it would previously leave this
+        // wire-shape contract test green.
+        var profile = new ChatProfile
+        {
+            ProfilePicture = new ProfilePicture { Race = AvatarCategory.HU, PictureId = 3, IsClassic = true },
+        };
+        var viewers = new[] { new ChannelViewerDto("Peter#123", "Peter", profile) };
 
         var result = new FocusChannelResult(ChatResultCode.Ok, Viewers: viewers);
 
         Assert.AreEqual(1, result.Viewers.Count);
         Assert.AreEqual("Peter#123", result.Viewers[0].BattleTag);
         Assert.AreEqual("Peter", result.Viewers[0].Name);
+        Assert.AreSame(profile, result.Viewers[0].Profile);
+        Assert.AreEqual(AvatarCategory.HU, result.Viewers[0].Profile.ProfilePicture.Race);
+        Assert.AreEqual(3, result.Viewers[0].Profile.ProfilePicture.PictureId);
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/ViewersAccumulatorTestFactory.cs
+++ b/W3ChampionsChatService.Tests/ViewersAccumulatorTestFactory.cs
@@ -17,5 +17,10 @@ namespace W3ChampionsChatService.Tests;
 internal static class ViewersAccumulatorTestFactory
 {
     internal static ViewersAccumulator CreateIgnored() =>
-        new ViewersAccumulator(new HubPushCaptureHarness().HubContext, new FocusRegistry());
+        new ViewersAccumulator(
+            new HubPushCaptureHarness().HubContext,
+            new FocusRegistry(),
+            new W3ChampionsChatService.Chats.ViewerResolver(
+                new W3ChampionsChatService.Sessions.SessionRegistry(),
+                new W3ChampionsChatService.Chats.ConnectionMapping()));
 }

--- a/W3ChampionsChatService.Tests/ViewersAccumulatorTestFactory.cs
+++ b/W3ChampionsChatService.Tests/ViewersAccumulatorTestFactory.cs
@@ -20,7 +20,19 @@ internal static class ViewersAccumulatorTestFactory
         new ViewersAccumulator(
             new HubPushCaptureHarness().HubContext,
             new FocusRegistry(),
-            new W3ChampionsChatService.Chats.ViewerResolver(
-                new W3ChampionsChatService.Sessions.SessionRegistry(),
-                new W3ChampionsChatService.Chats.ConnectionMapping()));
+            EmptyViewerResolver());
+
+    /// <summary>
+    /// A <see cref="W3ChampionsChatService.Chats.ViewerResolver"/> over freshly-empty
+    /// <see cref="W3ChampionsChatService.Sessions.SessionRegistry"/>/<see cref="W3ChampionsChatService.Chats.ConnectionMapping"/>
+    /// instances — correct ONLY where the test asserts nothing about a resolved viewer's display name or
+    /// flair (every resolve degrades to <c>ChannelViewerDto(tag, tag, null)</c> regardless of which empty
+    /// registries back it, so no test outcome can depend on which instance this is). A test that DOES
+    /// assert on a joined viewer's name/flair must wire a resolver over the SAME registries its fixture
+    /// seeds instead.
+    /// </summary>
+    internal static W3ChampionsChatService.Chats.ViewerResolver EmptyViewerResolver() =>
+        new W3ChampionsChatService.Chats.ViewerResolver(
+            new W3ChampionsChatService.Sessions.SessionRegistry(),
+            new W3ChampionsChatService.Chats.ConnectionMapping());
 }

--- a/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
+++ b/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
@@ -245,6 +245,7 @@ public class ViewersAccumulatorTests : IntegrationTestBase
     private FakeTimeProvider _time;
     private HubPushCaptureHarness _harness;
     private ViewersAccumulator _accumulator;
+    private ViewerResolver _viewerResolver;
     private FocusRegistry _focusRegistry;
     private OnlineMemberRegistry _onlineMemberRegistry;
     private SessionRegistry _sessionRegistry;
@@ -277,8 +278,8 @@ public class ViewersAccumulatorTests : IntegrationTestBase
         // RecordChange) and its current-state read (in FlushDue) see the live roster the hubs produce.
         // It also shares the SAME session/connection registries the hubs register into, so a joined
         // entry's flair reflects the live ChatUser each test seeds.
-        _accumulator = new ViewersAccumulator(
-            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
+        _viewerResolver = new ViewerResolver(_sessionRegistry, _connectionMapping);
+        _accumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry, _viewerResolver);
         _userDirectory = new UserDirectoryRepository(MongoClient);
         _muteRepository = new MuteRepository(MongoClient);
         _reconcileService = new MuteReconciliationTestHarness(_connectionMapping, _muteRepository).Service;
@@ -330,7 +331,8 @@ public class ViewersAccumulatorTests : IntegrationTestBase
             MentionFanOutTestFactory.CreateIgnored(MongoClient),
             new PresenceInterestRegistry(),
             new MentionInboxRepository(MongoClient),
-            new NotificationPreferenceRepository(MongoClient));
+            new NotificationPreferenceRepository(MongoClient),
+            _viewerResolver);
 
         hub.Clients = new Mock<IHubCallerClients>().Object;
         var context = new Mock<HubCallerContext>();

--- a/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
+++ b/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
@@ -53,7 +53,8 @@ public class ViewersAccumulatorTests : IntegrationTestBase
     {
         var harness = new HubPushCaptureHarness();
         var focus = new FocusRegistry();
-        var accumulator = new ViewersAccumulator(harness.HubContext, focus);
+        var accumulator = new ViewersAccumulator(
+            harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
         return (harness, focus, accumulator);
     }
 
@@ -68,6 +69,9 @@ public class ViewersAccumulatorTests : IntegrationTestBase
 
     private static bool Contains(IEnumerable<string> tags, string battleTag) =>
         tags.Any(t => string.Equals(t, battleTag, StringComparison.OrdinalIgnoreCase));
+
+    private static bool Contains(IEnumerable<ChannelViewerDto> viewers, string battleTag) =>
+        viewers.Any(v => string.Equals(v.BattleTag, battleTag, StringComparison.OrdinalIgnoreCase));
 
     // ---- PURE: accumulate / flush ------------------------------------------------------------------
 
@@ -121,7 +125,7 @@ public class ViewersAccumulatorTests : IntegrationTestBase
         Assert.AreSame(payloadA, payloadD, "the SAME batch object must be sent to every focused viewer (no per-connection deltas)");
 
         var batch = (ViewersChangedDto)payloadA;
-        Assert.That(batch.Joined, Is.EquivalentTo(new[] { "alice#1", "bob#2", "dan#4" }), "the shared batch carries every joiner");
+        Assert.That(batch.Joined.Select(j => j.BattleTag), Is.EquivalentTo(new[] { "alice#1", "bob#2", "dan#4" }), "the shared batch carries every joiner");
         Assert.IsEmpty(batch.Left);
         Assert.AreEqual(1, harness.SignalCount("conn-a", ChatEvents.ViewersChanged), "each focused viewer receives the batch exactly once");
     }
@@ -263,15 +267,18 @@ public class ViewersAccumulatorTests : IntegrationTestBase
         _time = new FakeTimeProvider(new DateTimeOffset(T0, TimeSpan.Zero));
         _harness = new HubPushCaptureHarness();
         _focusRegistry = new FocusRegistry();
-        // The accumulator shares the SAME FocusRegistry the hubs mutate — so its baseline capture (in
-        // RecordChange) and its current-state read (in FlushDue) see the live roster the hubs produce.
-        _accumulator = new ViewersAccumulator(_harness.HubContext, _focusRegistry);
 
         _onlineMemberRegistry = new OnlineMemberRegistry();
         _sessionRegistry = new SessionRegistry();
         _messageRateLimiter = new MessageRateLimiter();
         _readRateLimiter = new ReadRateLimiter();
         _connectionMapping = new ConnectionMapping();
+        // The accumulator shares the SAME FocusRegistry the hubs mutate — so its baseline capture (in
+        // RecordChange) and its current-state read (in FlushDue) see the live roster the hubs produce.
+        // It also shares the SAME session/connection registries the hubs register into, so a joined
+        // entry's flair reflects the live ChatUser each test seeds.
+        _accumulator = new ViewersAccumulator(
+            _harness.HubContext, _focusRegistry, new ViewerResolver(_sessionRegistry, _connectionMapping));
         _userDirectory = new UserDirectoryRepository(MongoClient);
         _muteRepository = new MuteRepository(MongoClient);
         _reconcileService = new MuteReconciliationTestHarness(_connectionMapping, _muteRepository).Service;
@@ -509,5 +516,44 @@ public class ViewersAccumulatorTests : IntegrationTestBase
         Assert.IsTrue(Contains(charlieBatches.Last().Left, BattleTagB),
             "an explicit LeaveChannel while staying connected MUST be reported as a leave");
         Assert.IsFalse(Contains(charlieBatches.Last().Joined, BattleTagB));
+    }
+
+    [Test]
+    public async Task FlushDue_JoinedEntries_CarryFlairAndDisplayName()
+    {
+        // This test needs SEEDED registries so the resolver has flair to find, so it builds its own
+        // accumulator rather than using NewAccumulator() (which wires empty ones).
+        var harness = new HubPushCaptureHarness();
+        var focus = new FocusRegistry();
+        var sessions = new SessionRegistry();
+        var connections = new ConnectionMapping();
+        var accumulator = new ViewersAccumulator(
+            harness.HubContext, focus, new ViewerResolver(sessions, connections));
+
+        const string joiner = "alice#1";
+
+        sessions.Register("conn-a", new W3CUserAuthentication { BattleTag = joiner, Name = "Alice" }, null);
+        connections.RegisterUser("conn-a", new ChatUser(
+            joiner,
+            false,
+            "W3C",
+            new ProfilePicture { Race = AvatarCategory.UD, PictureId = 4, IsClassic = false },
+            new ChatColor("chat_color_gold"),
+            [new ChatIcon("chat_icon_star")]));
+
+        accumulator.RecordChange(ChannelId, joiner, T0);
+        focus.Focus("conn-a", ChannelId, joiner);
+
+        await accumulator.FlushDue(T0 + Flush);
+
+        var batch = ViewersChangedFor(harness, "conn-a").Single();
+        var joined = batch.Joined.Single();
+
+        Assert.AreEqual(joiner, joined.BattleTag);
+        Assert.AreEqual("Alice", joined.Name, "A join must carry the display name, not just the battleTag");
+        Assert.IsNotNull(joined.Profile, "A join must carry flair so the roster never renders a default avatar");
+        Assert.AreEqual(AvatarCategory.UD, joined.Profile.ProfilePicture.Race);
+        Assert.AreEqual(4, joined.Profile.ProfilePicture.PictureId);
+        Assert.AreEqual("chat_color_gold", joined.Profile.ChatColor.ColorId);
     }
 }

--- a/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
+++ b/W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs
@@ -54,7 +54,7 @@ public class ViewersAccumulatorTests : IntegrationTestBase
         var harness = new HubPushCaptureHarness();
         var focus = new FocusRegistry();
         var accumulator = new ViewersAccumulator(
-            harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+            harness.HubContext, focus, ViewersAccumulatorTestFactory.EmptyViewerResolver());
         return (harness, focus, accumulator);
     }
 

--- a/W3ChampionsChatService/Chats/ChatHub.Channels.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Channels.cs
@@ -114,7 +114,7 @@ public partial class ChatHub
         // roster entry with no live session (e.g. a teardown race) falls back to the battleTag itself
         // rather than dropping the entry or throwing.
         var viewers = _focusRegistry.GetRoster(channelId)
-            .Select(rosterBattleTag => new ChannelViewerDto(rosterBattleTag, ResolveViewerName(rosterBattleTag)))
+            .Select(_viewerResolver.Resolve)
             .ToList();
 
         return new FocusChannelResult(ChatResultCode.Ok, viewers);
@@ -197,12 +197,6 @@ public partial class ChatHub
         _presenceInterestRegistry.RevokeFocus(Context.ConnectionId, channelId);
 
         return Task.FromResult(new ChannelOperationResult(ChatResultCode.Ok));
-    }
-
-    private string ResolveViewerName(string battleTag)
-    {
-        var session = _sessionRegistry.GetByBattleTag(battleTag);
-        return session?.Identity?.Name ?? battleTag;
     }
 
     /// <summary>

--- a/W3ChampionsChatService/Chats/ChatHub.Channels.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.Channels.cs
@@ -110,8 +110,9 @@ public partial class ChatHub
         }
 
         // Roster = the channel's ACTIVE viewers (online AND focused) from FocusRegistry — NEVER from
-        // membership. Each distinct battleTag is resolved to a display name via the live session; a
-        // roster entry with no live session (e.g. a teardown race) falls back to the battleTag itself
+        // membership. Each distinct battleTag is resolved to a display name via the live session; each
+        // entry also carries the viewer's flair (Profile), resolved in-memory via <see cref="ViewerResolver"/>.
+        // A roster entry with no live session (e.g. a teardown race) falls back to the battleTag itself
         // rather than dropping the entry or throwing.
         var viewers = _focusRegistry.GetRoster(channelId)
             .Select(_viewerResolver.Resolve)

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -107,6 +107,11 @@ public partial class ChatHub(
     private readonly MuteReconciliationService _muteReconciliation = muteReconciliation;
     private readonly ITicketStore _ticketStore = ticketStore;
     private readonly ISessionRegistry _sessionRegistry = sessionRegistry;
+    // Built from the primary-constructor params rather than injected, deliberately: adding a ctor
+    // parameter would force an edit to all 31 test files that construct a ChatHub. ViewerResolver is
+    // stateless (it holds only references to the two singletons above), so this instance and the
+    // DI-registered singleton the ViewersAccumulator receives are interchangeable.
+    private readonly ViewerResolver _viewerResolver = new(sessionRegistry, connections);
     private readonly UserDirectoryRepository _userDirectory = userDirectory;
     // C3 (Task 8): the SessionState snapshot assembler + the in-memory fan-out registries this hub
     // seeds on connect and tears down on disconnect. TimeProvider supplies the trusted server clock

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -101,17 +101,20 @@ public partial class ChatHub(
     // PR36 follow-up (D2): the notification-preference carrier — JoinChannel's rejoin-seed path reads it,
     // SetNotificationLevel's write path (Public/SemiPublic only) writes it. Both live in
     // ChatHub.Channels.cs; this is the ONLY ctor change this task makes to ChatHub itself.
-    NotificationPreferenceRepository notificationPreferenceRepository) : Hub
+    NotificationPreferenceRepository notificationPreferenceRepository,
+    // PR44 review ("No shortcuts. Follow proper DI!"): resolves a roster battleTag into a
+    // ChannelViewerDto (display name + flair) for FocusChannel. This MUST be the SAME singleton
+    // ViewersAccumulator receives (registered in Startup.cs) — that shared instance is what
+    // guarantees an initial roster snapshot and a subsequent ViewersChanged join delta can never
+    // render the same viewer differently. Stateless — it holds only references to ISessionRegistry
+    // and ConnectionMapping (both already above), so injecting it costs nothing beyond the reference.
+    ViewerResolver viewerResolver) : Hub
 {
     private readonly ConnectionMapping _connections = connections;
     private readonly MuteReconciliationService _muteReconciliation = muteReconciliation;
     private readonly ITicketStore _ticketStore = ticketStore;
     private readonly ISessionRegistry _sessionRegistry = sessionRegistry;
-    // Built from the primary-constructor params rather than injected, deliberately: adding a ctor
-    // parameter would force an edit to all 31 test files that construct a ChatHub. ViewerResolver is
-    // stateless (it holds only references to the two singletons above), so this instance and the
-    // DI-registered singleton the ViewersAccumulator receives are interchangeable.
-    private readonly ViewerResolver _viewerResolver = new(sessionRegistry, connections);
+    private readonly ViewerResolver _viewerResolver = viewerResolver;
     private readonly UserDirectoryRepository _userDirectory = userDirectory;
     // C3 (Task 8): the SessionState snapshot assembler + the in-memory fan-out registries this hub
     // seeds on connect and tears down on disconnect. TimeProvider supplies the trusted server clock

--- a/W3ChampionsChatService/Chats/ViewerResolver.cs
+++ b/W3ChampionsChatService/Chats/ViewerResolver.cs
@@ -1,0 +1,46 @@
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
+
+namespace W3ChampionsChatService.Chats;
+
+/// <summary>
+/// Builds a <see cref="ChannelViewerDto"/> for a roster battleTag. The SINGLE place that knows the
+/// session → connection → <see cref="ChatUser"/> → <see cref="ChatProfile"/> hop, shared by
+/// <c>ChatHub.FocusChannel</c> (initial roster) and <see cref="FanOut.ViewersAccumulator"/> (roster
+/// deltas) so the two can never construct roster entries differently.
+/// <para>
+/// PURELY IN-MEMORY by design: a roster entry is by definition an online AND focused viewer, so its
+/// <see cref="ChatUser"/> is already cached in <see cref="ConnectionMapping"/> from that user's own
+/// connect. This must never grow a Mongo or website-backend read — <c>FocusChannel</c> is a hot path
+/// and the roster can be several hundred entries.
+/// </para>
+/// <para>
+/// Degradation is per-field and never throws: a missing session falls back to the battleTag as the
+/// display name (pre-existing behaviour, preserved), and a missing <see cref="ChatUser"/> yields a
+/// null <see cref="ChannelViewerDto.Profile"/>. Dropping the entry would be worse — the viewer would
+/// silently vanish from the roster.
+/// </para>
+/// </summary>
+public class ViewerResolver(ISessionRegistry sessionRegistry, ConnectionMapping connections)
+{
+    private readonly ISessionRegistry _sessionRegistry = sessionRegistry;
+    private readonly ConnectionMapping _connections = connections;
+
+    public ChannelViewerDto Resolve(string battleTag)
+    {
+        var session = _sessionRegistry.GetByBattleTag(battleTag);
+        if (session == null)
+        {
+            return new ChannelViewerDto(battleTag, battleTag, null);
+        }
+
+        var name = session.Identity?.Name ?? battleTag;
+        var chatUser = _connections.GetUser(session.ConnectionId);
+
+        return new ChannelViewerDto(
+            battleTag,
+            name,
+            chatUser == null ? null : ChatProfileMapper.FromChatUser(chatUser));
+    }
+}

--- a/W3ChampionsChatService/FanOut/ViewersAccumulator.cs
+++ b/W3ChampionsChatService/FanOut/ViewersAccumulator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 using Serilog;
@@ -54,18 +55,15 @@ public class ViewersAccumulator(
     // when computing the delta (FlushDue). Reads happen under _lock; FocusRegistry never calls back into
     // this accumulator, and every path here acquires this lock BEFORE FocusRegistry's, so there is no
     // lock-ordering cycle.
-    //
-    // The same invariant extends to _viewerResolver below: FlushDue calls ViewerResolver.Resolve (for each
-    // joined battleTag) while still holding _lock, which nests SessionRegistry's and ConnectionMapping's
-    // own locks inside this one. That nesting is safe for the same reason as FocusRegistry — SessionRegistry
-    // holds no reference back to FanOut/this accumulator, and ConnectionMapping is a dependency-free leaf —
-    // so neither can call back in and there is no cycle.
     private readonly FocusRegistry _focusRegistry = focusRegistry;
 
     // Resolves a joined battleTag into a full roster entry (display name + flair). Shared with
-    // ChatHub.FocusChannel so a join delta and an initial roster can never render differently. Invoked from
-    // FlushDue WHILE _lock is held (see the field comment above) — its own SessionRegistry/ConnectionMapping
-    // locks are always the innermost in the nesting, never the outermost.
+    // ChatHub.FocusChannel so a join delta and an initial roster can never render differently. FlushDue
+    // collects the joined battleTags under _lock but calls Resolve AFTER releasing it (consistent with
+    // this component's existing send discipline — sends already run outside _lock) — nesting
+    // SessionRegistry's/ConnectionMapping's locks inside the single process-wide accumulator lock would be
+    // safe (neither calls back in), but is unnecessary hold-time on a lock every hub thread's RecordChange
+    // also contends for, so it is avoided rather than merely tolerated.
     private readonly Chats.ViewerResolver _viewerResolver = viewerResolver;
 
     // channelId -> the channel's accumulation window. Mutated only under _lock.
@@ -116,7 +114,11 @@ public class ViewersAccumulator(
     /// </summary>
     public async Task FlushDue(DateTime now)
     {
-        List<(IReadOnlyCollection<string> Connections, ViewersChangedDto Payload)> toEmit = null;
+        // Per due channel: its target connections, its joined battleTags (NOT YET resolved — Resolve
+        // happens after _lock is released, below) and its left battleTags. Resolution is deferred so the
+        // single process-wide accumulator lock isn't held across the SessionRegistry/ConnectionMapping
+        // lookups ViewerResolver.Resolve makes — matching how the SignalR sends already run outside _lock.
+        List<(IReadOnlyCollection<string> Connections, string ChannelId, List<string> JoinedBattleTags, List<string> Left)> toEmit = null;
         List<string> toEvict = null;
 
         lock (_lock)
@@ -136,14 +138,14 @@ public class ViewersAccumulator(
                     continue;
                 }
 
-                var joined = new List<ChannelViewerDto>();
+                var joinedBattleTags = new List<string>();
                 var left = new List<string>();
                 foreach (var (battleTag, wasViewing) in window.Baseline)
                 {
                     var isViewing = IsCurrentlyViewingNoLock(channelId, battleTag);
                     if (isViewing && !wasViewing)
                     {
-                        joined.Add(_viewerResolver.Resolve(battleTag));
+                        joinedBattleTags.Add(battleTag);
                     }
                     else if (!isViewing && wasViewing)
                     {
@@ -171,15 +173,13 @@ public class ViewersAccumulator(
                     continue;
                 }
 
-                if (joined.Count == 0 && left.Count == 0)
+                if (joinedBattleTags.Count == 0 && left.Count == 0)
                 {
                     continue;
                 }
 
-                // ONE payload object, sent to every current focused connection — no per-connection deltas.
-                var payload = new ViewersChangedDto(channelId, joined, left);
-                (toEmit ??= new List<(IReadOnlyCollection<string>, ViewersChangedDto)>())
-                    .Add((connections, payload));
+                (toEmit ??= new List<(IReadOnlyCollection<string>, string, List<string>, List<string>)>())
+                    .Add((connections, channelId, joinedBattleTags, left));
             }
 
             if (toEvict != null)
@@ -196,8 +196,15 @@ public class ViewersAccumulator(
             return;
         }
 
-        foreach (var (connections, payload) in toEmit)
+        foreach (var (connections, channelId, joinedBattleTags, left) in toEmit)
         {
+            // Resolved OUTSIDE _lock (see the comment on toEmit's declaration above). Order is preserved —
+            // joinedBattleTags was built by the same in-order Baseline walk the old under-lock code used,
+            // only the Resolve() call itself moved.
+            var joined = joinedBattleTags.Select(_viewerResolver.Resolve).ToList();
+
+            // ONE payload object, sent to every current focused connection — no per-connection deltas.
+            var payload = new ViewersChangedDto(channelId, joined, left);
             foreach (var connectionId in connections)
             {
                 try

--- a/W3ChampionsChatService/FanOut/ViewersAccumulator.cs
+++ b/W3ChampionsChatService/FanOut/ViewersAccumulator.cs
@@ -54,10 +54,18 @@ public class ViewersAccumulator(
     // when computing the delta (FlushDue). Reads happen under _lock; FocusRegistry never calls back into
     // this accumulator, and every path here acquires this lock BEFORE FocusRegistry's, so there is no
     // lock-ordering cycle.
+    //
+    // The same invariant extends to _viewerResolver below: FlushDue calls ViewerResolver.Resolve (for each
+    // joined battleTag) while still holding _lock, which nests SessionRegistry's and ConnectionMapping's
+    // own locks inside this one. That nesting is safe for the same reason as FocusRegistry — SessionRegistry
+    // holds no reference back to FanOut/this accumulator, and ConnectionMapping is a dependency-free leaf —
+    // so neither can call back in and there is no cycle.
     private readonly FocusRegistry _focusRegistry = focusRegistry;
 
     // Resolves a joined battleTag into a full roster entry (display name + flair). Shared with
-    // ChatHub.FocusChannel so a join delta and an initial roster can never render differently.
+    // ChatHub.FocusChannel so a join delta and an initial roster can never render differently. Invoked from
+    // FlushDue WHILE _lock is held (see the field comment above) — its own SessionRegistry/ConnectionMapping
+    // locks are always the innermost in the nesting, never the outermost.
     private readonly Chats.ViewerResolver _viewerResolver = viewerResolver;
 
     // channelId -> the channel's accumulation window. Mutated only under _lock.

--- a/W3ChampionsChatService/FanOut/ViewersAccumulator.cs
+++ b/W3ChampionsChatService/FanOut/ViewersAccumulator.cs
@@ -42,7 +42,10 @@ namespace W3ChampionsChatService.FanOut;
 /// <para>Singleton (registered in <see cref="Startup"/>). Task 15 drives <see cref="FlushDue"/> from the
 /// 1s-granularity hosted flush service.</para>
 /// </summary>
-public class ViewersAccumulator(IHubContext<ChatHub> hubContext, FocusRegistry focusRegistry)
+public class ViewersAccumulator(
+    IHubContext<ChatHub> hubContext,
+    FocusRegistry focusRegistry,
+    Chats.ViewerResolver viewerResolver)
 {
     // The SignalR delivery channel — pushes the shared ViewersChanged batch to each focused connection.
     private readonly IHubContext<ChatHub> _hubContext = hubContext;
@@ -52,6 +55,10 @@ public class ViewersAccumulator(IHubContext<ChatHub> hubContext, FocusRegistry f
     // this accumulator, and every path here acquires this lock BEFORE FocusRegistry's, so there is no
     // lock-ordering cycle.
     private readonly FocusRegistry _focusRegistry = focusRegistry;
+
+    // Resolves a joined battleTag into a full roster entry (display name + flair). Shared with
+    // ChatHub.FocusChannel so a join delta and an initial roster can never render differently.
+    private readonly Chats.ViewerResolver _viewerResolver = viewerResolver;
 
     // channelId -> the channel's accumulation window. Mutated only under _lock.
     private readonly Dictionary<string, ChannelWindow> _windows = new Dictionary<string, ChannelWindow>();
@@ -121,14 +128,14 @@ public class ViewersAccumulator(IHubContext<ChatHub> hubContext, FocusRegistry f
                     continue;
                 }
 
-                var joined = new List<string>();
+                var joined = new List<ChannelViewerDto>();
                 var left = new List<string>();
                 foreach (var (battleTag, wasViewing) in window.Baseline)
                 {
                     var isViewing = IsCurrentlyViewingNoLock(channelId, battleTag);
                     if (isViewing && !wasViewing)
                     {
-                        joined.Add(battleTag);
+                        joined.Add(_viewerResolver.Resolve(battleTag));
                     }
                     else if (!isViewing && wasViewing)
                     {

--- a/W3ChampionsChatService/Protocol/ChannelViewerDto.cs
+++ b/W3ChampionsChatService/Protocol/ChannelViewerDto.cs
@@ -10,7 +10,8 @@ namespace W3ChampionsChatService.Protocol;
 /// <c>ChatHub.BuildSenderSnapshot</c> reads for message flair — so a user's roster avatar and their
 /// message avatar are the same value by construction, never merely by convention. NULL only for a
 /// viewer whose live session or connection entry vanished mid-call (a teardown race); clients render
-/// their default avatar for that case. Defaulted so existing 2-arg construction still compiles.
+/// their default avatar for that case. No default value — every construction site must decide
+/// explicitly whether the entry carries flair or is deliberately flairless (pass <c>null</c>).
 /// </para>
 /// </summary>
-public record ChannelViewerDto(string BattleTag, string Name, ChatProfile Profile = null);
+public record ChannelViewerDto(string BattleTag, string Name, ChatProfile Profile);

--- a/W3ChampionsChatService/Protocol/ChannelViewerDto.cs
+++ b/W3ChampionsChatService/Protocol/ChannelViewerDto.cs
@@ -1,7 +1,16 @@
+using W3ChampionsChatService.Domain;
+
 namespace W3ChampionsChatService.Protocol;
 
 /// <summary>
-/// Active-viewer roster entry for <see cref="FocusChannelResult"/> (Task 1) and later focus/roster
-/// tasks (Task 9) that reuse this shape.
+/// Active-viewer roster entry for <see cref="FocusChannelResult"/> and <see cref="ViewersChangedDto"/>.
+/// <para>
+/// <see cref="Profile"/> is the viewer's flair, resolved in-memory by
+/// <see cref="Chats.ViewerResolver"/> from the same <c>ConnectionMapping</c> entry that
+/// <c>ChatHub.BuildSenderSnapshot</c> reads for message flair — so a user's roster avatar and their
+/// message avatar are the same value by construction, never merely by convention. NULL only for a
+/// viewer whose live session or connection entry vanished mid-call (a teardown race); clients render
+/// their default avatar for that case. Defaulted so existing 2-arg construction still compiles.
+/// </para>
 /// </summary>
-public record ChannelViewerDto(string BattleTag, string Name);
+public record ChannelViewerDto(string BattleTag, string Name, ChatProfile Profile = null);

--- a/W3ChampionsChatService/Protocol/ChatJsonProtocol.cs
+++ b/W3ChampionsChatService/Protocol/ChatJsonProtocol.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace W3ChampionsChatService.Protocol;
+
+/// <summary>
+/// The hub's JSON payload contract, extracted from <c>Startup</c> as a named unit so it can be unit
+/// tested directly (see <c>ChatJsonProtocolTests</c>) instead of only through a DI bootstrap.
+/// </summary>
+public static class ChatJsonProtocol
+{
+    /// <summary>
+    /// Omits null properties from every hub payload.
+    /// <para>
+    /// <see cref="JsonIgnoreCondition.WhenWritingNull"/> — deliberately NOT
+    /// <c>WhenWritingDefault</c>, which would also drop <c>false</c> and <c>0</c>. Those are
+    /// meaningful for flair: <c>isClassic: false</c> and <c>race: 0</c> (RnD) are real values the
+    /// client renders, and dropping them would silently change avatars.
+    /// </para>
+    /// <para>
+    /// Safe for the launcher: every flair field is already declared optional in
+    /// <c>chat-protocol.types.ts</c> and every client read path uses optional chaining with a
+    /// fallback, so an absent key and an explicit null are indistinguishable there.
+    /// </para>
+    /// </summary>
+    public static void Configure(JsonHubProtocolOptions options)
+    {
+        options.PayloadSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+    }
+}

--- a/W3ChampionsChatService/Protocol/ChatJsonProtocol.cs
+++ b/W3ChampionsChatService/Protocol/ChatJsonProtocol.cs
@@ -22,6 +22,17 @@ public static class ChatJsonProtocol
     /// <c>chat-protocol.types.ts</c> and every client read path uses optional chaining with a
     /// fallback, so an absent key and an explicit null are indistinguishable there.
     /// </para>
+    /// <para>
+    /// Rule for new nullable wire fields: because this omits null properties, a <c>null</c> reaching
+    /// the launcher is indistinguishable from an absent key. If a field's null value is meaningful
+    /// (not just "no value"), either pin it with
+    /// <c>[property: JsonIgnore(Condition = JsonIgnoreCondition.Never)]</c> — as
+    /// <see cref="MentionInboxEntryDto.ReadAt"/> is pinned, since null there means "unread" — or make
+    /// sure the client reads it with a truthy/nullish check rather than a strict <c>=== null</c>.
+    /// This is not a hypothetical: <c>MentionInboxEntryDto.ReadAt</c> shipped unpinned once and the
+    /// launcher's strict <c>=== null</c> checks silently broke the unread badge and mention
+    /// acknowledgement.
+    /// </para>
     /// </summary>
     public static void Configure(JsonHubProtocolOptions options)
     {

--- a/W3ChampionsChatService/Protocol/MentionInboxEntryDto.cs
+++ b/W3ChampionsChatService/Protocol/MentionInboxEntryDto.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 
 namespace W3ChampionsChatService.Protocol;
 
@@ -18,4 +19,9 @@ public record MentionInboxEntryDto(
     string AuthorName,
     string Excerpt,
     DateTime CreatedAt,
+    // ChatJsonProtocol.Configure omits null properties from EVERY hub payload (WhenWritingNull), but
+    // a null ReadAt is not an absence here — it IS the "unread" state. Pinned to always serialize
+    // (even as null) so the client can keep using a presence/nullness check instead of every reader
+    // having to treat "key missing" and "key null" as the same thing.
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     DateTime? ReadAt);

--- a/W3ChampionsChatService/Protocol/ViewersChangedDto.cs
+++ b/W3ChampionsChatService/Protocol/ViewersChangedDto.cs
@@ -8,9 +8,11 @@ namespace W3ChampionsChatService.Protocol;
 /// <see cref="FanOut.ViewersAccumulator"/>, and the SAME payload object is sent to EVERY current focused
 /// connection of the channel — there are no per-connection deltas (C3-plan decision 5).
 /// <para>
-/// <see cref="Joined"/>/<see cref="Left"/> are battleTags (NOT display names): the accumulator's only
-/// state sources are <see cref="FanOut.FocusRegistry"/> and the emit <c>IHubContext</c> — it never
-/// resolves names (that is <c>FocusChannel</c>'s job for the initial roster). A battleTag whose viewing
+/// <see cref="Left"/> entries are bare battleTags — removing a viewer needs no more than that.
+/// <see cref="Joined"/> entries are full <see cref="ChannelViewerDto"/>s carrying display name and
+/// flair, resolved through the same <see cref="Chats.ViewerResolver"/> <c>FocusChannel</c> uses for
+/// the initial roster, so a viewer's rendering is identical whether the client learned about them
+/// from a focus response or from a later join delta. A battleTag whose viewing
 /// state at flush equals its state at the START of the window appears in NEITHER list (idempotent — a
 /// join+leave or leave+rejoin flap within the window cancels). Clients apply the delta as an idempotent
 /// SET operation (union <see cref="Joined"/>, subtract <see cref="Left"/>), so a battleTag redundantly
@@ -20,5 +22,5 @@ namespace W3ChampionsChatService.Protocol;
 /// </summary>
 public record ViewersChangedDto(
     string ChannelId,
-    IReadOnlyList<string> Joined,
+    IReadOnlyList<ChannelViewerDto> Joined,
     IReadOnlyList<string> Left);

--- a/W3ChampionsChatService/Protocol/ViewersChangedDto.cs
+++ b/W3ChampionsChatService/Protocol/ViewersChangedDto.cs
@@ -12,12 +12,14 @@ namespace W3ChampionsChatService.Protocol;
 /// <see cref="Joined"/> entries are full <see cref="ChannelViewerDto"/>s carrying display name and
 /// flair, resolved through the same <see cref="Chats.ViewerResolver"/> <c>FocusChannel</c> uses for
 /// the initial roster, so a viewer's rendering is identical whether the client learned about them
-/// from a focus response or from a later join delta. A battleTag whose viewing
-/// state at flush equals its state at the START of the window appears in NEITHER list (idempotent — a
-/// join+leave or leave+rejoin flap within the window cancels). Clients apply the delta as an idempotent
-/// SET operation (union <see cref="Joined"/>, subtract <see cref="Left"/>), so a battleTag redundantly
-/// present in both the initial <c>FocusChannel</c> roster and a subsequent <see cref="Joined"/> is
-/// harmless.
+/// from a focus response or from a later join delta.
+/// </para>
+/// <para>
+/// A battleTag whose viewing state at flush equals its state at the START of the window appears in
+/// NEITHER list (idempotent — a join+leave or leave+rejoin flap within the window cancels). Clients
+/// apply the delta as an idempotent SET operation (union <see cref="Joined"/>, subtract <see cref="Left"/>),
+/// so a battleTag redundantly present in both the initial <c>FocusChannel</c> roster and a subsequent
+/// <see cref="Joined"/> is harmless.
 /// </para>
 /// </summary>
 public record ViewersChangedDto(

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -174,8 +174,10 @@ public class Startup
         services.AddSingleton<ChannelCreationRateLimiter>();
 
         services.AddSingleton<ConnectionMapping>();
-        // Singleton: holds only the singleton ConnectionMapping + ISessionRegistry. Consumed by
-        // ViewersAccumulator; ChatHub builds its own equivalent instance (see ChatHub.cs).
+        // Singleton: holds only the singleton ConnectionMapping + ISessionRegistry. Consumed by BOTH
+        // ViewersAccumulator and ChatHub (ctor-injected, PR44) — the SAME instance, which is what
+        // guarantees an initial roster and a ViewersChanged join delta can never render a viewer
+        // differently.
         services.AddSingleton<ViewerResolver>();
         // Reconciles the live mute cache from every ban WRITE path (hub + REST controller).
         // Singleton: it only holds the singleton ConnectionMapping + IHubContext<ChatHub>.

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -51,7 +51,8 @@ public class Startup
             // ChatHub.Messaging.cs — defense-in-depth against a client sending an oversized frame to
             // force needless buffering/allocation ahead of the app-level validation.
             options.MaximumReceiveMessageSize = 16 * 1024;
-        });
+        })
+        .AddJsonProtocol(ChatJsonProtocol.Configure);
 
         // D9 (C6 Task 3): registers IHttpClientFactory — WebsiteBackendRepository is rebuilt on it,
         // killing the per-call `new HttpClient()` socket-exhaustion anti-pattern (a fresh HttpClient

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -173,6 +173,9 @@ public class Startup
         services.AddSingleton<ChannelCreationRateLimiter>();
 
         services.AddSingleton<ConnectionMapping>();
+        // Singleton: holds only the singleton ConnectionMapping + ISessionRegistry. Consumed by
+        // ViewersAccumulator; ChatHub builds its own equivalent instance (see ChatHub.cs).
+        services.AddSingleton<ViewerResolver>();
         // Reconciles the live mute cache from every ban WRITE path (hub + REST controller).
         // Singleton: it only holds the singleton ConnectionMapping + IHubContext<ChatHub>.
         services.AddSingleton<MuteReconciliationService>();

--- a/docs/superpowers/plans/2026-08-09-roster-flair-enrichment-plan-a.md
+++ b/docs/superpowers/plans/2026-08-09-roster-flair-enrichment-plan-a.md
@@ -1,0 +1,1028 @@
+# Roster Flair Enrichment (Plan A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a chat channel's viewer roster carry each viewer's flair, so a user renders with their real avatar the moment they appear in the user list instead of only after they send a message.
+
+**Architecture:** `FocusChannel` already resolves each roster entry's display name via an in-memory `ISessionRegistry.GetByBattleTag` lookup. A new `ViewerResolver` service extends that same lookup to also read the viewer's `ChatUser` out of `ConnectionMapping` and map it to a `ChatProfile` — no Mongo read, no website-backend call, and identical by construction to the flair that user's own messages carry. Both `FocusChannel` (initial roster) and `ViewersAccumulator` (roster deltas) build their viewer DTOs through that one resolver. The client stores flair in a user-keyed store slice fed by live sources only, and `ChatUserListPanel` reads it instead of scavenging flair out of cached messages.
+
+**Tech Stack:** C# / .NET 8, ASP.NET Core SignalR, NUnit + Moq + Testcontainers (chat-service); TypeScript, React, easy-peasy (launcher-e).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md`. This plan implements §3.1 and §4 only. Live propagation (§3.2, §3.3) is Plan B and is explicitly out of scope here.
+- **Worktrees:** chat-service work happens in `C:\Users\Marco\git_projects\w3champions\.worktrees\chat-service-roster-flair`; launcher-e work in `C:\Users\Marco\git_projects\w3champions\.worktrees\launcher-e-roster-flair`. Both are on branch `feat/roster-flair-enrichment`.
+- **Wire compatibility:** shape-changing wire edits are permitted. The launcher force-updates before it can connect, so `Joined: string[]` → `Joined: ChannelViewerDto[]` is acceptable. Do not add legacy-compat duplicate fields.
+- **Single mapper:** all `ChatUser` → `ChatProfile` conversion goes through `ChatProfileMapper.FromChatUser`. Never hand-roll the mapping; the roster and `sender.flair` must not be able to drift.
+- **No DB on the roster path:** `ViewerResolver` must not touch `UserDirectoryRepository`, Mongo, or `IWebsiteBackendRepository`. Roster entries resolve from in-memory registries only.
+- **launcher-e has no test runner.** Do not add one and do not write frontend tests. Verification there is `npm run type-check`, `npm run lint:prod`, `npm run dprint`, `npm run check:i18n`.
+- **Docker must be running** for the chat-service suite (Testcontainers spins up Mongo).
+- **Baseline (verified 2026-08-09):** chat-service 1319 passed / 0 failed; launcher-e type-check, lint:prod, dprint all clean. Any deviation is a regression you introduced.
+- **Shell note:** the worktree-isolated session resets the shell cwd back to the chat-service worktree after each command, and rejects compound commands containing redirects. Re-`cd` at the start of every command and keep commands plain.
+
+---
+
+## File Structure
+
+**chat-service** (`.worktrees/chat-service-roster-flair`)
+
+| File | Responsibility |
+|---|---|
+| `W3ChampionsChatService/Protocol/ChannelViewerDto.cs` | *Modify.* Roster entry wire shape; gains `Profile`. |
+| `W3ChampionsChatService/Chats/ViewerResolver.cs` | **Create.** The single place that turns a roster battleTag into a `ChannelViewerDto`. Sole owner of the session→connection→`ChatUser`→`ChatProfile` hop. |
+| `W3ChampionsChatService/Chats/ChatHub.Channels.cs` | *Modify.* `FocusChannel` builds its roster via `ViewerResolver`; `ResolveViewerName` is deleted. |
+| `W3ChampionsChatService/Protocol/ChatJsonProtocol.cs` | **Create.** Named, testable SignalR JSON payload configuration (null omission). |
+| `W3ChampionsChatService/Startup.cs` | *Modify.* Register `ViewerResolver`; apply `ChatJsonProtocol.Configure`. |
+| `W3ChampionsChatService/Protocol/ViewersChangedDto.cs` | *Modify.* `Joined` becomes `IReadOnlyList<ChannelViewerDto>`. |
+| `W3ChampionsChatService/FanOut/ViewersAccumulator.cs` | *Modify.* Resolves joined entries through `ViewerResolver` at flush. |
+| `W3ChampionsChatService.Tests/ChatHubFocusTests.cs` | *Modify.* Roster-flair coverage. |
+| `W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs` | **Create.** Pins null-omitting serialization. |
+| `W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs` | *Modify.* Joined-carries-flair coverage. |
+| `W3ChampionsChatService.Tests/ViewersAccumulatorTestFactory.cs` | *Modify.* Thread the new dependency through the one shared place. |
+
+**launcher-e** (`.worktrees/launcher-e-roster-flair`)
+
+| File | Responsibility |
+|---|---|
+| `src/types/chat-protocol.types.ts` | *Modify.* `IChannelViewerDto.profile`; `IViewersChangedDto.joined` becomes objects. |
+| `src/models/chat-core.ts` | *Modify.* `flairByBattleTag` store slice + its writers. |
+| `src/components/chat/ChatUserListPanel.tsx` | *Modify.* Read the store slice; delete the message-scavenging memo. |
+| `src/helpers/chat-ui.helper.ts` | *Modify.* Doc-comment correction on `viewerToChatUser` only. |
+
+---
+
+### Task 1: `ViewerResolver` and roster flair on `FocusChannel`
+
+**Files:**
+- Create: `W3ChampionsChatService/Chats/ViewerResolver.cs`
+- Modify: `W3ChampionsChatService/Protocol/ChannelViewerDto.cs`
+- Modify: `W3ChampionsChatService/Chats/ChatHub.Channels.cs` (roster build at lines 116-118; delete `ResolveViewerName` at lines 202-206)
+- Modify: `W3ChampionsChatService/Startup.cs` (register `ViewerResolver`)
+- Test: `W3ChampionsChatService.Tests/ChatHubFocusTests.cs`
+
+**Interfaces:**
+- Consumes: `ISessionRegistry.GetByBattleTag(string) : ChatSession`; `ChatSession.ConnectionId`, `ChatSession.Identity`; `ConnectionMapping.GetUser(string connectionId) : ChatUser`; `ChatProfileMapper.FromChatUser(ChatUser) : ChatProfile`.
+- Produces:
+  - `record ChannelViewerDto(string BattleTag, string Name, ChatProfile Profile = null)`
+  - `class ViewerResolver(ISessionRegistry sessionRegistry, ConnectionMapping connections)` with `ChannelViewerDto Resolve(string battleTag)`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `W3ChampionsChatService.Tests/ChatHubFocusTests.cs`, immediately before the closing `}` of the class:
+
+```csharp
+    [Test]
+    public async Task FocusChannel_Roster_CarriesEachViewersFlair()
+    {
+        var channel = await CreateChannel();
+
+        RegisterSession("conn-peter", BattleTag, "Peter");
+        RegisterSession("conn-alice", OtherBattleTag, "Alice");
+        SeedMembership("conn-peter", channel.Id, BattleTag);
+        SeedMembership("conn-alice", channel.Id, OtherBattleTag);
+
+        // ConnectionMapping is what BuildSenderSnapshot reads for message flair, so seeding it here
+        // pins that the roster resolves from the SAME source — the two can never disagree.
+        _connectionMapping.RegisterUser("conn-alice", new ChatUser(
+            OtherBattleTag,
+            false,
+            "W3C",
+            new ProfilePicture { Race = AvatarCategory.NE, PictureId = 7, IsClassic = false },
+            new ChatColor("chat_color_purple"),
+            [new ChatIcon("chat_icon_crown")]));
+
+        var aliceHub = BuildHub("conn-alice");
+        await aliceHub.FocusChannel(channel.Id);
+
+        var peterHub = BuildHub("conn-peter");
+        var result = await peterHub.FocusChannel(channel.Id);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        var alice = result.Viewers.Single(v => v.BattleTag == OtherBattleTag);
+        Assert.IsNotNull(alice.Profile, "A roster entry for an online, focused viewer must carry flair");
+        Assert.AreEqual(AvatarCategory.NE, alice.Profile.ProfilePicture.Race);
+        Assert.AreEqual(7, alice.Profile.ProfilePicture.PictureId);
+        Assert.AreEqual("W3C", alice.Profile.ClanId);
+        Assert.AreEqual("chat_color_purple", alice.Profile.ChatColor.ColorId);
+        Assert.AreEqual("chat_icon_crown", alice.Profile.ChatIcons.Single().IconId);
+    }
+
+    [Test]
+    public async Task FocusChannel_Roster_ViewerWithNoConnectionMappingEntry_YieldsNullProfile_NotAnException()
+    {
+        // Teardown race: a session exists but its ConnectionMapping entry is already gone. The entry
+        // must survive with a null Profile (the client falls back to its default avatar) rather than
+        // being dropped or throwing — mirroring the pre-existing battleTag name fallback.
+        var channel = await CreateChannel();
+
+        RegisterSession("conn-peter", BattleTag, "Peter");
+        SeedMembership("conn-peter", channel.Id, BattleTag);
+
+        var hub = BuildHub("conn-peter");
+        var result = await hub.FocusChannel(channel.Id);
+
+        Assert.AreEqual(ChatResultCode.Ok, result.Code);
+        var peter = result.Viewers.Single();
+        Assert.AreEqual(BattleTag, peter.BattleTag);
+        Assert.AreEqual("Peter", peter.Name, "The display name must still resolve from the live session");
+        Assert.IsNull(peter.Profile);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --filter "FullyQualifiedName~ChatHubFocusTests.FocusChannel_Roster" --nologo
+```
+
+Expected: FAIL to compile — `'ChannelViewerDto' does not contain a definition for 'Profile'`.
+
+- [ ] **Step 3: Add `Profile` to the roster DTO**
+
+Replace the entire contents of `W3ChampionsChatService/Protocol/ChannelViewerDto.cs`:
+
+```csharp
+using W3ChampionsChatService.Domain;
+
+namespace W3ChampionsChatService.Protocol;
+
+/// <summary>
+/// Active-viewer roster entry for <see cref="FocusChannelResult"/> and <see cref="ViewersChangedDto"/>.
+/// <para>
+/// <see cref="Profile"/> is the viewer's flair, resolved in-memory by
+/// <see cref="Chats.ViewerResolver"/> from the same <c>ConnectionMapping</c> entry that
+/// <c>ChatHub.BuildSenderSnapshot</c> reads for message flair — so a user's roster avatar and their
+/// message avatar are the same value by construction, never merely by convention. NULL only for a
+/// viewer whose live session or connection entry vanished mid-call (a teardown race); clients render
+/// their default avatar for that case. Defaulted so existing 2-arg construction still compiles.
+/// </para>
+/// </summary>
+public record ChannelViewerDto(string BattleTag, string Name, ChatProfile Profile = null);
+```
+
+- [ ] **Step 4: Create the resolver**
+
+Create `W3ChampionsChatService/Chats/ViewerResolver.cs`:
+
+```csharp
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
+
+namespace W3ChampionsChatService.Chats;
+
+/// <summary>
+/// Builds a <see cref="ChannelViewerDto"/> for a roster battleTag. The SINGLE place that knows the
+/// session → connection → <see cref="ChatUser"/> → <see cref="ChatProfile"/> hop, shared by
+/// <c>ChatHub.FocusChannel</c> (initial roster) and <see cref="FanOut.ViewersAccumulator"/> (roster
+/// deltas) so the two can never construct roster entries differently.
+/// <para>
+/// PURELY IN-MEMORY by design: a roster entry is by definition an online AND focused viewer, so its
+/// <see cref="ChatUser"/> is already cached in <see cref="ConnectionMapping"/> from that user's own
+/// connect. This must never grow a Mongo or website-backend read — <c>FocusChannel</c> is a hot path
+/// and the roster can be several hundred entries.
+/// </para>
+/// <para>
+/// Degradation is per-field and never throws: a missing session falls back to the battleTag as the
+/// display name (pre-existing behaviour, preserved), and a missing <see cref="ChatUser"/> yields a
+/// null <see cref="ChannelViewerDto.Profile"/>. Dropping the entry would be worse — the viewer would
+/// silently vanish from the roster.
+/// </para>
+/// </summary>
+public class ViewerResolver(ISessionRegistry sessionRegistry, ConnectionMapping connections)
+{
+    private readonly ISessionRegistry _sessionRegistry = sessionRegistry;
+    private readonly ConnectionMapping _connections = connections;
+
+    public ChannelViewerDto Resolve(string battleTag)
+    {
+        var session = _sessionRegistry.GetByBattleTag(battleTag);
+        if (session == null)
+        {
+            return new ChannelViewerDto(battleTag, battleTag, null);
+        }
+
+        var name = session.Identity?.Name ?? battleTag;
+        var chatUser = _connections.GetUser(session.ConnectionId);
+
+        return new ChannelViewerDto(
+            battleTag,
+            name,
+            chatUser == null ? null : ChatProfileMapper.FromChatUser(chatUser));
+    }
+}
+```
+
+- [ ] **Step 5: Use the resolver in `FocusChannel` and delete the old helper**
+
+In `W3ChampionsChatService/Chats/ChatHub.Channels.cs`, replace the roster build (currently lines 116-118):
+
+```csharp
+        var viewers = _focusRegistry.GetRoster(channelId)
+            .Select(rosterBattleTag => new ChannelViewerDto(rosterBattleTag, ResolveViewerName(rosterBattleTag)))
+            .ToList();
+```
+
+with:
+
+```csharp
+        var viewers = _focusRegistry.GetRoster(channelId)
+            .Select(_viewerResolver.Resolve)
+            .ToList();
+```
+
+Then delete this method entirely (currently lines 202-206) — `_viewerResolver` subsumes it and it has no other call site:
+
+```csharp
+    private string ResolveViewerName(string battleTag)
+    {
+        var session = _sessionRegistry.GetByBattleTag(battleTag);
+        return session?.Identity?.Name ?? battleTag;
+    }
+```
+
+- [ ] **Step 6: Give `ChatHub` a resolver WITHOUT changing its constructor signature**
+
+`ChatHub` already receives `connections` and `sessionRegistry` as primary-constructor parameters (lines 24 and 27), so the resolver can be built in a field initializer from those existing parameters. **Do not add a constructor parameter** — 31 test files construct `new ChatHub(...)`, and changing the signature would churn every one of them for no behavioural gain.
+
+In `W3ChampionsChatService/Chats/ChatHub.cs`, add this field immediately after `_sessionRegistry` (line 109):
+
+```csharp
+    // Built from the primary-constructor params rather than injected, deliberately: adding a ctor
+    // parameter would force an edit to all 31 test files that construct a ChatHub. ViewerResolver is
+    // stateless (it holds only references to the two singletons above), so this instance and the
+    // DI-registered singleton the ViewersAccumulator receives are interchangeable.
+    private readonly ViewerResolver _viewerResolver = new(sessionRegistry, connections);
+```
+
+- [ ] **Step 7: Register the resolver for `ViewersAccumulator`**
+
+Task 3 injects `ViewerResolver` into `ViewersAccumulator` through DI, which needs a registration. In `W3ChampionsChatService/Startup.cs`, immediately after the `ConnectionMapping` registration (line 175):
+
+```csharp
+        // Singleton: holds only the singleton ConnectionMapping + ISessionRegistry. Consumed by
+        // ViewersAccumulator; ChatHub builds its own equivalent instance (see ChatHub.cs).
+        services.AddSingleton<ViewerResolver>();
+```
+
+- [ ] **Step 8: Run the new tests to verify they pass**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --filter "FullyQualifiedName~ChatHubFocusTests.FocusChannel_Roster" --nologo
+```
+
+Expected: `Passed! - Failed: 0, Passed: 2`
+
+- [ ] **Step 9: Run the full suite for regressions**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --nologo
+```
+
+Expected: `Failed: 0, Passed: 1321` (the 1319 baseline plus the 2 new tests).
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+git add W3ChampionsChatService/Chats/ViewerResolver.cs W3ChampionsChatService/Protocol/ChannelViewerDto.cs W3ChampionsChatService/Chats/ChatHub.Channels.cs W3ChampionsChatService/Chats/ChatHub.cs W3ChampionsChatService/Startup.cs W3ChampionsChatService.Tests
+git commit -m "feat(chat): carry viewer flair on the FocusChannel roster"
+```
+
+---
+
+### Task 2: Null-omitting wire serialization
+
+**Files:**
+- Create: `W3ChampionsChatService/Protocol/ChatJsonProtocol.cs`
+- Modify: `W3ChampionsChatService/Startup.cs` (the `AddSignalR` block, lines 41-54)
+- Test: `W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `static class ChatJsonProtocol` with `static void Configure(JsonHubProtocolOptions options)`.
+
+Extracting the configuration into a named static rather than an inline lambda in `Startup` is deliberate: it makes the wire contract directly unit-testable without bootstrapping the DI container.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using NUnit.Framework;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Protocol;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Pins the hub's JSON payload contract. Flair is the dominant payload on the wire (a roster can be
+/// several hundred entries, each carrying a ChatProfile), and most users have null clan/colour/icons
+/// and null rank — with nulls serialized, the KEY NAMES alone dominate the payload. Null omission is
+/// therefore load-bearing for payload size, not cosmetic.
+/// </summary>
+public class ChatJsonProtocolTests
+{
+    private static JsonSerializerOptions ConfiguredOptions()
+    {
+        var options = new JsonHubProtocolOptions();
+        ChatJsonProtocol.Configure(options);
+        return options.PayloadSerializerOptions;
+    }
+
+    [Test]
+    public void Configure_OmitsNullFlairFields()
+    {
+        var viewer = new ChannelViewerDto("peter#123", "Peter", new ChatProfile
+        {
+            ProfilePicture = new ProfilePicture { Race = AvatarCategory.HU, PictureId = 2, IsClassic = false },
+        });
+
+        var json = JsonSerializer.Serialize(viewer, ConfiguredOptions());
+
+        Assert.That(json, Does.Not.Contain("clanId"), "A null clanId must not occupy wire bytes");
+        Assert.That(json, Does.Not.Contain("chatColor"));
+        Assert.That(json, Does.Not.Contain("chatIcons"));
+        Assert.That(json, Does.Not.Contain("leagueName"));
+        Assert.That(json, Does.Not.Contain("gamesPlayed"));
+    }
+
+    [Test]
+    public void Configure_PreservesNonNullFields()
+    {
+        var viewer = new ChannelViewerDto("peter#123", "Peter", new ChatProfile
+        {
+            ClanId = "W3C",
+            ProfilePicture = new ProfilePicture { Race = AvatarCategory.NE, PictureId = 7, IsClassic = true },
+            ChatColor = new ChatColor("chat_color_purple"),
+        });
+
+        var json = JsonSerializer.Serialize(viewer, ConfiguredOptions());
+
+        Assert.That(json, Does.Contain("\"clanId\":\"W3C\""));
+        Assert.That(json, Does.Contain("\"pictureId\":7"));
+        Assert.That(json, Does.Contain("\"isClassic\":true"));
+        Assert.That(json, Does.Contain("chat_color_purple"));
+    }
+
+    [Test]
+    public void Configure_OmittingNullsDoesNotDropFalseOrZero()
+    {
+        // WhenWritingNull must not be confused with WhenWritingDefault: `isClassic: false` and
+        // `pictureId: 0` are MEANINGFUL values the client renders, not absences.
+        var viewer = new ChannelViewerDto("peter#123", "Peter", new ChatProfile
+        {
+            ProfilePicture = new ProfilePicture { Race = AvatarCategory.RnD, PictureId = 0, IsClassic = false },
+        });
+
+        var json = JsonSerializer.Serialize(viewer, ConfiguredOptions());
+
+        Assert.That(json, Does.Contain("\"pictureId\":0"));
+        Assert.That(json, Does.Contain("\"isClassic\":false"));
+        Assert.That(json, Does.Contain("\"race\":0"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --filter "FullyQualifiedName~ChatJsonProtocolTests" --nologo
+```
+
+Expected: FAIL to compile — `The name 'ChatJsonProtocol' does not exist in the current context`.
+
+- [ ] **Step 3: Create the configuration**
+
+Create `W3ChampionsChatService/Protocol/ChatJsonProtocol.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace W3ChampionsChatService.Protocol;
+
+/// <summary>
+/// The hub's JSON payload contract, extracted from <c>Startup</c> as a named unit so it can be unit
+/// tested directly (see <c>ChatJsonProtocolTests</c>) instead of only through a DI bootstrap.
+/// </summary>
+public static class ChatJsonProtocol
+{
+    /// <summary>
+    /// Omits null properties from every hub payload.
+    /// <para>
+    /// <see cref="JsonIgnoreCondition.WhenWritingNull"/> — deliberately NOT
+    /// <c>WhenWritingDefault</c>, which would also drop <c>false</c> and <c>0</c>. Those are
+    /// meaningful for flair: <c>isClassic: false</c> and <c>race: 0</c> (RnD) are real values the
+    /// client renders, and dropping them would silently change avatars.
+    /// </para>
+    /// <para>
+    /// Safe for the launcher: every flair field is already declared optional in
+    /// <c>chat-protocol.types.ts</c> and every client read path uses optional chaining with a
+    /// fallback, so an absent key and an explicit null are indistinguishable there.
+    /// </para>
+    /// </summary>
+    public static void Configure(JsonHubProtocolOptions options)
+    {
+        options.PayloadSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+    }
+}
+```
+
+- [ ] **Step 4: Apply it in `Startup`**
+
+In `W3ChampionsChatService/Startup.cs`, change the `AddSignalR` registration so the chained
+`AddJsonProtocol` call applies the configuration. The closing line of the block (currently line 54) becomes:
+
+```csharp
+        })
+        .AddJsonProtocol(ChatJsonProtocol.Configure);
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --filter "FullyQualifiedName~ChatJsonProtocolTests" --nologo
+```
+
+Expected: `Passed! - Failed: 0, Passed: 3`
+
+- [ ] **Step 6: Run the full suite**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --nologo
+```
+
+Expected: `Failed: 0, Passed: 1324`
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+git add W3ChampionsChatService/Protocol/ChatJsonProtocol.cs W3ChampionsChatService/Startup.cs W3ChampionsChatService.Tests/ChatJsonProtocolTests.cs
+git commit -m "feat(chat): omit null fields from hub JSON payloads"
+```
+
+---
+
+### Task 3: `ViewersChanged` joins carry flair
+
+**Files:**
+- Modify: `W3ChampionsChatService/Protocol/ViewersChangedDto.cs`
+- Modify: `W3ChampionsChatService/FanOut/ViewersAccumulator.cs` (constructor at line 45; joined build at lines 123-133)
+- Modify: `W3ChampionsChatService.Tests/ViewersAccumulatorTestFactory.cs`
+- Test: `W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs`
+
+**Interfaces:**
+- Consumes: `ViewerResolver.Resolve(string) : ChannelViewerDto` from Task 1.
+- Produces: `record ViewersChangedDto(string ChannelId, IReadOnlyList<ChannelViewerDto> Joined, IReadOnlyList<string> Left)`.
+
+`Left` stays a `string[]` — removing a viewer needs only their battleTag, and sending flair for someone who just left would be pure waste.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs`, immediately before the closing `}` of the class:
+
+```csharp
+    [Test]
+    public async Task FlushDue_JoinedEntries_CarryFlairAndDisplayName()
+    {
+        // This test needs SEEDED registries so the resolver has flair to find, so it builds its own
+        // accumulator rather than using NewAccumulator() (which wires empty ones).
+        var harness = new HubPushCaptureHarness();
+        var focus = new FocusRegistry();
+        var sessions = new SessionRegistry();
+        var connections = new ConnectionMapping();
+        var accumulator = new ViewersAccumulator(
+            harness.HubContext, focus, new ViewerResolver(sessions, connections));
+
+        const string joiner = "alice#1";
+
+        sessions.Register("conn-a", new W3CUserAuthentication { BattleTag = joiner, Name = "Alice" }, null);
+        connections.RegisterUser("conn-a", new ChatUser(
+            joiner,
+            false,
+            "W3C",
+            new ProfilePicture { Race = AvatarCategory.UD, PictureId = 4, IsClassic = false },
+            new ChatColor("chat_color_gold"),
+            [new ChatIcon("chat_icon_star")]));
+
+        accumulator.RecordChange(ChannelId, joiner, T0);
+        focus.Focus("conn-a", ChannelId, joiner);
+
+        await accumulator.FlushDue(T0 + Flush);
+
+        var batch = ViewersChangedFor(harness, "conn-a").Single();
+        var joined = batch.Joined.Single();
+
+        Assert.AreEqual(joiner, joined.BattleTag);
+        Assert.AreEqual("Alice", joined.Name, "A join must carry the display name, not just the battleTag");
+        Assert.IsNotNull(joined.Profile, "A join must carry flair so the roster never renders a default avatar");
+        Assert.AreEqual(AvatarCategory.UD, joined.Profile.ProfilePicture.Race);
+        Assert.AreEqual(4, joined.Profile.ProfilePicture.PictureId);
+        Assert.AreEqual("chat_color_gold", joined.Profile.ChatColor.ColorId);
+    }
+```
+
+If `ViewersAccumulatorTests.cs` lacks any of these usings, add them: `W3ChampionsChatService.Authentication`, `W3ChampionsChatService.Chats`, `W3ChampionsChatService.Domain`, `W3ChampionsChatService.Sessions`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --filter "FullyQualifiedName~ViewersAccumulatorTests.FlushDue_JoinedEntries_CarryFlairAndDisplayName" --nologo
+```
+
+Expected: FAIL to compile — the `ViewersAccumulator` constructor takes 2 arguments, not 3.
+
+- [ ] **Step 3: Change the DTO**
+
+In `W3ChampionsChatService/Protocol/ViewersChangedDto.cs`, replace the record declaration (lines 21-24):
+
+```csharp
+public record ViewersChangedDto(
+    string ChannelId,
+    IReadOnlyList<ChannelViewerDto> Joined,
+    IReadOnlyList<string> Left);
+```
+
+In the same file's doc comment, replace this sentence:
+
+```
+/// <see cref="Joined"/>/<see cref="Left"/> are battleTags (NOT display names): the accumulator's only
+/// state sources are <see cref="FanOut.FocusRegistry"/> and the emit <c>IHubContext</c> — it never
+/// resolves names (that is <c>FocusChannel</c>'s job for the initial roster).
+```
+
+with:
+
+```
+/// <see cref="Left"/> entries are bare battleTags — removing a viewer needs no more than that.
+/// <see cref="Joined"/> entries are full <see cref="ChannelViewerDto"/>s carrying display name and
+/// flair, resolved through the same <see cref="Chats.ViewerResolver"/> <c>FocusChannel</c> uses for
+/// the initial roster, so a viewer's rendering is identical whether the client learned about them
+/// from a focus response or from a later join delta.
+```
+
+- [ ] **Step 4: Resolve joined entries in the accumulator**
+
+In `W3ChampionsChatService/FanOut/ViewersAccumulator.cs`, change the class declaration (line 45):
+
+```csharp
+public class ViewersAccumulator(
+    IHubContext<ChatHub> hubContext,
+    FocusRegistry focusRegistry,
+    Chats.ViewerResolver viewerResolver)
+```
+
+Add a backing field alongside the existing `_focusRegistry` field:
+
+```csharp
+    // Resolves a joined battleTag into a full roster entry (display name + flair). Shared with
+    // ChatHub.FocusChannel so a join delta and an initial roster can never render differently.
+    private readonly Chats.ViewerResolver _viewerResolver = viewerResolver;
+```
+
+Change the joined accumulator declaration (line 123) from:
+
+```csharp
+                var joined = new List<string>();
+```
+
+to:
+
+```csharp
+                var joined = new List<ChannelViewerDto>();
+```
+
+and the join branch (line 128) from:
+
+```csharp
+                        joined.Add(battleTag);
+```
+
+to:
+
+```csharp
+                        joined.Add(_viewerResolver.Resolve(battleTag));
+```
+
+Ensure the file has `using W3ChampionsChatService.Protocol;`.
+
+- [ ] **Step 5: Update the shared test factory**
+
+In `W3ChampionsChatService.Tests/ViewersAccumulatorTestFactory.cs`, replace the factory method:
+
+```csharp
+    internal static ViewersAccumulator CreateIgnored() =>
+        new ViewersAccumulator(
+            new HubPushCaptureHarness().HubContext,
+            new FocusRegistry(),
+            new W3ChampionsChatService.Chats.ViewerResolver(
+                new W3ChampionsChatService.Sessions.SessionRegistry(),
+                new W3ChampionsChatService.Chats.ConnectionMapping()));
+```
+
+- [ ] **Step 6: Update the existing accumulator test helpers**
+
+Two helpers in `W3ChampionsChatService.Tests/ViewersAccumulatorTests.cs` need adjusting. Both changes are designed so that **no existing test body changes**.
+
+First, `NewAccumulator()` (lines 51-58) gains a resolver over empty registries — the existing tests assert on battleTags only, so a null `Profile` is correct for them:
+
+```csharp
+    private static (HubPushCaptureHarness harness, FocusRegistry focus, ViewersAccumulator accumulator)
+        NewAccumulator()
+    {
+        var harness = new HubPushCaptureHarness();
+        var focus = new FocusRegistry();
+        var accumulator = new ViewersAccumulator(
+            harness.HubContext, focus, new ViewerResolver(new SessionRegistry(), new ConnectionMapping()));
+        return (harness, focus, accumulator);
+    }
+```
+
+Second, the `Contains` helper (lines 69-70) is currently called with both `batch.Joined` and `batch.Left`. `Left` is still `IEnumerable<string>`, but `Joined` is now `IEnumerable<ChannelViewerDto>`. **Keep the existing string overload and add a second one** — overload resolution then routes every existing call site correctly with no edits to any test body:
+
+```csharp
+    private static bool Contains(IEnumerable<string> tags, string battleTag) =>
+        tags.Any(t => string.Equals(t, battleTag, StringComparison.OrdinalIgnoreCase));
+
+    private static bool Contains(IEnumerable<ChannelViewerDto> viewers, string battleTag) =>
+        viewers.Any(v => string.Equals(v.BattleTag, battleTag, StringComparison.OrdinalIgnoreCase));
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --filter "FullyQualifiedName~ViewersAccumulatorTests" --nologo
+```
+
+Expected: all `ViewersAccumulatorTests` pass, including the new one.
+
+- [ ] **Step 8: Run the full suite**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --nologo
+```
+
+Expected: `Failed: 0, Passed: 1325`
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+git add W3ChampionsChatService/Protocol/ViewersChangedDto.cs W3ChampionsChatService/FanOut/ViewersAccumulator.cs W3ChampionsChatService.Tests
+git commit -m "feat(chat): carry viewer flair on ViewersChanged joins"
+```
+
+---
+
+### Task 4: Client protocol types and the flair store slice
+
+**Files:**
+- Modify: `.worktrees/launcher-e-roster-flair/src/types/chat-protocol.types.ts` (lines 213-216, 248-252)
+- Modify: `.worktrees/launcher-e-roster-flair/src/models/chat-core.ts` (state type ~line 125; init ~line 213; wipe ~line 274; `ownProfile` assignment line 316; `addFocused` lines 331-337; `ingestViewersChanged` lines 347-359)
+
+**Interfaces:**
+- Consumes: the Task 1 and Task 3 wire shapes — `ChannelViewerDto { battleTag, name, profile? }` and `ViewersChangedDto { channelId, joined: ChannelViewerDto[], left: string[] }`.
+- Produces: `chatStore.flairByBattleTag: Record<string, IChatProfileDto>`, keyed on **lowercased** battleTag.
+
+All work in this task is in the launcher-e worktree. There is no test runner; correctness is enforced by `tsc` plus the panel change in Task 5.
+
+- [ ] **Step 1: Add `profile` to the viewer DTO**
+
+In `src/types/chat-protocol.types.ts`, replace the `IChannelViewerDto` block (lines 209-216):
+
+```ts
+/**
+ * Wire DTO: a viewer in a focused channel.
+ *
+ * `profile` is the viewer's flair, resolved server-side from the same in-memory
+ * `ConnectionMapping` entry that supplies `sender.flair` on that user's messages —
+ * so a user's roster avatar and their message avatar agree by construction. It is
+ * optional because the server sends null for a viewer whose session vanished
+ * mid-call, and because null fields are omitted from the wire entirely.
+ */
+export interface IChannelViewerDto {
+    battleTag: string;
+    name: string;
+    profile?: IChatProfileDto | null;
+}
+```
+
+- [ ] **Step 2: Make `joined` carry viewers**
+
+In the same file, replace the `IViewersChangedDto` block (lines 245-252):
+
+```ts
+/**
+ * Wire DTO: viewers changed in a focused channel.
+ *
+ * `joined` carries full viewer entries (display name + flair) so a user who joins
+ * mid-session renders correctly immediately; `left` needs only battleTags.
+ */
+export interface IViewersChangedDto {
+    channelId: string;
+    joined: IChannelViewerDto[];
+    left: string[];
+}
+```
+
+- [ ] **Step 3: Declare the store slice**
+
+In `src/models/chat-core.ts`, immediately after the `viewersByChannel` state declaration (line 125):
+
+```ts
+    /**
+     * Flair keyed by LOWERCASED battleTag. Fed by live sources only — the
+     * `FocusChannel` roster, `ViewersChanged` joins, and `ownProfile` — never by
+     * message senders: `sender.flair` is frozen at send time, so an old history
+     * message would otherwise clobber current flair with a stale snapshot.
+     * Message rows read `sender.flair` directly and are unaffected.
+     */
+    flairByBattleTag: Record<string, IChatProfileDto>;
+```
+
+Add `IChatProfileDto` to the existing `chat-protocol.types` import in this file if it is not already imported.
+
+- [ ] **Step 4: Initialise and wipe the slice**
+
+In the same file, immediately after the `viewersByChannel: {},` initialiser (line 213):
+
+```ts
+        flairByBattleTag: {},
+```
+
+and immediately after `state.viewersByChannel = {};` inside `rebuildFromSnapshot` (line 274):
+
+```ts
+            state.flairByBattleTag = {};
+```
+
+- [ ] **Step 5: Record own flair from the snapshot**
+
+In the same file, replace the `ownProfile` assignment (line 316):
+
+```ts
+            state.ownProfile = snapshot.ownProfile;
+            if (snapshot.ownProfile?.flair) {
+                state.flairByBattleTag[snapshot.ownProfile.battleTag.toLowerCase()] = snapshot.ownProfile.flair;
+            }
+```
+
+- [ ] **Step 6: Record flair from the focus roster**
+
+Replace the `addFocused` action (lines 331-337):
+
+```ts
+        addFocused: action((state, payload) => {
+            if (!state.focusedChannelIds.includes(payload.channelId)) {
+                if (state.focusedChannelIds.length >= CHAT_LIMITS.MAX_FOCUSED_CHANNELS) return;
+                state.focusedChannelIds.push(payload.channelId);
+            }
+            state.viewersByChannel[payload.channelId] = payload.viewers;
+            for (const viewer of payload.viewers) {
+                if (viewer.profile) state.flairByBattleTag[viewer.battleTag.toLowerCase()] = viewer.profile;
+            }
+        }),
+```
+
+- [ ] **Step 7: Record flair from join deltas**
+
+Replace the `ingestViewersChanged` action (lines 347-359):
+
+```ts
+        ingestViewersChanged: action((state, payload) => {
+            // A late batch arriving after unfocus would otherwise recreate a
+            // ghost `viewersByChannel` entry for a channel nobody is viewing
+            // anymore — ignore it (state-adjacent guard, race-free).
+            if (!state.focusedChannelIds.includes(payload.channelId)) return;
+            const map = new Map<string, IChannelViewerDto>();
+            for (const viewer of state.viewersByChannel[payload.channelId] ?? []) map.set(viewer.battleTag, viewer);
+            for (const viewer of payload.joined ?? []) {
+                // Unconditional set (the old code skipped existing keys): a join entry is now
+                // strictly richer than what the map may already hold, carrying a real display
+                // name and flair rather than a battleTag-only stub.
+                map.set(viewer.battleTag, viewer);
+                if (viewer.profile) state.flairByBattleTag[viewer.battleTag.toLowerCase()] = viewer.profile;
+            }
+            for (const battleTag of payload.left ?? []) map.delete(battleTag);
+            state.viewersByChannel[payload.channelId] = [...map.values()];
+        }),
+```
+
+- [ ] **Step 8: Type-check**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+npm run type-check
+```
+
+Expected: no output, exit 0. If `ChatUserListPanel.tsx` errors here, leave it — Task 5 fixes it.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+git add src/types/chat-protocol.types.ts src/models/chat-core.ts
+git commit -m "feat(chat): store roster flair in a user-keyed store slice"
+```
+
+---
+
+### Task 5: `ChatUserListPanel` reads the store slice
+
+**Files:**
+- Modify: `.worktrees/launcher-e-roster-flair/src/components/chat/ChatUserListPanel.tsx` (lines 24-38, 59-62)
+- Modify: `.worktrees/launcher-e-roster-flair/src/helpers/chat-ui.helper.ts` (doc comment on `viewerToChatUser`, lines 474-482)
+
+**Interfaces:**
+- Consumes: `chatStore.flairByBattleTag` from Task 4.
+- Produces: nothing consumed by later tasks.
+
+`viewerToChatUser`'s signature and body are unchanged — only its stale doc comment is corrected. The panel keeps passing flair in; it just gets it from a live store instead of scavenging messages.
+
+- [ ] **Step 1: Replace the scavenging memo with a store read**
+
+In `src/components/chat/ChatUserListPanel.tsx`, delete the entire block from the `// Roster DTOs carry no flair` comment through the closing of the `flairByBattleTag` memo (lines 24-38) and replace it with:
+
+```ts
+    // Roster entries carry their own flair (`IChannelViewerDto.profile`), recorded into
+    // `flairByBattleTag` by the store's live-source writers. This replaced an earlier workaround
+    // that scavenged flair out of cached messages, which left any user absent from the 50-message
+    // seed rendering the default avatar until they happened to speak.
+    const flairByBattleTag = useStoreState(x => x.chatStore.flairByBattleTag);
+```
+
+- [ ] **Step 2: Read flair by lowercased key**
+
+In the same file, replace the `users` memo (lines 59-62):
+
+```ts
+    const users = useMemo(
+        () => viewers.map(v => viewerToChatUser(v, flairByBattleTag[v.battleTag.toLowerCase()])).sort(compareUsers),
+        [viewers, ownBattleTag, flairByBattleTag],
+    );
+```
+
+- [ ] **Step 3: Remove the now-unused messages selector and imports**
+
+The `messages` selector (line 30) exists only to feed the deleted memo. Delete this line:
+
+```ts
+    const messages = useStoreState(x => (activeChannelId ? x.chatStore.messagesByChannel[activeChannelId] : undefined) ?? EMPTY_MESSAGES);
+```
+
+`EMPTY_MESSAGES` and `IChatProfileDto` are each referenced **only** inside the block deleted in Step 1 and the line deleted above (verified by grep), so both imports are now unconditionally dead. Change the helper import on line 9 to drop `EMPTY_MESSAGES`:
+
+```ts
+import { battleTagsEqual, EMPTY_VIEWERS, viewerToChatUser } from "@/helpers/chat-ui.helper";
+```
+
+and delete line 12 entirely:
+
+```ts
+import { IChatProfileDto } from "@/types/chat-protocol.types";
+```
+
+Keep the `ownProfile` selector — `ownBattleTag` still uses it for the self-pinning sort.
+
+- [ ] **Step 4: Correct the stale helper doc comment**
+
+In `src/helpers/chat-ui.helper.ts`, in the doc comment above `viewerToChatUser`, replace the sentence fragment referring to scavenging:
+
+```
+ * `flair`, when the caller can supply it from a source that DOES
+ * carry it (the viewer's own `ownProfile.flair`, or a cached message sender's
+ * `flair`, see `ChatUserListPanel`), restores the real avatar/color/icons the
+ * same way `messageDtoToChatMessage` does for a message row. `undefined` flair
+ * degrades to today's default-avatar/no-color behavior.
+```
+
+with:
+
+```
+ * `flair` comes from the store's `flairByBattleTag` slice, fed by the roster's
+ * own `IChannelViewerDto.profile` and by `ownProfile.flair`. `undefined` flair
+ * degrades to the default-avatar/no-color behavior — reachable only when the
+ * server could not resolve a viewer's live session at roster-build time.
+```
+
+- [ ] **Step 5: Verify**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+npm run type-check
+```
+
+Expected: no output, exit 0.
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+npm run lint:prod
+```
+
+Expected: no output, exit 0. An "unused variable" error here means a leftover import from Step 3.
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+npm run dprint
+```
+
+Expected: no output, exit 0. Run `npm run dprint:fix` if it reports formatting differences.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+git add src/components/chat/ChatUserListPanel.tsx src/helpers/chat-ui.helper.ts
+git commit -m "fix(chat): render roster avatars from server flair, not cached messages"
+```
+
+---
+
+### Task 6: End-to-end verification
+
+**Files:** none modified.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces: nothing.
+
+This task exists because every preceding task verified one side of a wire contract in isolation. Nothing so far has run a real client against a real server.
+
+- [ ] **Step 1: Full chat-service suite**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+dotnet test --nologo
+```
+
+Expected: `Failed: 0, Passed: 1325`
+
+- [ ] **Step 2: Full launcher-e verification set**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+npm run type-check
+```
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+npm run lint:prod
+```
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+npm run dprint
+```
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/launcher-e-roster-flair"
+npm run check:i18n
+```
+
+Expected: all four exit 0.
+
+- [ ] **Step 3: Confirm no DB access crept onto the roster path**
+
+```bash
+cd "C:/Users/Marco/git_projects/w3champions/.worktrees/chat-service-roster-flair"
+grep -n "Repository\|Mongo\|await" W3ChampionsChatService/Chats/ViewerResolver.cs
+```
+
+Expected: no matches. Any hit means the resolver acquired an I/O dependency and the hot-path guarantee in the spec is broken.
+
+- [ ] **Step 4: Manual smoke test**
+
+Run the launcher against the chat-service build and confirm all four:
+
+1. Connect with the Lounge focused while another user is online and has **not** sent a message in the last 50 messages. That user shows their real avatar immediately, not the sheep.
+2. Colour and chat icons render for roster users, not only avatars.
+3. A user who joins the channel while you are already focused appears with their real avatar within the 5-second `ViewersChanged` flush window.
+4. Message-row avatars are unchanged — they still come from `sender.flair`.
+
+- [ ] **Step 5: Report**
+
+Report the suite counts, the four verification exit codes, and the outcome of each manual check. Do not claim completion without the manual results — no automated test in this plan exercises a real client against a real server.
+
+---
+
+## Notes for Plan B
+
+Plan B (live propagation) builds directly on this work and will need:
+
+- `ViewerResolver` — reuse it to build the `FlairChangedDto` payload so the push and the roster agree.
+- `flairByBattleTag` — the `FlairChanged` handler is a one-line write into this slice, which is why it is user-keyed rather than nested under `viewersByChannel`.
+- The `FreshFromWb == false` no-op rule in spec §5 — the single most important behaviour in Plan B, and the one place the feature could regress production.

--- a/docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md
+++ b/docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md
@@ -1,0 +1,380 @@
+# Roster Flair Enrichment + Live Propagation — Design
+
+**Date:** 2026-08-09
+**Repos touched:** `chat-service` (primary), `website-backend`, `launcher-e`
+**Status:** Approved, ready for implementation planning
+
+---
+
+## 1. Problem
+
+After the chat revamp shipped to production, users appear in the chat user list with the default
+sheep avatar instead of their real profile picture. The avatar corrects itself once that user types
+a message.
+
+### Root cause
+
+The roster wire contract carries no flair. `ChannelViewerDto` is a 2-tuple
+(`Protocol/ChannelViewerDto.cs:7`):
+
+```csharp
+public record ChannelViewerDto(string BattleTag, string Name);
+```
+
+`ViewersChangedDto` (`Protocol/ViewersChangedDto.cs:21-24`) likewise carries only bare battleTag
+strings, and `PresenceChangedDto` / `FriendPresenceChangedDto` carry only `(battleTag, online)`.
+
+The **only** wire surfaces that carry another user's flair are the per-message
+`MessageSender.Flair` snapshot and — for autocomplete only — `MentionCandidateDto.Profile`.
+
+The client compensates in `ChatUserListPanel.tsx:32-38` by scavenging flair out of cached chat
+messages:
+
+```ts
+const flairByBattleTag = useMemo(() => {
+    const map = new Map<string, IChatProfileDto>();
+    for (const message of messages) {
+        if (message.sender.flair) map.set(message.sender.battleTag.toLowerCase(), message.sender.flair);
+    }
+    if (ownProfile) map.set(ownProfile.battleTag.toLowerCase(), ownProfile.flair);
+    return map;
+}, [messages, ownProfile]);
+```
+
+A miss falls through to `DEFAULT_CHAT_PROFILE_PICTURE` (`chat-ui.helper.ts:13-17`) — `STARTER` /
+`pictureId: 1`, which is literally the sheep asset (`website/public/assets/raceAvatars/STARTER_1.jpg`).
+
+This produces two symptoms:
+
+1. **Transient, on connect.** In `applySessionState`, `FocusChannel` populates `viewersByChannel`
+   and `setActiveChannel(active)` fires at `chat-core.ts:689` — *before* the
+   `await chatService.getMessages(...)` at `chat-core.ts:704`. The panel renders a full roster
+   against an empty flair map.
+2. **Permanent, and the reported symptom.** The history seed is only
+   `REBUILD_ACTIVE_SEED_LIMIT = 50` messages (`models/chat.ts:14`). Any online user absent from that
+   window has no flair source anywhere in the protocol and stays a sheep until they speak.
+
+The gap was known. `ChatUserListPanel.tsx:40-47` says *"until chat-service's roster DTO enrichment
+ships"*; commit `8446d527` added the scavenging workaround and the server-side enrichment it was
+waiting on never landed.
+
+### Ruled out by production evidence (2026-08-09, 46 min post-release)
+
+| Hypothesis | Evidence |
+|---|---|
+| wb rate limiting / timeout | `Failed to enrich chat user` = **0**; `Restoring cached directory flair` = **0**; `TaskCanceled\|timed out\|HttpRequestException` = **0**. Warning-level logging demonstrably active in the same window (`Receiver ... failed to authenticate` present), so the zero is meaningful. |
+| Endpoint latency | `/api/players/{tag}/clan-and-picture` measured at **42–75 ms** against a 2000 ms client timeout (`WebsiteBackendRepository.cs:37`). |
+| Rate limiting configured | None. The repo's `[RateLimit]` attribute is applied only to `ReplaysController`. |
+| Misconfiguration | `STATISTIC_SERVICE_URI=https://statistic-service.w3champions.com` — correct. |
+| First-launch only | No. `rebuildFromSnapshot` wipes `messagesByChannel` on every connect *and* reconnect (`chat-core.ts:271-274`); nothing chat-related is persisted. |
+
+Separately observed, out of scope: `ProfilePicture.Default()`
+(`website-backend`, `PersonalSettings/ProfilePicture.cs:8-16`) calls `new Random()` per invocation,
+so settings-less players get a different avatar on every call (measured `pictureId` 1, 2, 3, 1 across
+four consecutive requests), and `random.Next(1, 5)` never serves `STARTER_5.jpg`.
+
+---
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- A user in a channel roster renders with their real flair immediately on connect, without having
+  spoken.
+- A flair change (portrait, chat colour, chat icons, clan) propagates to other viewers live, without
+  requiring the changed user to reconnect.
+- A flair change is reflected in the changed user's own subsequent messages within the same
+  connection.
+- No new persistent storage, and no additional load on `website-backend` for the roster path.
+
+**Non-goals**
+
+- Retroactive repair of already-rendered history. `ChannelMessage.Sender.Flair` remains an immutable
+  send-time snapshot; the message list keeps reading `dto.sender.flair` per message.
+- Reducing the existing per-message flair storage cost (see §6).
+- Flair for users who are not in a roster (offline, or online but not focused on the channel).
+- Fixing the `ProfilePicture.Default()` randomness noted above.
+
+---
+
+## 3. Architecture
+
+Four independent pieces. Each degrades to current behaviour on its own, so they are separately
+deployable.
+
+### 3.1 Roster enrichment (the bug fix)
+
+`FocusChannel` already resolves each roster entry's display name through an in-memory session lookup
+(`ChatHub.Channels.cs:202-206`):
+
+```csharp
+private string ResolveViewerName(string battleTag)
+{
+    var session = _sessionRegistry.GetByBattleTag(battleTag);
+    return session?.Identity?.Name ?? battleTag;
+}
+```
+
+Every roster entry is by definition online *and* focused, so its `ChatUser` — carrying full flair —
+is already in `ConnectionMapping`, keyed by `session.ConnectionId`. Flair therefore rides the lookup
+that is already happening:
+
+- **No Mongo read.** No `UserDirectoryRepository` involvement on this path.
+- **No website-backend call.**
+- **Identical by construction** to what that user's own messages carry, because both go through
+  `ChatProfileMapper.FromChatUser` off the same `ConnectionMapping` entry.
+
+### 3.2 Live propagation — website-backend side
+
+There are **five** flair-write paths, not one. Any design hooking only `SetProfilePicture` misses
+most of them:
+
+| Path | Location |
+|---|---|
+| Profile picture | `PortraitCommandHandler.UpdatePicture` (`Rewards/Portraits/PortraitCommandHandler.cs:18-28`) |
+| Chat colour / icons | `PersonalSetting.Update` via `PersonalSettingsController.cs:67-80` |
+| Reward grant / revoke | `ChatColorRewardModule.cs:53,105`, `ChatIconRewardModule.cs:58,112` — bypasses the controller |
+| Clan join / leave / kick | `ClanCommandHandler.cs:30,50,125,156` |
+| Clan delete | `ClanCommandHandler.cs:80` — **bulk, many battleTags in one call** |
+
+Plus `PersonalSetting.UpdateSpecialPictures` (`PersonalSetting.cs:92-110`) can silently reset a
+picture.
+
+Notification therefore hangs off the **persistence boundary**, which every write path must cross,
+implemented as decorators over the existing interfaces rather than as edits to the repositories:
+
+```
+FlairNotifyingPersonalSettingsRepository : IPersonalSettingsRepository
+FlairNotifyingClanRepository             : IClanRepository
+        │ delegates every member to the inner repository
+        └─ after a successful Save / SaveMany / UpsertMemberShip / SaveMemberShips
+           → IFlairChangeNotifier.NotifyChanged(battleTags)
+```
+
+`PersonalSettingsRepository` and `ClanRepository` stay pure. All five paths — including the two
+reward modules and the bulk clan delete — are covered because they all persist through these
+interfaces, and a sixth path added later is covered for free. `Program.cs:178,187` already resolves
+both through `AddInterceptedTransient`, so decoration is consistent with how this codebase composes
+services.
+
+**Deliberate over-notification.** The decorator fires on any settings save, not only flair-relevant
+ones. Fingerprinting the flair fields to suppress no-op pings was considered and rejected: it avoids
+a ~50 ms call that only occurs for users currently online in chat, at the cost of real machinery and
+a new way to be subtly wrong. Chat-side coalescing absorbs the volume.
+
+`IFlairChangeNotifier` clones the `RelationshipChangeNotifier` triad 1:1 — the same
+`ChatInternalApiSigner` HMAC scheme and headers, the same `ChatPingSettings` /
+`CHAT_INTERNAL_API_SECRET` (already set in production alongside `CHAT_API`), the same
+`Task.Run` fire-and-forget with 2 attempts and a 3 s per-attempt cap, and the same self-disable when
+the secret is absent.
+
+### 3.3 Live propagation — chat-service side
+
+`POST /internal/profile-changes`, gated `[InternalHmacAuth(InternalCaller.Wb)]`, validated exactly
+like `InternalRelationshipChangesController`. Payload `{ battleTags: [...] }`.
+
+Requests feed a coalescer modelled on `ActivityCoalescer` / `ViewersAccumulator` so a burst for one
+battleTag collapses into a single refresh. Per battleTag:
+
+- **No live session → no-op.** Their next connect re-enriches anyway. Work is bounded by the set of
+  users currently online in chat.
+- **Live session →** `GetUserFromIdentity(session.Identity)`; then, **only if `FreshFromWb == true`**
+  (see §5), `RegisterUser` → directory upsert → `FlairChanged` fan-out. If `FreshFromWb` is false the
+  whole refresh is abandoned with no side effects.
+
+Reusing `GetUserFromIdentity` means admin colour/icon forcing, the three-tier fallback and the
+never-clobber invariant all come for free. Because it refreshes `ConnectionMapping`, it also fixes
+the case where a user's own subsequent messages still carried their old flair.
+
+### 3.4 Reconnect backstop
+
+Unchanged: connect always re-enriches from wb. Every layer above is therefore free to be
+best-effort — a dropped ping degrades to today's behaviour, never to a permanent wrong state.
+
+---
+
+## 4. Wire contract
+
+All three changes are shape-changing. This is acceptable because the launcher force-updates before
+it can connect.
+
+| DTO | Change |
+|---|---|
+| `ChannelViewerDto` | `(BattleTag, Name)` → `(BattleTag, Name, ChatProfile Profile)` |
+| `ViewersChangedDto` | `Joined: IReadOnlyList<string>` → `IReadOnlyList<ChannelViewerDto>`; `Left` unchanged (`string[]`) |
+| *new* `FlairChangedDto` | `(string BattleTag, ChatProfile Profile)` on a new `FlairChanged` event |
+
+`ViewersAccumulator` computes its `joined` set at flush time from `FocusRegistry` and currently has
+no way to resolve flair — it is constructed with `(IHubContext<ChatHub>, FocusRegistry)`
+(`FanOut/ViewersAccumulator.cs:45`). Enriching `Joined` therefore requires injecting `ISessionRegistry`
+and `ConnectionMapping` into it, using the same lookup as `ResolveViewerName`. Resolution happens at
+flush, outside the lock, consistent with the component's existing send discipline.
+
+**Single shared type.** The roster reuses the full `ChatProfile` rather than a trimmed roster type.
+The client renders only four of its fields today, but `viewerToChatUser(viewer, flair?: IChatProfileDto)`
+already accepts exactly this type, and one shared `ChatProfileMapper.FromChatUser` for both roster
+and `sender.flair` is what guarantees the two cannot drift — the codebase already documents that
+property as load-bearing.
+
+**Null omission.** The SignalR hub JSON protocol is configured with
+`DefaultIgnoreCondition = WhenWritingNull`. `Startup.cs:41-53` currently sets no null handling, so
+all 13 flair keys serialize even when null. Most users have null `clanId`, `chatColor`, `chatIcons`
+and null rank, and the measured *minimum* flair was still 281 chars — the key names dominate.
+Omitting nulls drops a typical flair from ~291 to roughly 110 chars, and shrinks `sender.flair` on
+every message and history page for free with no API change. Safe client-side: the TypeScript DTOs
+already declare these fields optional (`clanId?: string | null`, `chat-protocol.types.ts:130-138`)
+and every read path uses optional chaining with a fallback.
+
+**`FlairChanged` fan-out targeting.** Flair is user-scoped, so the event is not channel-scoped. For a
+changed battleTag X with a live session: take `GetFocusedChannels(X.ConnectionId)`, union their
+`GetFocusedConnections`, dedupe, and send once per connection — plus X's own connection
+unconditionally, so a user focused on nothing still sees their own avatar update.
+
+### Client state
+
+New `chatStore.flairByBattleTag: Record<string, IChatProfileDto>`, keyed on lowercased battleTag
+(matching the server's roster tag casing and the current memo's normalization). Wiped by
+`rebuildFromSnapshot` alongside all other chat state.
+
+Written by **live sources only** — `FocusChannel` viewers, `ViewersChanged.joined`,
+`SessionState.ownProfile`, and `FlairChanged`. Deliberately **not** by message senders:
+`sender.flair` is frozen at send time, so a three-day-old history message could otherwise clobber
+fresh flair. It is also unnecessary, since every roster user now arrives with live flair and the
+message list reads `dto.sender.flair` per message regardless. This yields one precedence rule
+instead of a source-ranking scheme.
+
+`ChatUserListPanel` drops its `flairByBattleTag` `useMemo` entirely and reads the store slice, which
+also retires the per-message O(buffer × roster) rebuild.
+
+### Data flow
+
+```
+player changes portrait
+  → PortraitCommandHandler → IPersonalSettingsRepository.Save
+      → [decorator] IFlairChangeNotifier.NotifyChanged(["Foo#123"])
+          → POST /internal/profile-changes   (HMAC, fire-and-forget, 2 attempts)
+              → coalescer (per-battleTag, collapses bursts)
+                  → no live session → no-op        (next connect re-enriches)
+                  → live session    → GetUserFromIdentity
+                                    → RegisterUser
+                                    → directory Upsert (iff FreshFromWb)
+                                    → FlairChanged → focused connections
+                                         → client: flairByBattleTag[tag] = profile
+                                         → user list re-renders
+```
+
+---
+
+## 5. Error handling
+
+- **Decorator** — notification fires only after the inner write succeeds, wrapped in its own
+  try/catch. A notifier fault can never fail a settings write or clan operation. If the inner write
+  throws, no ping is sent.
+- **Notifier** — fire-and-forget, 2 attempts, 3 s per-attempt cap, non-2xx falls through to retry
+  then `Log.Warning`, never rethrows, never logs the secret. Self-disables without
+  `CHAT_INTERNAL_API_SECRET`, with one startup log line.
+- **Controller** — HMAC-gated; battleTags validated non-blank and control-char-free including
+  U+2028/U+2029; batch capped at `InternalMaxMembersPerCall` (64); generic 400 on any violation with
+  no partial processing.
+- **Coalescer** — bounded pending set; drop on overflow rather than grow. A dropped refresh degrades
+  to the reconnect backstop.
+- **Fan-out** — sends outside the lock, fault-isolated per connection, mirroring
+  `ViewersAccumulator`.
+- **Null `Profile` on a roster entry** — possible when a session disappears mid-call. The client
+  keeps `DEFAULT_CHAT_PROFILE_PICTURE` for exactly this case, mirroring the existing precedent where
+  `ResolveViewerName` falls back to the raw battleTag rather than dropping the entry.
+
+### The `FreshFromWb` rule
+
+On a refresh, if `GetUserFromIdentity` returns `FreshFromWb == false`, **do nothing at all** — no
+`RegisterUser`, no directory write, no `FlairChanged`.
+
+A wb blip during a flair ping would otherwise take a degraded tier-3 profile and actively broadcast
+the sheep to every viewer in the channel, converting a transient upstream hiccup into a visible
+regression for everyone. This extends the existing never-clobber invariant from the directory to the
+connection cache and to the wire. It is the one place this design could make things worse than
+today, and it gets an explicit test.
+
+---
+
+## 6. Load and data-transfer analysis
+
+Measured on production, 2026-08-09.
+
+### Storage: no change
+
+| `messages` collection (1000-doc sample) | |
+|---|---|
+| Avg message document | 593 chars |
+| Avg `Sender.Flair` within it | **291 chars — 49% of the document** |
+| Avg message content | **18 chars** |
+
+Every chat message already carries a full 13-field flair blob; half of each stored message is flair
+while the text averages 18 characters. This is pre-existing and **unchanged** by this design — the
+message path is not touched.
+
+Roster flair lives in memory only (`SessionRegistry` + `ConnectionMapping`).
+`user_directory.Profile` already exists at 288 chars × 1041 rows = 0.4 MB. The design writes it
+slightly more often but adds no field and no document. **Net new persistent storage: zero.**
+
+### Transfer
+
+Inputs: 789 distinct users/hour, ~600 messages/hour, largest channel 992 members (next 59, 55, 36),
+`ChatProfile` 291 chars, current `{battleTag, name}` viewer ≈ 45 chars. No metrics endpoint exists
+on the container, so **concurrent focused Lounge viewers is estimated at 300**, derived from 789
+unique users/hour against 992 memberships. Totals below are order-of-magnitude.
+
+| Lounge focus payload (300 viewers) | Per focus | ~800 focuses/hr |
+|---|---|---|
+| Today | 13.5 KB | 11 MB/hr |
+| + full `ChatProfile`, nulls included | 101 KB | 81 MB/hr |
+| **+ full `ChatProfile`, nulls omitted (chosen)** | **~40 KB** | **~32 MB/hr** |
+
+`ViewersChanged` is delta-only on a 5 s batch — a handful of joins per window, negligible.
+`FlairChanged` is rare (a portrait change is roughly once per session) but fans out to every focused
+connection of the user's channels, so ~100 KB per event in the Lounge; the coalescer bounds bursts.
+
+Null omission also shrinks `sender.flair` on every message and history page, partially offsetting
+the pre-existing 49% overhead noted above.
+
+---
+
+## 7. Testing
+
+**chat-service** (`W3ChampionsChatService.Tests`, NUnit) — failing test first:
+
+- `FocusChannel` returns viewers whose `Profile` is populated from the live session (fails against
+  today's 2-tuple).
+- `ViewersChanged.Joined` carries flair.
+- `FlairChanged` reaches exactly the focused connections of the changed user's channels, plus their
+  own connection, deduped.
+- The `FreshFromWb == false` no-op rule: no `RegisterUser`, no directory write, no emit.
+- Coalescing collapses a burst for one battleTag into a single refresh.
+- Controller validation and HMAC rejection. **The new internal controller must be added to the
+  dynamic reflection sweep in `InternalChannelsControllerTests`** that pins HMAC gating across
+  internal controllers.
+
+**website-backend** (`WC3ChampionsStatisticService.UnitTests`, NUnit):
+
+- The decorator notifies on `Save`, `SaveMany`, `UpsertMemberShip`, `SaveMemberShips`.
+- The bulk `DeleteClan` path emits every affected battleTag, not just one.
+- No notification when the inner repository throws.
+- A notifier fault does not surface to the caller.
+- Signature vectors are already pinned by `ChatInternalApiSignerTests`.
+
+**launcher-e**: no test runner exists in this repo. Verification is `type-check`, `lint`, `dprint`,
+`check:i18n`, plus a manual run confirming (a) a silent user shows their real avatar on connect and
+(b) changing a portrait updates it live without a reconnect.
+
+---
+
+## 8. Rollout
+
+Ship in this order so the user-visible fix lands before the propagation machinery:
+
+1. **chat-service roster enrichment + null omission** — inert until the client reads it.
+2. **launcher-e client** — consumes the roster flair; the reported bug is fixed at this point.
+3. **website-backend notifier + chat-service internal endpoint** — self-disables without
+   `CHAT_INTERNAL_API_SECRET`, so it can be deployed dark and enabled by configuration.
+
+Each step degrades to current behaviour if the next never ships.

--- a/docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md
+++ b/docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md
@@ -370,11 +370,22 @@ the pre-existing 49% overhead noted above.
 
 ## 8. Rollout
 
-Ship in this order so the user-visible fix lands before the propagation machinery:
+Ship in this order. The wire change is breaking, not inert: `ViewersChangedDto.Joined` moves from
+`string[]` to an array of objects, and chat-service has no server-side client-version gate (verified
+by grep — no `minVersion`/`clientVersion`/`forceUpdate` check exists). An un-updated launcher's
+`ingestViewersChanged` keys its viewer Map on an object and then throws on
+`v.battleTag.toLowerCase()` in `ChatUserListPanel`, killing the user-list panel. The
+`MentionInboxEntryDto.ReadAt` pin matters to old clients too. So the launcher's force-update floor
+must be bumped and rolled out *before* chat-service deploys — nothing on the server does that
+gating for us:
 
-1. **chat-service roster enrichment + null omission** — inert until the client reads it.
-2. **launcher-e client** — consumes the roster flair; the reported bug is fixed at this point.
-3. **website-backend notifier + chat-service internal endpoint** — self-disables without
+1. **launcher-e force-update floor bump** — raised past the last pre-change build, and given time to
+   reach clients, before the next step.
+2. **chat-service roster enrichment + null omission** — safe now that no client below the new floor
+   can connect.
+3. **launcher-e client** — consumes the roster flair; the reported bug is fixed at this point.
+4. **website-backend notifier + chat-service internal endpoint** — self-disables without
    `CHAT_INTERNAL_API_SECRET`, so it can be deployed dark and enabled by configuration.
 
-Each step degrades to current behaviour if the next never ships.
+Steps 2-4 degrade to current behaviour if the next never ships; step 1 is a hard prerequisite for
+step 2, not a degrade-gracefully step.


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not deploy this before the launcher release.** See [Deploy order](#deploy-order).
>
> Paired PR: **https://github.com/w3champions/launcher-e/pull/850**

## The bug

Users load into chat rendering the default sheep avatar in the channel user list instead of their real icon. It corrects itself only once that user sends a message.

## Root cause

The roster wire contract carried no flair:

```csharp
public record ChannelViewerDto(string BattleTag, string Name);
public record ViewersChangedDto(string ChannelId, IReadOnlyList<string> Joined, IReadOnlyList<string> Left);
```

With no avatar on a roster entry, the launcher scavenged flair out of its cached messages — which only ever finds users present in the 50-message seed. Anyone online but quiet rendered the client's default (`STARTER_1`) until they spoke.

### Ruled out, with production evidence

Investigated read-only on the live host before writing any code:

| Hypothesis | Evidence |
|---|---|
| Rate limiting / website-backend failure | 0 enrichment failures, 0 cache restores, 0 timeouts over 46 min, while warnings were demonstrably being logged |
| Latency | `clan-and-picture` endpoint 42–75 ms against the 2000 ms timeout |
| Misconfiguration | `STATISTIC_SERVICE_URI` correct |
| First-launch only | No — the client wipes and rebuilds on every connect |

Decisive discriminator: the sheep is *consistently* `STARTER_1`. `ProfilePicture.Default()` in website-backend picks a **random** `STARTER 1-4`, so a consistent sheep can only be the client-side constant — the server was never the source.

## Approach

`FocusChannel` already resolved each roster entry's display name through an in-memory `ISessionRegistry.GetByBattleTag` lookup. Flair rides that same lookup — no Mongo read, no website-backend call.

**`ViewerResolver`** is the single place that knows the session → connection → `ChatUser` → `ChatProfile` hop:

- Both `FocusChannel` (initial roster) and `ViewersAccumulator` (join deltas) build entries through it, so the two cannot render differently.
- It maps via `ChatProfileMapper.FromChatUser` — the same call `BuildSenderSnapshot` uses for message `sender.flair`. A user's roster avatar and message avatar are identical **by construction**, not by convention.
- Purely in-memory and total: a missing session degrades to the battleTag as display name (pre-existing behaviour), a missing `ConnectionMapping` entry yields a null `Profile`. It never throws and never drops an entry — a dropped entry would silently remove the viewer from the roster.

## What changed

- **`ViewerResolver`** (new) — as above. Deliberately has no repository dependency and no `await`; `FocusChannel` is a hot path and a roster can be several hundred entries.
- **`ChannelViewerDto`** gains `ChatProfile Profile`.
- **`ViewersChangedDto.Joined`** becomes `IReadOnlyList<ChannelViewerDto>`. `Left` stays bare battleTags — removing a viewer needs nothing more, and flair for someone who just left is pure waste.
- **`ChatJsonProtocol`** (new) — hub payloads omit null properties. Extracted from `Startup` as a named static so the wire contract is unit-testable without a DI bootstrap.
- `ChatHub` builds its resolver in a field initializer from existing primary-constructor params rather than taking a new one — a signature change would have churned 31 test files for no behavioural gain.

### Why null omission

Flair is now the dominant payload. Measured on production: `Sender.Flair` is 291 of 593 chars per message document (49%), against an average content length of 18 chars. Most users have null clan/colour/icons and null rank, so with nulls serialized the **key names alone** dominate. Without omission, a full `ChatProfile` on the roster took a Lounge focus from 13.5 KB to 101 KB — a 7.5× increase. With it, the cost is proportional to flair users actually have.

`WhenWritingNull`, deliberately **not** `WhenWritingDefault` — `isClassic: false`, `pictureId: 0`, and `race: 0` (RnD) are meaningful values the client renders. There is a test pinning exactly that distinction.

### The regression this caught

Null omission applies to *every* hub payload, not just the roster. `MentionInboxEntryDto.ReadAt` is `null` for every unread mention, so it began arriving **absent** — and the launcher read it with strict `readAt === null` in six places. Symptom: unread badge reads 0, mentions never auto-acknowledge, every tray row renders as read. Silent, and only after a reconnect.

Fixed on both ends independently: `ReadAt` is pinned with `[property: JsonIgnore(Condition = JsonIgnoreCondition.Never)]`, and the launcher switched to truthy checks. `ChatJsonProtocol`'s doc comment now records the rule for the next nullable wire field.

Two tests close the structural gap that let it through: a DI wiring test that fails if `.AddJsonProtocol(...)` is removed from `Startup` (the previous tests passed either way), and a round-trip sweep over the DTOs whose nullable fields carry meaning.

## Verification

`Failed: 0, Passed: 1358` after rebasing onto `master`. 11 tests added by this branch.

One pre-existing `CS1998` warning in `ChatHubClanChannelTests.cs:325` comes from `master`, not this branch — no commit here touches that file.

## Deploy order

**The launcher release must go out first.** `ViewersChanged.joined` changed from `string[]` to an array of objects and there is **no server-side client-version gate** (verified by grep — no `minVersion` / `clientVersion` / `forceUpdate` check exists). An un-updated launcher keys its viewer `Map` on an object and then throws on `v.battleTag.toLowerCase()`, killing its user-list panel.

The design doc originally claimed this step was "inert until the client reads it". That was wrong; `docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md` §8 has been corrected and the rollout reordered.

## Still owed: manual verification

No automated test here runs a real client against a real server. The five checks are listed in the paired launcher PR.

## Known and accepted, not addressed here

- **Live propagation** of a flair *change* to already-connected clients — planned follow-up. Today a change is picked up on next reconnect.
- **`ProfilePicture.Default()` randomness** in website-backend.
- **Denormalized `ChannelMessage.Sender.Flair`** (~49% of message document size).
- **Reconnect window:** `SessionRegistry.Register` repoints `battleTag → connectionId` immediately, but `ConnectionMapping.RegisterUser` only runs after up to ~4 s of awaited I/O in `SessionStateAssembler`. An observer focusing inside that window sees `Profile: null` for the reconnecting user until the next join delta. It degrades to pre-branch behaviour, so I left it rather than reordering connect-time I/O outside this plan's scope.

## Design docs

- Spec: `docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md`
- Plan: `docs/superpowers/plans/2026-08-09-roster-flair-enrichment-plan-a.md`
