### PR TITLE
feat(chat): propagate flair changes to connected viewers live

### DIFF
--- a/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
@@ -14,13 +14,15 @@ namespace W3ChampionsChatService.Tests;
 /// <summary>
 /// C3 (Task 15) test for the <see cref="FanOutFlushService"/> — the single production
 /// <c>BackgroundService</c> whose 1s <see cref="System.Threading.PeriodicTimer"/> drains the Task 13
-/// <see cref="ActivityCoalescer"/> and Task 14 <see cref="ViewersAccumulator"/>. The pure aggregator
-/// tests (<see cref="ActivityCoalescerTests"/>/<see cref="ViewersAccumulatorTests"/>) already prove the
-/// coalescing/batching decisions against explicit <c>now</c> values; THIS test proves the OTHER half of
-/// acceptance — that the timer loop actually invokes <c>FlushDue(now)</c> in production, not just in
-/// unit tests. It drives the REAL aggregators over the REAL <see cref="PeriodicTimer"/> path using a
-/// <see cref="FakeTimeProvider"/>, so there is NO wall-clock sleep: advancing the fake clock past both
-/// cadences (10s) must produce BOTH a coalesced <c>ChannelActivity</c> and a batched <c>ViewersChanged</c>.
+/// <see cref="ActivityCoalescer"/>, Task 14 <see cref="ViewersAccumulator"/>, and the live-flair
+/// <see cref="FlairRefreshCoalescer"/>. The pure aggregator tests
+/// (<see cref="ActivityCoalescerTests"/>/<see cref="ViewersAccumulatorTests"/>/
+/// <see cref="FlairRefreshCoalescerTests"/>) already prove each one's own coalescing/batching decisions;
+/// THIS test proves the OTHER half of acceptance — that the timer loop actually invokes all three drains
+/// in production, not just in unit tests. It drives the REAL participants over the REAL
+/// <see cref="PeriodicTimer"/> path using a <see cref="FakeTimeProvider"/>, so there is NO wall-clock
+/// sleep: advancing the fake clock past every cadence (10s) must produce a coalesced
+/// <c>ChannelActivity</c>, a batched <c>ViewersChanged</c>, AND an observed flair refresh.
 /// </summary>
 public class FanOutFlushServiceTests
 {
@@ -33,6 +35,10 @@ public class FanOutFlushServiceTests
     // Accumulator arming: a focused viewer whose baseline-not-viewing → now-viewing flush emits a join.
     private const string ViewerConn = "conn-viewer";
     private const string ViewerTag = "Viewer#2";
+
+    // Flair coalescer arming: a battleTag recorded before the service starts, so the timer loop's third
+    // drain must be the thing that gets it refreshed — never invoked directly by the test.
+    private const string FlairTag = "Flair#3";
 
     private static readonly DateTime T0 = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
 
@@ -74,9 +80,12 @@ public class FanOutFlushServiceTests
             "the accumulated join must not emit until the flush service ticks");
 
         // --- Arm the flair-refresh coalescer: it has no cadence of its own (every pending tag is due on
-        // every flush), so it needs no arming beyond a no-op refresher — this test's acceptance is about
-        // the timer loop, not the coalescer's own collapsing behaviour (covered by FlairRefreshCoalescerTests).
-        var flairRefreshCoalescer = new FlairRefreshCoalescer(new NoOpFlairRefresher());
+        // every flush), so RecordChange before the service even starts is enough to make it due on the
+        // very first tick. The refresher RECORDS what it was asked to refresh, so this test can assert
+        // the timer loop's third drain actually ran — not just that it was constructed.
+        var flairRefresher = new RecordingFlairRefresher();
+        var flairRefreshCoalescer = new FlairRefreshCoalescer(flairRefresher);
+        flairRefreshCoalescer.RecordChange(FlairTag);
 
         var fakeTime = new FakeTimeProvider(new DateTimeOffset(T0, TimeSpan.Zero));
         var service = new FanOutFlushService(coalescer, accumulator, flairRefreshCoalescer, fakeTime);
@@ -98,10 +107,12 @@ public class FanOutFlushServiceTests
             // never fires the FlushDue calls.
             var flushed = await SpinUntil(() =>
                 harness.SignalCount(MemberConn, ChatEvents.ChannelActivity) >= 2 &&
-                ViewersChangedFor(harness, ViewerConn).Count >= 1);
+                ViewersChangedFor(harness, ViewerConn).Count >= 1 &&
+                flairRefresher.Refreshed.Contains(FlairTag));
 
             Assert.IsTrue(flushed,
-                "the 1s PeriodicTimer loop must invoke BOTH FlushDue methods so the pending activity and the accumulated join emit");
+                "the 1s PeriodicTimer loop must invoke all three drains so the pending activity, the " +
+                "accumulated join, and the pending flair refresh all emit");
         }
         finally
         {
@@ -123,6 +134,12 @@ public class FanOutFlushServiceTests
         Assert.IsTrue(batches[0].Joined.Any(v => string.Equals(v.BattleTag, ViewerTag, StringComparison.OrdinalIgnoreCase)),
             "the timer-driven ViewersChanged batch must report the viewer as joined");
         Assert.IsEmpty(batches[0].Left);
+
+        // The flair coalescer's pending tag, recorded before the service even started, flushed via the
+        // same timer path. This is the crux of this test's fix: deleting the flair drain from
+        // FanOutFlushService.ExecuteAsync must make this assertion fail.
+        Assert.That(flairRefresher.Refreshed, Is.EqualTo(new[] { FlairTag }),
+            "the pending flair refresh must be drained exactly once via the timer");
     }
 
     // Bounded, wall-clock-free spin: yields to the scheduler up to maxSpins times, returning true as soon
@@ -142,10 +159,17 @@ public class FanOutFlushServiceTests
         return condition();
     }
 
-    // Arming filler for the third flush participant — this test's acceptance is the timer loop calling
-    // all three drains, not the flair coalescer's own behaviour (covered by FlairRefreshCoalescerTests).
-    private class NoOpFlairRefresher : IFlairRefresher
+    // Records what it was asked to refresh, so this test can assert the timer loop's third drain
+    // genuinely ran — the coalescer's own collapsing/budget behaviour is covered by
+    // FlairRefreshCoalescerTests, this class exists only to make the drain OBSERVABLE here.
+    private class RecordingFlairRefresher : IFlairRefresher
     {
-        public Task Refresh(string battleTag) => Task.CompletedTask;
+        public List<string> Refreshed { get; } = new();
+
+        public Task Refresh(string battleTag)
+        {
+            Refreshed.Add(battleTag);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
@@ -73,8 +73,13 @@ public class FanOutFlushServiceTests
         Assert.AreEqual(0, ViewersChangedFor(harness, ViewerConn).Count,
             "the accumulated join must not emit until the flush service ticks");
 
+        // --- Arm the flair-refresh coalescer: it has no cadence of its own (every pending tag is due on
+        // every flush), so it needs no arming beyond a no-op refresher — this test's acceptance is about
+        // the timer loop, not the coalescer's own collapsing behaviour (covered by FlairRefreshCoalescerTests).
+        var flairRefreshCoalescer = new FlairRefreshCoalescer(new NoOpFlairRefresher());
+
         var fakeTime = new FakeTimeProvider(new DateTimeOffset(T0, TimeSpan.Zero));
-        var service = new FanOutFlushService(coalescer, accumulator, fakeTime);
+        var service = new FanOutFlushService(coalescer, accumulator, flairRefreshCoalescer, fakeTime);
 
         await service.StartAsync(CancellationToken.None);
         try
@@ -135,5 +140,12 @@ public class FanOutFlushServiceTests
             await Task.Yield();
         }
         return condition();
+    }
+
+    // Arming filler for the third flush participant — this test's acceptance is the timer loop calling
+    // all three drains, not the flair coalescer's own behaviour (covered by FlairRefreshCoalescerTests).
+    private class NoOpFlairRefresher : IFlairRefresher
+    {
+        public Task Refresh(string battleTag) => Task.CompletedTask;
     }
 }

--- a/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
+++ b/W3ChampionsChatService.Tests/FanOutFlushServiceTests.cs
@@ -14,15 +14,18 @@ namespace W3ChampionsChatService.Tests;
 /// <summary>
 /// C3 (Task 15) test for the <see cref="FanOutFlushService"/> — the single production
 /// <c>BackgroundService</c> whose 1s <see cref="System.Threading.PeriodicTimer"/> drains the Task 13
-/// <see cref="ActivityCoalescer"/>, Task 14 <see cref="ViewersAccumulator"/>, and the live-flair
-/// <see cref="FlairRefreshCoalescer"/>. The pure aggregator tests
-/// (<see cref="ActivityCoalescerTests"/>/<see cref="ViewersAccumulatorTests"/>/
-/// <see cref="FlairRefreshCoalescerTests"/>) already prove each one's own coalescing/batching decisions;
-/// THIS test proves the OTHER half of acceptance — that the timer loop actually invokes all three drains
-/// in production, not just in unit tests. It drives the REAL participants over the REAL
-/// <see cref="PeriodicTimer"/> path using a <see cref="FakeTimeProvider"/>, so there is NO wall-clock
-/// sleep: advancing the fake clock past every cadence (10s) must produce a coalesced
-/// <c>ChannelActivity</c>, a batched <c>ViewersChanged</c>, AND an observed flair refresh.
+/// <see cref="ActivityCoalescer"/> and Task 14 <see cref="ViewersAccumulator"/>. The pure aggregator
+/// tests (<see cref="ActivityCoalescerTests"/>/<see cref="ViewersAccumulatorTests"/>) already prove each
+/// one's own coalescing/batching decisions; THIS test proves the OTHER half of acceptance — that the
+/// timer loop actually invokes both drains in production, not just in unit tests. It drives the REAL
+/// participants over the REAL <see cref="PeriodicTimer"/> path using a <see cref="FakeTimeProvider"/>, so
+/// there is NO wall-clock sleep: advancing the fake clock past every cadence (10s) must produce a
+/// coalesced <c>ChannelActivity</c> AND a batched <c>ViewersChanged</c>.
+/// <para>
+/// The live-flair <see cref="FlairRefreshCoalescer"/>'s drain coverage lives in
+/// <see cref="FlairRefreshFlushServiceTests"/> — it moved off this service's own dedicated
+/// <see cref="FlairRefreshFlushService"/> (fix round, P1), so it is no longer this service's concern.
+/// </para>
 /// </summary>
 public class FanOutFlushServiceTests
 {
@@ -35,10 +38,6 @@ public class FanOutFlushServiceTests
     // Accumulator arming: a focused viewer whose baseline-not-viewing → now-viewing flush emits a join.
     private const string ViewerConn = "conn-viewer";
     private const string ViewerTag = "Viewer#2";
-
-    // Flair coalescer arming: a battleTag recorded before the service starts, so the timer loop's third
-    // drain must be the thing that gets it refreshed — never invoked directly by the test.
-    private const string FlairTag = "Flair#3";
 
     private static readonly DateTime T0 = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
 
@@ -79,16 +78,8 @@ public class FanOutFlushServiceTests
         Assert.AreEqual(0, ViewersChangedFor(harness, ViewerConn).Count,
             "the accumulated join must not emit until the flush service ticks");
 
-        // --- Arm the flair-refresh coalescer: it has no cadence of its own (every pending tag is due on
-        // every flush), so RecordChange before the service even starts is enough to make it due on the
-        // very first tick. The refresher RECORDS what it was asked to refresh, so this test can assert
-        // the timer loop's third drain actually ran — not just that it was constructed.
-        var flairRefresher = new RecordingFlairRefresher();
-        var flairRefreshCoalescer = new FlairRefreshCoalescer(flairRefresher);
-        flairRefreshCoalescer.RecordChange(FlairTag);
-
         var fakeTime = new FakeTimeProvider(new DateTimeOffset(T0, TimeSpan.Zero));
-        var service = new FanOutFlushService(coalescer, accumulator, flairRefreshCoalescer, fakeTime);
+        var service = new FanOutFlushService(coalescer, accumulator, fakeTime);
 
         await service.StartAsync(CancellationToken.None);
         try
@@ -107,12 +98,11 @@ public class FanOutFlushServiceTests
             // never fires the FlushDue calls.
             var flushed = await SpinUntil(() =>
                 harness.SignalCount(MemberConn, ChatEvents.ChannelActivity) >= 2 &&
-                ViewersChangedFor(harness, ViewerConn).Count >= 1 &&
-                flairRefresher.Refreshed.Contains(FlairTag));
+                ViewersChangedFor(harness, ViewerConn).Count >= 1);
 
             Assert.IsTrue(flushed,
-                "the 1s PeriodicTimer loop must invoke all three drains so the pending activity, the " +
-                "accumulated join, and the pending flair refresh all emit");
+                "the 1s PeriodicTimer loop must invoke both drains so the pending activity and the " +
+                "accumulated join both emit");
         }
         finally
         {
@@ -134,12 +124,6 @@ public class FanOutFlushServiceTests
         Assert.IsTrue(batches[0].Joined.Any(v => string.Equals(v.BattleTag, ViewerTag, StringComparison.OrdinalIgnoreCase)),
             "the timer-driven ViewersChanged batch must report the viewer as joined");
         Assert.IsEmpty(batches[0].Left);
-
-        // The flair coalescer's pending tag, recorded before the service even started, flushed via the
-        // same timer path. This is the crux of this test's fix: deleting the flair drain from
-        // FanOutFlushService.ExecuteAsync must make this assertion fail.
-        Assert.That(flairRefresher.Refreshed, Is.EqualTo(new[] { FlairTag }),
-            "the pending flair refresh must be drained exactly once via the timer");
     }
 
     // Bounded, wall-clock-free spin: yields to the scheduler up to maxSpins times, returning true as soon
@@ -157,19 +141,5 @@ public class FanOutFlushServiceTests
             await Task.Yield();
         }
         return condition();
-    }
-
-    // Records what it was asked to refresh, so this test can assert the timer loop's third drain
-    // genuinely ran — the coalescer's own collapsing/budget behaviour is covered by
-    // FlairRefreshCoalescerTests, this class exists only to make the drain OBSERVABLE here.
-    private class RecordingFlairRefresher : IFlairRefresher
-    {
-        public List<string> Refreshed { get; } = new();
-
-        public Task Refresh(string battleTag)
-        {
-            Refreshed.Add(battleTag);
-            return Task.CompletedTask;
-        }
     }
 }

--- a/W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs
@@ -97,14 +97,13 @@ public class FlairRefreshCoalescerTests
     }
 
     [Test]
-    public async Task Flush_WhenOneRefreshThrows_StillRefreshesTheRest()
+    public void Flush_WhenOneRefreshThrows_StillRefreshesTheRest()
     {
         _refresher.Throw = true;
         _coalescer.RecordChange("peter#123");
         _coalescer.RecordChange("alice#456");
 
         Assert.DoesNotThrowAsync(() => _coalescer.Flush());
-        await Task.CompletedTask;
 
         Assert.That(_refresher.Refreshed, Has.Count.EqualTo(2),
             "one player's failed refresh must not cancel everyone else's");

--- a/W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs
@@ -88,6 +88,28 @@ public class FlairRefreshCoalescerTests
     }
 
     [Test]
+    public async Task Flush_TakesOnlyThePerTickBudget_LeavingTheRemainderPendingForTheNextTick()
+    {
+        // One tick's worth plus a few more, so the first Flush must leave a genuine remainder rather
+        // than happening to drain everything anyway.
+        var total = ChatLimits.FlairRefreshPerTickBudget + 5;
+        for (var i = 0; i < total; i++) _coalescer.RecordChange($"player{i}#1");
+
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Has.Count.EqualTo(ChatLimits.FlairRefreshPerTickBudget),
+            "a single Flush must refresh no more than one tick's budget");
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(5),
+            "the remainder beyond the budget must stay pending for the next tick");
+
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Has.Count.EqualTo(total),
+            "a second Flush must refresh the leftover remainder");
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+
+    [Test]
     public void RecordChange_IgnoresBlankTags()
     {
         _coalescer.RecordChange(null);

--- a/W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+
+namespace W3ChampionsChatService.Tests;
+
+public class FlairRefreshCoalescerTests
+{
+    private class RecordingRefresher : IFlairRefresher
+    {
+        public List<string> Refreshed { get; } = new();
+        public bool Throw { get; set; }
+
+        public Task Refresh(string battleTag)
+        {
+            Refreshed.Add(battleTag);
+            if (Throw) throw new System.InvalidOperationException("refresh exploded");
+            return Task.CompletedTask;
+        }
+    }
+
+    private RecordingRefresher _refresher;
+    private FlairRefreshCoalescer _coalescer;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _refresher = new RecordingRefresher();
+        _coalescer = new FlairRefreshCoalescer(_refresher);
+    }
+
+    [Test]
+    public async Task Flush_RefreshesEachRecordedBattleTagOnce()
+    {
+        _coalescer.RecordChange("peter#123");
+        _coalescer.RecordChange("alice#456");
+
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Is.EquivalentTo(new[] { "peter#123", "alice#456" }));
+    }
+
+    [Test]
+    public async Task Flush_CollapsesABurstForOneBattleTagIntoASingleRefresh()
+    {
+        // Five writes in one tick — e.g. a reward grant that touches colour then icons — must cost one
+        // website-backend round-trip, not five.
+        for (var i = 0; i < 5; i++) _coalescer.RecordChange("peter#123");
+
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Is.EqualTo(new[] { "peter#123" }));
+    }
+
+    [Test]
+    public async Task RecordChange_IsCaseInsensitive()
+    {
+        _coalescer.RecordChange("Peter#123");
+        _coalescer.RecordChange("peter#123");
+
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Flush_DrainsThePendingSet()
+    {
+        _coalescer.RecordChange("peter#123");
+        await _coalescer.Flush();
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Is.EqualTo(new[] { "peter#123" }));
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void RecordChange_AtCapacity_DropsRatherThanGrows()
+    {
+        for (var i = 0; i < ChatLimits.FlairRefreshPendingCap + 50; i++)
+        {
+            _coalescer.RecordChange($"player{i}#1");
+        }
+
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(ChatLimits.FlairRefreshPendingCap));
+    }
+
+    [Test]
+    public void RecordChange_IgnoresBlankTags()
+    {
+        _coalescer.RecordChange(null);
+        _coalescer.RecordChange("   ");
+
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Flush_WhenOneRefreshThrows_StillRefreshesTheRest()
+    {
+        _refresher.Throw = true;
+        _coalescer.RecordChange("peter#123");
+        _coalescer.RecordChange("alice#456");
+
+        Assert.DoesNotThrowAsync(() => _coalescer.Flush());
+        await Task.CompletedTask;
+
+        Assert.That(_refresher.Refreshed, Has.Count.EqualTo(2),
+            "one player's failed refresh must not cancel everyone else's");
+    }
+}

--- a/W3ChampionsChatService.Tests/FlairRefreshFlushServiceTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefreshFlushServiceTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using NUnit.Framework;
+using W3ChampionsChatService.FanOut;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// Fix round (P1) test for <see cref="FlairRefreshFlushService"/> — the live-flair drain's OWN
+/// <c>BackgroundService</c>, split out of <see cref="FanOutFlushService"/> so a website-backend outage
+/// during a flair refresh can never stall the unrelated ActivityCoalescer/ViewersAccumulator fan-out on a
+/// shared loop (see the service's own doc comment). This test proves the isolated drain still actually
+/// runs in production, not just in <see cref="FlairRefreshCoalescerTests"/>'s direct-call unit tests: it
+/// drives the REAL <see cref="FlairRefreshCoalescer"/> over the REAL <see cref="PeriodicTimer"/> path
+/// using a <see cref="FakeTimeProvider"/>, so there is no wall-clock sleep.
+/// <para>
+/// This is the coverage that used to live in <c>FanOutFlushServiceTests</c> (moved here verbatim in
+/// spirit, not deleted) when the drain lived on the shared service.
+/// </para>
+/// </summary>
+public class FlairRefreshFlushServiceTests
+{
+    // Recorded before the service even starts, so the timer loop's OWN drain must be the thing that gets
+    // it refreshed — never invoked directly by the test.
+    private const string FlairTag = "Flair#3";
+
+    private static readonly DateTime T0 = new DateTime(2026, 7, 3, 12, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task FlushService_OnFakeClockAdvance_DrainsTheFlairRefreshCoalescer()
+    {
+        var flairRefresher = new RecordingFlairRefresher();
+        var flairRefreshCoalescer = new FlairRefreshCoalescer(flairRefresher);
+        flairRefreshCoalescer.RecordChange(FlairTag);
+
+        var fakeTime = new FakeTimeProvider(new DateTimeOffset(T0, TimeSpan.Zero));
+        var service = new FlairRefreshFlushService(flairRefreshCoalescer, fakeTime);
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            // The coalescer has no cadence of its own — every pending tag is due on the very first tick —
+            // so a single 1s advance is enough. Advance a couple of steps for margin, yielding after each
+            // so the PeriodicTimer loop body gets a turn to process the tick.
+            for (var step = 0; step < 3; step++)
+            {
+                fakeTime.Advance(TimeSpan.FromSeconds(1));
+                await Task.Yield();
+            }
+
+            // Deterministic, sleep-free wait: spin on Task.Yield (NO wall-clock Task.Delay). A correct
+            // timer path satisfies this within a few yields; the spin cap only guards against a hang if
+            // the loop never fires Flush.
+            var flushed = await SpinUntil(() => flairRefresher.Refreshed.Contains(FlairTag));
+
+            Assert.IsTrue(flushed,
+                "the 1s PeriodicTimer loop must invoke FlairRefreshCoalescer.Flush so the pending refresh emits");
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+
+        // The crux of this test: deleting the Flush() call from FlairRefreshFlushService.ExecuteAsync
+        // must make this assertion fail (mutation-sensitive — verified by hand against that mutation).
+        Assert.That(flairRefresher.Refreshed, Is.EqualTo(new[] { FlairTag }),
+            "the pending flair refresh must be drained exactly once via the timer");
+    }
+
+    // Bounded, wall-clock-free spin: yields to the scheduler up to maxSpins times, returning true as soon
+    // as the condition holds. Unlike Task.Delay this consumes no real time budget — it only cedes the
+    // current turn so the background loop's continuation can run — so it is deterministic rather than a
+    // "hope it flushed in N milliseconds" flake.
+    private static async Task<bool> SpinUntil(Func<bool> condition, int maxSpins = 100_000)
+    {
+        for (var i = 0; i < maxSpins; i++)
+        {
+            if (condition())
+            {
+                return true;
+            }
+            await Task.Yield();
+        }
+        return condition();
+    }
+
+    // Records what it was asked to refresh, so this test can assert the timer loop's drain genuinely ran
+    // — the coalescer's own collapsing/budget behaviour is covered by FlairRefreshCoalescerTests, this
+    // class exists only to make the drain OBSERVABLE here.
+    private class RecordingFlairRefresher : IFlairRefresher
+    {
+        public List<string> Refreshed { get; } = new();
+
+        public Task Refresh(string battleTag)
+        {
+            Refreshed.Add(battleTag);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/W3ChampionsChatService.Tests/FlairRefresherTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefresherTests.cs
@@ -119,6 +119,24 @@ public class FlairRefresherTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task Refresh_DoesNotEmitToAConnectionFocusedOnlyOnAnUnrelatedChannel()
+    {
+        // A connection focused only on a channel the changed player is not focused on must receive
+        // nothing — a regression to Clients.All would still pass every other test in this file.
+        const string BystanderTag = "bystander#789";
+        GoOnline("conn-peter", ChangedTag);
+        GoOnline("conn-bystander", BystanderTag);
+        _focus.Focus("conn-peter", "lounge", ChangedTag);
+        _focus.Focus("conn-bystander", "clan", BystanderTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_harness.SignalsFor("conn-bystander"), Is.Empty,
+            "a connection focused only on an unrelated channel must receive no FlairChanged signal");
+    }
+
+    [Test]
     public async Task Refresh_SendsOncePerConnection_EvenWhenSharingSeveralChannels()
     {
         GoOnline("conn-peter", ChangedTag);

--- a/W3ChampionsChatService.Tests/FlairRefresherTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefresherTests.cs
@@ -245,6 +245,43 @@ public class FlairRefresherTests : IntegrationTestBase
             "the stale pre-await session must not be used to push a FlairChanged");
     }
 
+    // Codex P2 follow-up: the pre-write revalidation (the test above) closes the "disconnect during the
+    // await" race, but ChatHub.OnDisconnectedAsync's Unregister+Remove sequence can still land in the
+    // narrow, unsynchronized gap between that revalidation and the ConnectionMapping.RegisterUser write —
+    // two separate lock sections with no await in between. Real thread preemption would only hit this
+    // non-deterministically, so a mocked ISessionRegistry is used to force the exact interleaving: the
+    // session is present for the first two reads (the initial lookup and the pre-write revalidation) and
+    // gone by the THIRD read — the post-write validation this fix adds. A real ConnectionMapping is used
+    // so the assertion exercises the actual Remove/RegisterUser interplay, not a mock.
+    [Test]
+    public async Task Refresh_WhenDisconnectRacesTheConnectionMappingWrite_LeavesNoOrphanMappingEntry()
+    {
+        var connections = new ConnectionMapping();
+        connections.RegisterUser("conn-peter", UserWith(ChangedTag, AvatarCategory.HU, 1));
+
+        var identity = new W3CUserAuthentication { BattleTag = ChangedTag, Name = "peter" };
+        var liveSession = new ChatSession { ConnectionId = "conn-peter", Identity = identity, Context = null };
+
+        var sessions = new Mock<ISessionRegistry>();
+        sessions.SetupSequence(s => s.GetByBattleTag(ChangedTag))
+            .Returns(liveSession)      // initial lookup (Refresh's first read)
+            .Returns(liveSession)      // pre-write revalidation (after the GetUserFromIdentity await)
+            .Returns((ChatSession)null); // post-write validation: disconnect landed in the gap
+
+        var auth = new Mock<IChatAuthenticationService>();
+        auth.Setup(a => a.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .ReturnsAsync(new ChatUserResolution(UserWith(ChangedTag, AvatarCategory.NE, 7), true));
+
+        var refresher = new FlairRefresher(
+            sessions.Object, auth.Object, connections, _userDirectory, _focus,
+            _harness.HubContext, new FakeTimeProvider());
+
+        await refresher.Refresh(ChangedTag);
+
+        Assert.That(connections.GetUser("conn-peter"), Is.Null,
+            "the post-write validation must remove the entry RegisterUser resurrected once the authoritative session is gone");
+    }
+
     // Finding 3 (P2): the webhook-supplied battleTag can carry website-backend's storage casing, while
     // the live session identity carries the authoritative display casing. DisplayBattleTag must always
     // win with the identity's casing — matching the connect path (ChatHub.UpsertDirectory).

--- a/W3ChampionsChatService.Tests/FlairRefresherTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefresherTests.cs
@@ -282,6 +282,44 @@ public class FlairRefresherTests : IntegrationTestBase
             "the post-write validation must remove the entry RegisterUser resurrected once the authoritative session is gone");
     }
 
+    // A newer connection can replace this session between the ConnectionMapping write and the post-write
+    // check (e.g. two closely spaced profile changes). Once that happens, this refresh is stale: it must
+    // stop after cleaning up the mapping it wrote, not fall through and overwrite a newer directory
+    // profile or broadcast an older flair to live viewers.
+    [Test]
+    public async Task Refresh_WhenDisconnectRacesTheConnectionMappingWrite_PerformsNoDirectoryUpsertOrFanOut()
+    {
+        var connections = new ConnectionMapping();
+        connections.RegisterUser("conn-peter", UserWith(ChangedTag, AvatarCategory.HU, 1));
+
+        var identity = new W3CUserAuthentication { BattleTag = ChangedTag, Name = "peter" };
+        var liveSession = new ChatSession { ConnectionId = "conn-peter", Identity = identity, Context = null };
+
+        var sessions = new Mock<ISessionRegistry>();
+        sessions.SetupSequence(s => s.GetByBattleTag(ChangedTag))
+            .Returns(liveSession)      // initial lookup (Refresh's first read)
+            .Returns(liveSession)      // pre-write revalidation (after the GetUserFromIdentity await)
+            .Returns((ChatSession)null); // post-write validation: a newer connection took over in the gap
+
+        var auth = new Mock<IChatAuthenticationService>();
+        auth.Setup(a => a.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .ReturnsAsync(new ChatUserResolution(UserWith(ChangedTag, AvatarCategory.NE, 7), true));
+
+        var refresher = new FlairRefresher(
+            sessions.Object, auth.Object, connections, _userDirectory, _focus,
+            _harness.HubContext, new FakeTimeProvider());
+
+        await refresher.Refresh(ChangedTag);
+
+        Assert.That(connections.GetUser("conn-peter"), Is.Null,
+            "the stale mapping write must still be cleaned up");
+        var entry = await _userDirectory.Load(ChangedTag);
+        Assert.That(entry, Is.Null,
+            "a stale refresh must not overwrite the directory profile a newer refresh may have already written");
+        Assert.That(_harness.AllSignals, Is.Empty,
+            "a stale refresh must not broadcast an outdated flair to live viewers");
+    }
+
     // Finding 3 (P2): the webhook-supplied battleTag can carry website-backend's storage casing, while
     // the live session identity carries the authoritative display casing. DisplayBattleTag must always
     // win with the identity's casing — matching the connect path (ChatHub.UpsertDirectory).

--- a/W3ChampionsChatService.Tests/FlairRefresherTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefresherTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// The FreshFromWb rule is the single most important behaviour here: a website-backend blip must never
+/// broadcast a degraded profile to every viewer in a channel.
+/// </summary>
+public class FlairRefresherTests : IntegrationTestBase
+{
+    private const string ChangedTag = "peter#123";
+    private const string ViewerTag = "alice#456";
+
+    private HubPushCaptureHarness _harness;
+    private SessionRegistry _sessions;
+    private ConnectionMapping _connections;
+    private FocusRegistry _focus;
+    private UserDirectoryRepository _userDirectory;
+    private Mock<IChatAuthenticationService> _auth;
+    private FlairRefresher _refresher;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _harness = new HubPushCaptureHarness();
+        _sessions = new SessionRegistry();
+        _connections = new ConnectionMapping();
+        _focus = new FocusRegistry();
+        _userDirectory = new UserDirectoryRepository(MongoClient);
+        _auth = new Mock<IChatAuthenticationService>();
+
+        _refresher = new FlairRefresher(
+            _sessions, _auth.Object, _connections, _userDirectory, _focus,
+            _harness.HubContext, new FakeTimeProvider());
+    }
+
+    private static ChatUser UserWith(string battleTag, AvatarCategory race, long pictureId) =>
+        new(battleTag, false, "W3C",
+            new ProfilePicture { Race = race, PictureId = pictureId, IsClassic = false },
+            new ChatColor("chat_color_purple"),
+            [new ChatIcon("chat_icon_crown")]);
+
+    private void GoOnline(string connectionId, string battleTag)
+    {
+        _sessions.Register(connectionId, new W3CUserAuthentication { BattleTag = battleTag, Name = battleTag.Split('#')[0] }, null);
+        _connections.RegisterUser(connectionId, UserWith(battleTag, AvatarCategory.HU, 1));
+    }
+
+    private void ResolvesTo(ChatUser user, bool freshFromWb) =>
+        _auth.Setup(a => a.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .ReturnsAsync(new ChatUserResolution(user, freshFromWb));
+
+    [Test]
+    public async Task Refresh_WithNoLiveSession_IsANoOp()
+    {
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        _auth.Verify(a => a.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()), Times.Never);
+        Assert.That(_harness.AllSignals, Is.Empty);
+    }
+
+    [Test]
+    public async Task Refresh_UpdatesConnectionMappingSoTheirOwnNextMessageCarriesTheNewFlair()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        var cached = _connections.GetUser("conn-peter");
+        Assert.That(cached.ProfilePicture.Race, Is.EqualTo(AvatarCategory.NE));
+        Assert.That(cached.ProfilePicture.PictureId, Is.EqualTo(7));
+    }
+
+    [Test]
+    public async Task Refresh_EmitsFlairChangedToTheChangedUsersOwnConnection_EvenWithNoFocus()
+    {
+        // A user focused on nothing must still see their OWN avatar update.
+        GoOnline("conn-peter", ChangedTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        var signals = _harness.SignalsFor("conn-peter").Where(s => s.Method == ChatEvents.FlairChanged).ToList();
+        Assert.That(signals, Has.Count.EqualTo(1));
+        var payload = (FlairChangedDto)signals.Single().Payload;
+        Assert.That(payload.BattleTag, Is.EqualTo(ChangedTag));
+        Assert.That(payload.Profile.ProfilePicture.PictureId, Is.EqualTo(7));
+        Assert.That(payload.Profile.ClanId, Is.EqualTo("W3C"));
+    }
+
+    [Test]
+    public async Task Refresh_EmitsToEveryConnectionFocusedOnAChannelTheChangedUserIsFocusedOn()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        GoOnline("conn-alice", ViewerTag);
+        _focus.Focus("conn-peter", "lounge", ChangedTag);
+        _focus.Focus("conn-alice", "lounge", ViewerTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_harness.SignalsFor("conn-alice").Count(s => s.Method == ChatEvents.FlairChanged), Is.EqualTo(1));
+        Assert.That(_harness.SignalsFor("conn-peter").Count(s => s.Method == ChatEvents.FlairChanged), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Refresh_SendsOncePerConnection_EvenWhenSharingSeveralChannels()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        GoOnline("conn-alice", ViewerTag);
+        _focus.Focus("conn-peter", "lounge", ChangedTag);
+        _focus.Focus("conn-peter", "clan", ChangedTag);
+        _focus.Focus("conn-alice", "lounge", ViewerTag);
+        _focus.Focus("conn-alice", "clan", ViewerTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_harness.SignalsFor("conn-alice").Count(s => s.Method == ChatEvents.FlairChanged), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Refresh_WhenNotFreshFromWb_DoesNothingAtAll()
+    {
+        // THE RULE. A wb blip resolves to a degraded tier-3 profile. Acting on it would replace good
+        // cached flair and broadcast the default avatar to everyone viewing this user — turning a
+        // transient upstream hiccup into a visible regression for the whole channel.
+        GoOnline("conn-peter", ChangedTag);
+        GoOnline("conn-alice", ViewerTag);
+        _focus.Focus("conn-peter", "lounge", ChangedTag);
+        _focus.Focus("conn-alice", "lounge", ViewerTag);
+
+        var degraded = new ChatUser(ChangedTag, false, null, new ProfilePicture(), null, null);
+        ResolvesTo(degraded, false);
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_harness.AllSignals, Is.Empty, "no FlairChanged may be emitted on a stale resolution");
+
+        var cached = _connections.GetUser("conn-peter");
+        Assert.That(cached.ProfilePicture.Race, Is.EqualTo(AvatarCategory.HU),
+            "the good cached ChatUser must survive — never clobbered by a degraded resolution");
+        Assert.That(cached.ClanTag, Is.EqualTo("W3C"));
+
+        var entry = await _userDirectory.Load(ChangedTag);
+        Assert.That(entry, Is.Null, "no directory write may happen on a stale resolution");
+    }
+
+    [Test]
+    public async Task Refresh_WhenFreshFromWb_WritesTheDirectoryProfile()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        var entry = await _userDirectory.Load(ChangedTag);
+        Assert.That(entry, Is.Not.Null);
+        Assert.That(entry.Profile.ProfilePicture.PictureId, Is.EqualTo(7));
+    }
+}

--- a/W3ChampionsChatService.Tests/FlairRefresherTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefresherTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Time.Testing;
@@ -6,7 +5,6 @@ using Moq;
 using NUnit.Framework;
 using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Chats;
-using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Protocol;
 using W3ChampionsChatService.Sessions;

--- a/W3ChampionsChatService.Tests/FlairRefresherTests.cs
+++ b/W3ChampionsChatService.Tests/FlairRefresherTests.cs
@@ -191,4 +191,84 @@ public class FlairRefresherTests : IntegrationTestBase
         Assert.That(entry, Is.Not.Null);
         Assert.That(entry.Profile.ProfilePicture.PictureId, Is.EqualTo(7));
     }
+
+    // Finding 2 (P2): a player can disconnect WHILE GetUserFromIdentity is in flight. Every side effect
+    // after that await must be skipped, or ConnectionMapping.RegisterUser resurrects an entry that
+    // ChatHub.OnDisconnectedAsync's `finally` already removed — and since disconnect only fires once,
+    // nothing would ever remove it again (an unbounded leak under repeated races).
+    [Test]
+    public async Task Refresh_WhenTheSessionDisconnectsDuringTheAwait_SkipsEverySideEffect()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        _auth.Setup(a => a.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .Returns(async () =>
+            {
+                // Simulate ChatHub.OnDisconnectedAsync's `finally` block running while this call is
+                // in flight: Unregister the session, then remove the connection→user mapping — exactly
+                // what the hub does, in the same order.
+                _sessions.Unregister("conn-peter");
+                _connections.Remove("conn-peter");
+                await Task.Yield();
+                return new ChatUserResolution(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+            });
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_connections.GetUser("conn-peter"), Is.Null,
+            "RegisterUser must not resurrect an entry ChatHub.OnDisconnectedAsync already removed");
+        Assert.That(_harness.AllSignals, Is.Empty,
+            "no FlairChanged may be sent to a connection that disconnected mid-refresh");
+        var entry = await _userDirectory.Load(ChangedTag);
+        Assert.That(entry, Is.Null, "no directory write may happen for a session that is no longer live");
+    }
+
+    // Finding 2 (P2), reconnect variant: the player disconnects AND reconnects under a NEW connection id
+    // while GetUserFromIdentity is in flight. The stale `session` captured before the await must not be
+    // acted on even though a session for the battleTag exists again — it is not the SAME connection.
+    [Test]
+    public async Task Refresh_WhenTheSessionReconnectsUnderANewConnectionDuringTheAwait_SkipsEverySideEffect()
+    {
+        GoOnline("conn-peter-old", ChangedTag);
+        _auth.Setup(a => a.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .Returns(async () =>
+            {
+                _sessions.Unregister("conn-peter-old");
+                _connections.Remove("conn-peter-old");
+                GoOnline("conn-peter-new", ChangedTag);
+                await Task.Yield();
+                return new ChatUserResolution(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+            });
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_connections.GetUser("conn-peter-old"), Is.Null,
+            "the OLD connection's mapping must not be resurrected");
+        Assert.That(_harness.AllSignals, Is.Empty,
+            "the stale pre-await session must not be used to push a FlairChanged");
+    }
+
+    // Finding 3 (P2): the webhook-supplied battleTag can carry website-backend's storage casing, while
+    // the live session identity carries the authoritative display casing. DisplayBattleTag must always
+    // win with the identity's casing — matching the connect path (ChatHub.UpsertDirectory).
+    [Test]
+    public async Task Refresh_UsesTheSessionIdentitysCasing_NotTheWebhookSuppliedCasing()
+    {
+        const string IdentityCasedTag = "Peter#123";
+        const string WebhookCasedTag = "peter#123";
+        GoOnline("conn-peter", IdentityCasedTag);
+        ResolvesTo(UserWith(IdentityCasedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(WebhookCasedTag);
+
+        var entry = await _userDirectory.Load(IdentityCasedTag);
+        Assert.That(entry, Is.Not.Null);
+        Assert.That(entry.DisplayBattleTag, Is.EqualTo(IdentityCasedTag),
+            "the session identity's display casing must win over the webhook-supplied casing");
+
+        var signals = _harness.SignalsFor("conn-peter").Where(s => s.Method == ChatEvents.FlairChanged).ToList();
+        Assert.That(signals, Has.Count.EqualTo(1));
+        var payload = (FlairChangedDto)signals.Single().Payload;
+        Assert.That(payload.BattleTag, Is.EqualTo(IdentityCasedTag),
+            "the pushed FlairChangedDto must also carry the identity's casing, matching the directory write");
+    }
 }

--- a/W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;

--- a/W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+using W3ChampionsChatService.Internal;
+
+namespace W3ChampionsChatService.Tests;
+
+public class InternalProfileChangesControllerTests
+{
+    private class NoOpRefresher : IFlairRefresher
+    {
+        public System.Threading.Tasks.Task Refresh(string battleTag) => System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    private FlairRefreshCoalescer _coalescer;
+    private InternalProfileChangesController _controller;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _coalescer = new FlairRefreshCoalescer(new NoOpRefresher());
+        _controller = new InternalProfileChangesController(_coalescer)
+        {
+            // No-TestServer controller idiom shared with InternalRelationshipChangesControllerTests:
+            // Post logs via InternalHmacAuthFilter.ResolveCaller(HttpContext), which NREs against the
+            // default null HttpContext a directly-constructed controller otherwise has.
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
+    }
+
+    private static InternalProfileChangeRequest Request(params string[] battleTags) =>
+        new() { BattleTags = battleTags.ToList() };
+
+    [Test]
+    public void Post_EnqueuesEveryBattleTag()
+    {
+        var result = _controller.Post(Request("peter#123", "alice#456"));
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Post_AtTheCap_IsAccepted()
+    {
+        var tags = Enumerable.Range(0, ChatLimits.InternalMaxMembersPerCall).Select(i => $"player{i}#1").ToArray();
+
+        Assert.That(_controller.Post(Request(tags)), Is.InstanceOf<OkResult>());
+    }
+
+    [Test]
+    public void Post_OverTheCap_IsRejectedWithNoPartialProcessing()
+    {
+        var tags = Enumerable.Range(0, ChatLimits.InternalMaxMembersPerCall + 1).Select(i => $"player{i}#1").ToArray();
+
+        Assert.That(_controller.Post(Request(tags)), Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Post_WithNullRequest_IsRejected()
+    {
+        Assert.That(_controller.Post(null), Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [Test]
+    public void Post_WithNoBattleTags_IsRejected()
+    {
+        Assert.That(_controller.Post(new InternalProfileChangeRequest { BattleTags = null }), Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(_controller.Post(Request()), Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("peter\u0000123")]
+    [TestCase("peter\u2028123")]
+    [TestCase("peter\u2029123")]
+    public void Post_WithAnInvalidBattleTag_RejectsTheWholeBatch(string invalid)
+    {
+        // No partial processing: one bad entry rejects the batch, and nothing is enqueued.
+        Assert.That(_controller.Post(Request("peter#123", invalid)), Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+}

--- a/W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs
+++ b/W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NUnit.Framework;
+using W3ChampionsChatService.Authentication;
 using W3ChampionsChatService.Domain;
 using W3ChampionsChatService.FanOut;
 using W3ChampionsChatService.Internal;
@@ -84,5 +86,27 @@ public class InternalProfileChangesControllerTests
         // No partial processing: one bad entry rejects the batch, and nothing is enqueued.
         Assert.That(_controller.Post(Request("peter#123", invalid)), Is.InstanceOf<BadRequestObjectResult>());
         Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+
+    // ── H1 realm-disjointness (Wb-only pin) ──────────────────────────────────────────────────────
+
+    [Test]
+    public void Controller_DeclaresHmacAttribute_WbOnly_NoUserHasPermission()
+    {
+        var type = typeof(InternalProfileChangesController);
+
+        var hmac = type.GetCustomAttribute<InternalHmacAuthAttribute>();
+        Assert.That(hmac, Is.Not.Null,
+            "the profile-changes controller must be HMAC-gated at class level (H1)");
+        Assert.That(hmac.AllowedCallers, Is.EqualTo(new[] { InternalCaller.Wb }),
+            "InternalProfileChangesController must allow EXACTLY Wb (least privilege) — flair refreshes are website-backend's to trigger");
+
+        Assert.That(type.GetCustomAttribute<UserHasPermissionAttribute>(), Is.Null,
+            "internal/* controllers live in the HMAC realm, never the JWT/permission realm");
+        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        {
+            Assert.That(method.GetCustomAttribute<UserHasPermissionAttribute>(), Is.Null,
+                $"{type.Name}.{method.Name} must not carry [UserHasPermission] — the two auth realms must stay disjoint");
+        }
     }
 }

--- a/W3ChampionsChatService/Chats/ChatHub.cs
+++ b/W3ChampionsChatService/Chats/ChatHub.cs
@@ -284,26 +284,8 @@ public partial class ChatHub(
     // ChatUser's flair. Non-fatal: a directory write must never fail a connect. `now` is the caller's
     // single injected-clock read (OnConnectedAsync) — routed through, not read again here, so this
     // stays on the SAME TimeProvider clock as the rest of the connect path.
-    private async Task UpsertDirectory(W3CUserAuthentication identity, ChatUserResolution resolution, DateTime now)
-    {
-        try
-        {
-            var entry = await _userDirectory.Load(identity.BattleTag)
-                ?? new UserDirectoryEntry { BattleTag = identity.BattleTag };
-            entry.DisplayBattleTag = identity.BattleTag;
-            entry.NormalizedName = identity.BattleTag?.Trim().ToLowerInvariant();
-            entry.LastSeenAt = now;
-            if (resolution.FreshFromWb)
-            {
-                entry.Profile = ChatProfileMapper.FromChatUser(resolution.User);
-            }
-            await _userDirectory.Upsert(entry);
-        }
-        catch (Exception ex)
-        {
-            Log.Warning(ex, "Failed to upsert user_directory entry for {BattleTag}", identity.BattleTag);
-        }
-    }
+    private Task UpsertDirectory(W3CUserAuthentication identity, ChatUserResolution resolution, DateTime now) =>
+        UserDirectoryUpsert.Apply(_userDirectory, identity.BattleTag, resolution, now);
 
     // C5 (Task 1): best-effort connect-time friend-presence push. Deliberately fire-and-forget — the
     // caller does NOT await it, so a slow/unreachable wb read never adds latency to (or fails) a connect.

--- a/W3ChampionsChatService/Chats/UserDirectoryUpsert.cs
+++ b/W3ChampionsChatService/Chats/UserDirectoryUpsert.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading.Tasks;
+using Serilog;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.Chats;
+
+/// <summary>
+/// The user-directory write shared by the connect path (<c>ChatHub.UpsertDirectory</c>) and the live
+/// flair-refresh path (<c>FanOut.FlairRefresher</c>).
+/// <para>
+/// Extracted so the NEVER-CLOBBER rule exists once: identity fields are always refreshed, but
+/// <see cref="UserDirectoryEntry.Profile"/> is replaced ONLY when the resolution came fresh from
+/// website-backend. Two copies of this rule would be two chances to get it wrong, and the failure
+/// mode — overwriting a good cached profile with a degraded one — is invisible until a user complains
+/// that their avatar reverted.
+/// </para>
+/// <para>
+/// Non-fatal by design: a directory write failure is logged and swallowed. Neither caller should fail
+/// because a cache update did.
+/// </para>
+/// </summary>
+public static class UserDirectoryUpsert
+{
+    public static async Task Apply(
+        UserDirectoryRepository userDirectory,
+        string battleTag,
+        ChatUserResolution resolution,
+        DateTime now)
+    {
+        try
+        {
+            var entry = await userDirectory.Load(battleTag)
+                ?? new UserDirectoryEntry { BattleTag = battleTag };
+            entry.DisplayBattleTag = battleTag;
+            entry.NormalizedName = battleTag?.Trim().ToLowerInvariant();
+            entry.LastSeenAt = now;
+            if (resolution.FreshFromWb)
+            {
+                entry.Profile = ChatProfileMapper.FromChatUser(resolution.User);
+            }
+            await userDirectory.Upsert(entry);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to upsert user_directory entry for {BattleTag}", battleTag);
+        }
+    }
+}

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -255,4 +255,11 @@ public static class ChatLimits
     /// hits it" was unfalsifiable in production. A sustained-denial user must not spam the log on every
     /// call, so this bounds it to once per window. Not spec §13 text; hard-coded, adjust here only.</summary>
     public static readonly TimeSpan ReadRateLimiterDenyLogInterval = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Maximum battleTags the flair-refresh coalescer will hold between flushes. At the cap it DROPS
+    /// new tags rather than growing: a dropped refresh degrades to the reconnect backstop, whereas an
+    /// unbounded set would let a website-backend write storm consume memory here.
+    /// </summary>
+    public const int FlairRefreshPendingCap = 512;
 }

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -265,13 +265,17 @@ public static class ChatLimits
 
     /// <summary>
     /// One flush tick's flair-refresh budget: <see cref="FanOut.FlairRefreshCoalescer.Flush"/> drains at
-    /// most this many pending battleTags per call, leaving any remainder pending for the next tick. Each
-    /// refresh is a website-backend HTTP round trip plus a Mongo load/upsert plus per-connection
-    /// SignalR sends — qualitatively heavier than the other two <see cref="FanOut.FanOutFlushService"/>
-    /// participants, which are pure in-memory work. Unbounded draining lets a large burst (e.g. a bulk
-    /// clan delete notifying every online former member) starve the coalescer's and accumulator's
-    /// flushes on the same shared 1s tick for as long as the burst takes to drain. This is safe to bound
-    /// because the coalescer's semantics already tolerate a tag being refreshed a tick later.
+    /// most this many pending battleTags per call, leaving any remainder pending for the next tick.
+    /// <para>
+    /// Now that the drain runs on its own <see cref="FanOut.FlairRefreshFlushService"/> (fix round, P1) —
+    /// not the shared <see cref="FanOut.FanOutFlushService"/> loop — this budget no longer protects that
+    /// loop's cadence; an unbounded drain can no longer stall unrelated live-chat fan-out regardless of
+    /// burst size. What it still protects is website-backend itself: each refresh is an HTTP round trip
+    /// plus a Mongo load/upsert plus per-connection SignalR sends, so an unbounded drain would let a large
+    /// burst (e.g. a bulk clan delete notifying every online former member) fire dozens-to-hundreds of
+    /// concurrent-ish website-backend requests from a single tick. This is safe to bound because the
+    /// coalescer's semantics already tolerate a tag being refreshed a tick later.
+    /// </para>
     /// </summary>
     public const int FlairRefreshPerTickBudget = 32;
 }

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -262,4 +262,16 @@ public static class ChatLimits
     /// unbounded set would let a website-backend write storm consume memory here.
     /// </summary>
     public const int FlairRefreshPendingCap = 512;
+
+    /// <summary>
+    /// One flush tick's flair-refresh budget: <see cref="FanOut.FlairRefreshCoalescer.Flush"/> drains at
+    /// most this many pending battleTags per call, leaving any remainder pending for the next tick. Each
+    /// refresh is a website-backend HTTP round trip plus a Mongo load/upsert plus per-connection
+    /// SignalR sends — qualitatively heavier than the other two <see cref="FanOut.FanOutFlushService"/>
+    /// participants, which are pure in-memory work. Unbounded draining lets a large burst (e.g. a bulk
+    /// clan delete notifying every online former member) starve the coalescer's and accumulator's
+    /// flushes on the same shared 1s tick for as long as the burst takes to drain. This is safe to bound
+    /// because the coalescer's semantics already tolerate a tag being refreshed a tick later.
+    /// </summary>
+    public const int FlairRefreshPerTickBudget = 32;
 }

--- a/W3ChampionsChatService/FanOut/FanOutFlushService.cs
+++ b/W3ChampionsChatService/FanOut/FanOutFlushService.cs
@@ -7,15 +7,20 @@ using Serilog;
 namespace W3ChampionsChatService.FanOut;
 
 /// <summary>
-/// The single production driver that makes the Task 13/14/live-flair fan-out timers actually fire. The
+/// The single production driver that makes the Task 13/14 fan-out timers actually fire. The
 /// <see cref="ActivityCoalescer"/> and <see cref="ViewersAccumulator"/> are PURE, deterministic-time
 /// sinks — they emit ONLY when their own cadence (10s coalesce / 5s viewers flush) has elapsed as of the
-/// explicit <c>now</c> handed to <c>FlushDue</c>, and NOTHING calls <c>FlushDue</c> outside tests. The
-/// <see cref="FlairRefreshCoalescer"/> is the same idea with no cadence of its own — its window IS the
-/// flush tick, so every pending battleTag is due on every flush. This hosted service is the caller for
-/// all three: a 1s <see cref="PeriodicTimer"/> that, every tick, drains each with the current clock. It
-/// is what turns their unit-tested coalescing/batching decisions into live behaviour in production
-/// (acceptance: makes tasks 1/2/4 run in production, not just tests).
+/// explicit <c>now</c> handed to <c>FlushDue</c>, and NOTHING calls <c>FlushDue</c> outside tests. This
+/// hosted service is the caller for both: a 1s <see cref="PeriodicTimer"/> that, every tick, drains each
+/// with the current clock. It is what turns their unit-tested coalescing/batching decisions into live
+/// behaviour in production (acceptance: makes tasks 1/2 run in production, not just tests).
+/// <para>
+/// The live-flair <see cref="FlairRefreshCoalescer"/> deliberately does NOT share this loop — see
+/// <see cref="FlairRefreshFlushService"/>, its own dedicated driver. A flair refresh is a website-backend
+/// HTTP round trip plus Mongo I/O plus per-connection sends, qualitatively heavier than the pure in-memory
+/// work here; sharing a loop would let a website-backend outage stall this service's unrelated fan-out
+/// for as long as the outage lasts (fix round, P1).
+/// </para>
 /// <para>
 /// Mirrors <see cref="Domain.WeeklyCleanupService"/>'s do/while +
 /// <see cref="PeriodicTimer.WaitForNextTickAsync"/> loop and its catch-log-continue discipline — a single
@@ -23,14 +28,12 @@ namespace W3ChampionsChatService.FanOut;
 /// timer deterministically testable: the timer is built with the <see cref="TimeProvider"/> overload and
 /// <c>now</c> is read from that same injected clock (never <see cref="DateTime.UtcNow"/>), so a
 /// <c>FakeTimeProvider</c> drives the whole path without wall-clock sleeps. Each drain call is isolated
-/// in its OWN try/catch so a throw in one can neither crash the loop nor skip the others on the same
-/// tick.
+/// in its OWN try/catch so a throw in one can neither crash the loop nor skip the other on the same tick.
 /// </para>
 /// </summary>
 public class FanOutFlushService(
     ActivityCoalescer coalescer,
     ViewersAccumulator accumulator,
-    FlairRefreshCoalescer flairRefreshCoalescer,
     TimeProvider timeProvider) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -58,15 +61,6 @@ public class FanOutFlushService(
             catch (Exception e)
             {
                 Log.Error(e, "ViewersAccumulator flush failed; will retry next tick");
-            }
-
-            try
-            {
-                await flairRefreshCoalescer.Flush();
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "FlairRefreshCoalescer flush failed; will retry next tick");
             }
         } while (await timer.WaitForNextTickAsync(stoppingToken));
     }

--- a/W3ChampionsChatService/FanOut/FanOutFlushService.cs
+++ b/W3ChampionsChatService/FanOut/FanOutFlushService.cs
@@ -7,27 +7,30 @@ using Serilog;
 namespace W3ChampionsChatService.FanOut;
 
 /// <summary>
-/// The single production driver that makes the Task 13/14 fan-out timers actually fire. The
+/// The single production driver that makes the Task 13/14/live-flair fan-out timers actually fire. The
 /// <see cref="ActivityCoalescer"/> and <see cref="ViewersAccumulator"/> are PURE, deterministic-time
 /// sinks — they emit ONLY when their own cadence (10s coalesce / 5s viewers flush) has elapsed as of the
-/// explicit <c>now</c> handed to <c>FlushDue</c>, and NOTHING calls <c>FlushDue</c> outside tests. This
-/// hosted service is that caller: a 1s <see cref="PeriodicTimer"/> that, every tick, drains BOTH
-/// aggregators with the current clock. It is what turns their unit-tested coalescing/batching decisions
-/// into live behaviour in production (acceptance: makes tasks 1/2/4 run in production, not just tests).
+/// explicit <c>now</c> handed to <c>FlushDue</c>, and NOTHING calls <c>FlushDue</c> outside tests. The
+/// <see cref="FlairRefreshCoalescer"/> is the same idea with no cadence of its own — its window IS the
+/// flush tick, so every pending battleTag is due on every flush. This hosted service is the caller for
+/// all three: a 1s <see cref="PeriodicTimer"/> that, every tick, drains each with the current clock. It
+/// is what turns their unit-tested coalescing/batching decisions into live behaviour in production
+/// (acceptance: makes tasks 1/2/4 run in production, not just tests).
 /// <para>
 /// Mirrors <see cref="Domain.WeeklyCleanupService"/>'s do/while +
 /// <see cref="PeriodicTimer.WaitForNextTickAsync"/> loop and its catch-log-continue discipline — a single
 /// tick's failure is logged and swallowed so the loop never dies. TWO deliberate deviations make the
 /// timer deterministically testable: the timer is built with the <see cref="TimeProvider"/> overload and
 /// <c>now</c> is read from that same injected clock (never <see cref="DateTime.UtcNow"/>), so a
-/// <c>FakeTimeProvider</c> drives the whole path without wall-clock sleeps. Each <c>FlushDue</c> call is
-/// isolated in its OWN try/catch so a throw draining one aggregator can neither crash the loop nor skip
-/// the other aggregator on the same tick.
+/// <c>FakeTimeProvider</c> drives the whole path without wall-clock sleeps. Each drain call is isolated
+/// in its OWN try/catch so a throw in one can neither crash the loop nor skip the others on the same
+/// tick.
 /// </para>
 /// </summary>
 public class FanOutFlushService(
     ActivityCoalescer coalescer,
     ViewersAccumulator accumulator,
+    FlairRefreshCoalescer flairRefreshCoalescer,
     TimeProvider timeProvider) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -55,6 +58,15 @@ public class FanOutFlushService(
             catch (Exception e)
             {
                 Log.Error(e, "ViewersAccumulator flush failed; will retry next tick");
+            }
+
+            try
+            {
+                await flairRefreshCoalescer.Flush();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "FlairRefreshCoalescer flush failed; will retry next tick");
             }
         } while (await timer.WaitForNextTickAsync(stoppingToken));
     }

--- a/W3ChampionsChatService/FanOut/FlairRefreshCoalescer.cs
+++ b/W3ChampionsChatService/FanOut/FlairRefreshCoalescer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
 using W3ChampionsChatService.Domain;
@@ -45,14 +46,21 @@ public class FlairRefreshCoalescer(IFlairRefresher refresher)
         }
     }
 
+    /// <summary>
+    /// Drains at most <see cref="ChatLimits.FlairRefreshPerTickBudget"/> pending battleTags, leaving any
+    /// remainder pending for a later call. Each refresh is a website-backend HTTP round trip plus Mongo
+    /// I/O plus per-connection sends — a bounded slice keeps one large burst (e.g. a bulk clan delete)
+    /// from monopolizing the shared flush tick this coalescer shares with the other, purely in-memory,
+    /// <see cref="FanOutFlushService"/> participants.
+    /// </summary>
     public async Task Flush()
     {
         List<string> due;
         lock (_lock)
         {
             if (_pending.Count == 0) return;
-            due = new List<string>(_pending);
-            _pending.Clear();
+            due = _pending.Take(ChatLimits.FlairRefreshPerTickBudget).ToList();
+            foreach (var battleTag in due) _pending.Remove(battleTag);
         }
 
         foreach (var battleTag in due)

--- a/W3ChampionsChatService/FanOut/FlairRefreshCoalescer.cs
+++ b/W3ChampionsChatService/FanOut/FlairRefreshCoalescer.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Serilog;
+using W3ChampionsChatService.Domain;
+
+namespace W3ChampionsChatService.FanOut;
+
+/// <summary>
+/// Collapses a burst of flair-change notifications for the same player into one refresh per flush
+/// tick. website-backend deliberately over-notifies (it pings on any settings save, not only
+/// flair-relevant ones), and a single user action can cross the persistence boundary several times —
+/// this is where that volume is absorbed.
+/// <para>
+/// Mirrors the discipline of <see cref="ActivityCoalescer"/> and <see cref="ViewersAccumulator"/>:
+/// mutate state under one lock, do the work outside it, fault-isolate per item.
+/// </para>
+/// </summary>
+public class FlairRefreshCoalescer(IFlairRefresher refresher)
+{
+    private readonly IFlairRefresher _refresher = refresher;
+    private readonly HashSet<string> _pending = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _lock = new();
+
+    /// <summary>Test seam.</summary>
+    internal int PendingCount
+    {
+        get { lock (_lock) { return _pending.Count; } }
+    }
+
+    public void RecordChange(string battleTag)
+    {
+        if (string.IsNullOrWhiteSpace(battleTag)) return;
+
+        lock (_lock)
+        {
+            // At the cap, drop rather than grow. Dropping degrades to the reconnect backstop; growing
+            // without bound would let an upstream write storm become a memory problem here.
+            if (_pending.Count >= ChatLimits.FlairRefreshPendingCap && !_pending.Contains(battleTag))
+            {
+                return;
+            }
+
+            _pending.Add(battleTag);
+        }
+    }
+
+    public async Task Flush()
+    {
+        List<string> due;
+        lock (_lock)
+        {
+            if (_pending.Count == 0) return;
+            due = new List<string>(_pending);
+            _pending.Clear();
+        }
+
+        foreach (var battleTag in due)
+        {
+            try
+            {
+                await _refresher.Refresh(battleTag);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Flair refresh failed for {BattleTag} — skipping, the next connect re-enriches", battleTag);
+            }
+        }
+    }
+}

--- a/W3ChampionsChatService/FanOut/FlairRefreshFlushService.cs
+++ b/W3ChampionsChatService/FanOut/FlairRefreshFlushService.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace W3ChampionsChatService.FanOut;
+
+/// <summary>
+/// The single production driver behind <see cref="FlairRefreshCoalescer"/>. Split out from
+/// <see cref="FanOutFlushService"/> (fix round, P1) because a flair refresh is qualitatively different
+/// work from that service's other two participants: <see cref="ActivityCoalescer"/> and
+/// <see cref="ViewersAccumulator"/> are pure, in-memory, bounded-time sinks, while
+/// <see cref="FlairRefreshCoalescer.Flush"/> is a serial loop of website-backend HTTP round trips (each
+/// capped at <see cref="Chats.WebsiteBackendRepository"/>'s 2s timeout) plus Mongo I/O plus per-connection
+/// SignalR sends. On a shared flush loop, a website-backend outage occupies the loop for up to
+/// budget × 2s, stalling the unrelated coalescer/accumulator fan-out globally for as long as the outage
+/// lasts — merely shrinking the per-tick budget rescales that stall, it does not remove it. Draining on
+/// its OWN <see cref="BackgroundService"/> means a flair-refresh stall can never delay live-chat fan-out,
+/// no matter how large or slow the flair burst is.
+/// <para>
+/// Mirrors <see cref="Domain.WeeklyCleanupService"/>'s do/while + <see cref="PeriodicTimer.WaitForNextTickAsync"/>
+/// loop and its catch-log-continue discipline — a single tick's failure is logged and swallowed so the
+/// loop never dies. Like <see cref="FanOutFlushService"/>, the timer is built with the
+/// <see cref="TimeProvider"/> overload so a <c>FakeTimeProvider</c> drives the whole path deterministically
+/// in tests, with no wall-clock sleep.
+/// </para>
+/// </summary>
+public class FlairRefreshFlushService(
+    FlairRefreshCoalescer flairRefreshCoalescer,
+    TimeProvider timeProvider) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1), timeProvider);
+        do
+        {
+            try
+            {
+                await flairRefreshCoalescer.Flush();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "FlairRefreshCoalescer flush failed; will retry next tick");
+            }
+        } while (await timer.WaitForNextTickAsync(stoppingToken));
+    }
+}

--- a/W3ChampionsChatService/FanOut/FlairRefresher.cs
+++ b/W3ChampionsChatService/FanOut/FlairRefresher.cs
@@ -55,61 +55,44 @@ public class FlairRefresher(
 
         var resolution = await _chatAuthenticationService.GetUserFromIdentity(session.Identity);
 
-        // Fix round P2 (findings 2+3): re-validate AFTER the await, before any side effect. The awaited
-        // wb round-trip above is a window in which the player can disconnect, or reconnect under a new
-        // connection id. If the authoritative session for this battleTag is no longer THIS connection,
-        // every side effect below must be skipped:
-        //  - acting on the stale `session` would resurrect ConnectionMapping's entry for a connection
-        //    ChatHub.OnDisconnectedAsync already tore down (Remove runs in a `finally`, unconditionally,
-        //    then RegisterUser's unconditional `_users[connectionId] = user` would recreate it) —
-        //    disconnect fires once, so nothing would ever remove it again: an unbounded leak under
-        //    repeated connect/disconnect-during-refresh races.
-        //  - the send targets below would include a dead SignalR connection id (harmless — sends to a
-        //    dead connection are silent no-ops — but pointless).
+        // The awaited wb round-trip above is a window in which the player can disconnect, or reconnect
+        // under a new connection id. Re-validate against the authoritative session before touching any
+        // state: acting on the stale `session` would resurrect a ConnectionMapping entry that
+        // ChatHub.OnDisconnectedAsync's `finally` already tore down, and since disconnect fires exactly
+        // once, nothing would ever remove it again — an unbounded leak under repeated connect/disconnect
+        // races.
         var current = _sessionRegistry.GetByBattleTag(battleTag);
         if (current == null || current.ConnectionId != session.ConnectionId) return;
 
-        // THE RULE (spec §5). A wb blip degrades to a tier-3 profile with FreshFromWb false. Acting on
-        // it would replace a good cached ChatUser and broadcast the default avatar to every viewer —
-        // converting a transient upstream hiccup into a visible regression for the whole channel. Doing
-        // nothing costs nothing: the next successful ping, or the player's next connect, re-enriches.
+        // THE RULE. A wb blip degrades to a tier-3 profile with FreshFromWb false. Acting on it would
+        // replace a good cached ChatUser and broadcast the default avatar to every viewer — converting a
+        // transient upstream hiccup into a visible regression for the whole channel. Doing nothing costs
+        // nothing: the next successful ping, or the player's next connect, re-enriches.
         if (!resolution.FreshFromWb) return;
 
-        // Fix round P2 (finding 3): downstream uses the LIVE SESSION IDENTITY's casing, not the raw
-        // webhook-supplied `battleTag` parameter — matching the connect path (ChatHub.UpsertDirectory,
-        // which always passes identity.BattleTag). The webhook value comes from website-backend's
-        // PersonalSetting.Id / ClanMembership.BattleTag (storage casing) and nothing reconciles it
-        // against the session; DisplayBattleTag is the authoritative display casing read by mention
-        // search (ChatHub.Mentions.cs), so acting on the webhook casing here could overwrite a user's
-        // display casing with storage casing on every flair ping.
+        // Downstream uses the LIVE SESSION IDENTITY's casing, not the raw webhook-supplied `battleTag`
+        // parameter — matching the connect path (ChatHub.UpsertDirectory, which always passes
+        // identity.BattleTag). The webhook value comes from website-backend's storage casing and nothing
+        // reconciles it against the session; DisplayBattleTag is the authoritative display casing read by
+        // mention search, so acting on the webhook casing here could overwrite a user's display casing
+        // with storage casing on every flair ping.
         var liveBattleTag = current.Identity.BattleTag;
 
         _connections.RegisterUser(current.ConnectionId, resolution.User);
 
-        // Codex P2 follow-up: the pre-write revalidation above (lines 69-70) narrows the disconnect race
-        // but does not close it. It and the RegisterUser write immediately above are two separate,
-        // unsynchronized critical sections (SessionRegistry's lock, then ConnectionMapping's lock) with no
-        // await between them — so ChatHub.OnDisconnectedAsync's Unregister+Remove sequence can still land
-        // in that gap on another thread. If it does, RegisterUser just resurrected the _users entry that
-        // Remove already cleaned up, and since disconnect fires exactly once, nothing would ever remove it
-        // again: an unbounded leak under repeated connect/disconnect-during-refresh races.
-        //
-        // Close the loop with a POST-write validation instead of a cross-lock atomic write (which would
-        // require SessionRegistry and ConnectionMapping to share a lock — a bigger, riskier change for two
-        // registries that are deliberately independent). Re-read the authoritative session; if it no longer
-        // points at this connection, undo the write. ConnectionMapping.Remove is safe to call here:
-        //  - it is a no-op for an already-absent connectionId (Remove/TryGetValue-based, never throws), so
-        //    it is safe whether OnDisconnectedAsync's own Remove already ran or hasn't run yet;
-        //  - it is scoped to THIS connectionId only (room lookup, mute cache and _users are all keyed by
-        //    connectionId, which SignalR guarantees unique per connection), so it can never remove a
-        //    different, live connection's mapping — including another connection for the same battleTag.
-        //
-        // This only guards the ConnectionMapping write. The user-directory upsert and the fan-out send
-        // below don't need the same guard: the directory upsert is a keyed-by-battleTag, idempotent
-        // "latest known-good profile" write with no dangling state if the session is gone — harmless, and
-        // still correct for the player's next connect. The fan-out send targets a dead connection id at
-        // worst, which SignalR already treats as a silent no-op (see the catch below) — pointless, not
-        // leaky. Only ConnectionMapping accumulates unbounded, un-owned state if left unvalidated.
+        // The revalidation above narrows the disconnect race but does not close it: that read and this
+        // write are two separate, unsynchronized critical sections with no await between them, so
+        // ChatHub.OnDisconnectedAsync can still land in the gap on another thread and have its Remove
+        // undone by the RegisterUser call just above. Re-read the authoritative session once more; if it
+        // no longer points at this connection, someone else got there first — undo the write and stop.
+        // ConnectionMapping.Remove is safe here: it no-ops on an already-absent connectionId, and it is
+        // scoped to this connectionId only, so it can never remove a different, live connection's mapping
+        // (including another connection for the same battleTag). Returning here — rather than falling
+        // through into the directory upsert and fan-out below — matters: those two use this stale
+        // request's `resolution`, and a newer refresh for the same battleTag may already have written a
+        // fresher one. Idempotent, battleTag-keyed writes don't save you when two refreshes interleave —
+        // the older one finishing last still overwrites the newer profile and broadcasts outdated flair
+        // to live viewers, not just a dead connection.
         var postWriteSession = _sessionRegistry.GetByBattleTag(battleTag);
         if (postWriteSession == null || postWriteSession.ConnectionId != current.ConnectionId)
         {

--- a/W3ChampionsChatService/FanOut/FlairRefresher.cs
+++ b/W3ChampionsChatService/FanOut/FlairRefresher.cs
@@ -114,6 +114,7 @@ public class FlairRefresher(
         if (postWriteSession == null || postWriteSession.ConnectionId != current.ConnectionId)
         {
             _connections.Remove(current.ConnectionId);
+            return;
         }
 
         await UserDirectoryUpsert.Apply(

--- a/W3ChampionsChatService/FanOut/FlairRefresher.cs
+++ b/W3ChampionsChatService/FanOut/FlairRefresher.cs
@@ -86,6 +86,36 @@ public class FlairRefresher(
 
         _connections.RegisterUser(current.ConnectionId, resolution.User);
 
+        // Codex P2 follow-up: the pre-write revalidation above (lines 69-70) narrows the disconnect race
+        // but does not close it. It and the RegisterUser write immediately above are two separate,
+        // unsynchronized critical sections (SessionRegistry's lock, then ConnectionMapping's lock) with no
+        // await between them — so ChatHub.OnDisconnectedAsync's Unregister+Remove sequence can still land
+        // in that gap on another thread. If it does, RegisterUser just resurrected the _users entry that
+        // Remove already cleaned up, and since disconnect fires exactly once, nothing would ever remove it
+        // again: an unbounded leak under repeated connect/disconnect-during-refresh races.
+        //
+        // Close the loop with a POST-write validation instead of a cross-lock atomic write (which would
+        // require SessionRegistry and ConnectionMapping to share a lock — a bigger, riskier change for two
+        // registries that are deliberately independent). Re-read the authoritative session; if it no longer
+        // points at this connection, undo the write. ConnectionMapping.Remove is safe to call here:
+        //  - it is a no-op for an already-absent connectionId (Remove/TryGetValue-based, never throws), so
+        //    it is safe whether OnDisconnectedAsync's own Remove already ran or hasn't run yet;
+        //  - it is scoped to THIS connectionId only (room lookup, mute cache and _users are all keyed by
+        //    connectionId, which SignalR guarantees unique per connection), so it can never remove a
+        //    different, live connection's mapping — including another connection for the same battleTag.
+        //
+        // This only guards the ConnectionMapping write. The user-directory upsert and the fan-out send
+        // below don't need the same guard: the directory upsert is a keyed-by-battleTag, idempotent
+        // "latest known-good profile" write with no dangling state if the session is gone — harmless, and
+        // still correct for the player's next connect. The fan-out send targets a dead connection id at
+        // worst, which SignalR already treats as a silent no-op (see the catch below) — pointless, not
+        // leaky. Only ConnectionMapping accumulates unbounded, un-owned state if left unvalidated.
+        var postWriteSession = _sessionRegistry.GetByBattleTag(battleTag);
+        if (postWriteSession == null || postWriteSession.ConnectionId != current.ConnectionId)
+        {
+            _connections.Remove(current.ConnectionId);
+        }
+
         await UserDirectoryUpsert.Apply(
             _userDirectory, liveBattleTag, resolution, _timeProvider.GetUtcNow().UtcDateTime);
 

--- a/W3ChampionsChatService/FanOut/FlairRefresher.cs
+++ b/W3ChampionsChatService/FanOut/FlairRefresher.cs
@@ -55,24 +55,47 @@ public class FlairRefresher(
 
         var resolution = await _chatAuthenticationService.GetUserFromIdentity(session.Identity);
 
+        // Fix round P2 (findings 2+3): re-validate AFTER the await, before any side effect. The awaited
+        // wb round-trip above is a window in which the player can disconnect, or reconnect under a new
+        // connection id. If the authoritative session for this battleTag is no longer THIS connection,
+        // every side effect below must be skipped:
+        //  - acting on the stale `session` would resurrect ConnectionMapping's entry for a connection
+        //    ChatHub.OnDisconnectedAsync already tore down (Remove runs in a `finally`, unconditionally,
+        //    then RegisterUser's unconditional `_users[connectionId] = user` would recreate it) —
+        //    disconnect fires once, so nothing would ever remove it again: an unbounded leak under
+        //    repeated connect/disconnect-during-refresh races.
+        //  - the send targets below would include a dead SignalR connection id (harmless — sends to a
+        //    dead connection are silent no-ops — but pointless).
+        var current = _sessionRegistry.GetByBattleTag(battleTag);
+        if (current == null || current.ConnectionId != session.ConnectionId) return;
+
         // THE RULE (spec §5). A wb blip degrades to a tier-3 profile with FreshFromWb false. Acting on
         // it would replace a good cached ChatUser and broadcast the default avatar to every viewer —
         // converting a transient upstream hiccup into a visible regression for the whole channel. Doing
         // nothing costs nothing: the next successful ping, or the player's next connect, re-enriches.
         if (!resolution.FreshFromWb) return;
 
-        _connections.RegisterUser(session.ConnectionId, resolution.User);
+        // Fix round P2 (finding 3): downstream uses the LIVE SESSION IDENTITY's casing, not the raw
+        // webhook-supplied `battleTag` parameter — matching the connect path (ChatHub.UpsertDirectory,
+        // which always passes identity.BattleTag). The webhook value comes from website-backend's
+        // PersonalSetting.Id / ClanMembership.BattleTag (storage casing) and nothing reconciles it
+        // against the session; DisplayBattleTag is the authoritative display casing read by mention
+        // search (ChatHub.Mentions.cs), so acting on the webhook casing here could overwrite a user's
+        // display casing with storage casing on every flair ping.
+        var liveBattleTag = current.Identity.BattleTag;
+
+        _connections.RegisterUser(current.ConnectionId, resolution.User);
 
         await UserDirectoryUpsert.Apply(
-            _userDirectory, battleTag, resolution, _timeProvider.GetUtcNow().UtcDateTime);
+            _userDirectory, liveBattleTag, resolution, _timeProvider.GetUtcNow().UtcDateTime);
 
-        var payload = new FlairChangedDto(battleTag, ChatProfileMapper.FromChatUser(resolution.User));
+        var payload = new FlairChangedDto(liveBattleTag, ChatProfileMapper.FromChatUser(resolution.User));
 
         // Flair is user-scoped, not channel-scoped: the audience is every connection focused on any
         // channel this player is focused on, deduped, plus their own connection unconditionally so a
         // player focused on nothing still sees their own avatar update.
-        var targets = new HashSet<string>(StringComparer.Ordinal) { session.ConnectionId };
-        foreach (var channelId in _focusRegistry.GetFocusedChannels(session.ConnectionId))
+        var targets = new HashSet<string>(StringComparer.Ordinal) { current.ConnectionId };
+        foreach (var channelId in _focusRegistry.GetFocusedChannels(current.ConnectionId))
         {
             foreach (var connectionId in _focusRegistry.GetFocusedConnections(channelId))
             {

--- a/W3ChampionsChatService/FanOut/FlairRefresher.cs
+++ b/W3ChampionsChatService/FanOut/FlairRefresher.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Serilog;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.FanOut;
+
+public interface IFlairRefresher
+{
+    Task Refresh(string battleTag);
+}
+
+/// <summary>
+/// Re-resolves one player's flair after website-backend reports a change, then pushes it to everyone
+/// who can currently see them.
+/// <para>
+/// Reuses <see cref="IChatAuthenticationService.GetUserFromIdentity"/> rather than reading settings
+/// directly, so admin colour/icon forcing, the three-tier fallback and the never-clobber invariant all
+/// come for free and cannot drift from the connect path. Because it also refreshes
+/// <see cref="ConnectionMapping"/>, the changed player's own subsequent messages carry the new flair
+/// within the same connection.
+/// </para>
+/// <para>
+/// A player with no live session is a no-op: their next connect re-enriches anyway. Work is therefore
+/// bounded by the set of players currently online in chat, not by website-backend's write volume.
+/// </para>
+/// </summary>
+public class FlairRefresher(
+    ISessionRegistry sessionRegistry,
+    IChatAuthenticationService chatAuthenticationService,
+    ConnectionMapping connections,
+    UserDirectoryRepository userDirectory,
+    FocusRegistry focusRegistry,
+    IHubContext<ChatHub> hubContext,
+    TimeProvider timeProvider) : IFlairRefresher
+{
+    private readonly ISessionRegistry _sessionRegistry = sessionRegistry;
+    private readonly IChatAuthenticationService _chatAuthenticationService = chatAuthenticationService;
+    private readonly ConnectionMapping _connections = connections;
+    private readonly UserDirectoryRepository _userDirectory = userDirectory;
+    private readonly FocusRegistry _focusRegistry = focusRegistry;
+    private readonly IHubContext<ChatHub> _hubContext = hubContext;
+    private readonly TimeProvider _timeProvider = timeProvider;
+
+    public async Task Refresh(string battleTag)
+    {
+        var session = _sessionRegistry.GetByBattleTag(battleTag);
+        if (session == null) return;
+
+        var resolution = await _chatAuthenticationService.GetUserFromIdentity(session.Identity);
+
+        // THE RULE (spec §5). A wb blip degrades to a tier-3 profile with FreshFromWb false. Acting on
+        // it would replace a good cached ChatUser and broadcast the default avatar to every viewer —
+        // converting a transient upstream hiccup into a visible regression for the whole channel. Doing
+        // nothing costs nothing: the next successful ping, or the player's next connect, re-enriches.
+        if (!resolution.FreshFromWb) return;
+
+        _connections.RegisterUser(session.ConnectionId, resolution.User);
+
+        await UserDirectoryUpsert.Apply(
+            _userDirectory, battleTag, resolution, _timeProvider.GetUtcNow().UtcDateTime);
+
+        var payload = new FlairChangedDto(battleTag, ChatProfileMapper.FromChatUser(resolution.User));
+
+        // Flair is user-scoped, not channel-scoped: the audience is every connection focused on any
+        // channel this player is focused on, deduped, plus their own connection unconditionally so a
+        // player focused on nothing still sees their own avatar update.
+        var targets = new HashSet<string>(StringComparer.Ordinal) { session.ConnectionId };
+        foreach (var channelId in _focusRegistry.GetFocusedChannels(session.ConnectionId))
+        {
+            foreach (var connectionId in _focusRegistry.GetFocusedConnections(channelId))
+            {
+                targets.Add(connectionId);
+            }
+        }
+
+        foreach (var connectionId in targets)
+        {
+            try
+            {
+                await _hubContext.Clients.Client(connectionId).SendAsync(ChatEvents.FlairChanged, payload);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Fan-out send of FlairChanged failed for connection {ConnectionId} — skipping", connectionId);
+            }
+        }
+    }
+}

--- a/W3ChampionsChatService/Internal/InternalChannelsController.cs
+++ b/W3ChampionsChatService/Internal/InternalChannelsController.cs
@@ -292,15 +292,7 @@ public class InternalChannelsController(MatchChannelService matchChannelService)
         && members.Count <= ChatLimits.InternalMaxMembersPerCall
         && members.All(IsValidMemberEntry);
 
-    // 2026-08-05 fix wave (final review M5): mirrors InternalRelationshipChangesController's
-    // IsValidParticipant EXACTLY — non-blank AND control-char-free. Before this, a member entry was
-    // bounded only by the 64 KB body cap and landed as a lowercased Mongo BattleTag key with no
-    // per-entry length or control-char guard, asymmetric with the relationship-changes surface's
-    // identical-shaped field. char.IsControl catches an embedded '\n'/'\r'/'\t'/NUL (log-injection);
-    // U+2028/U+2029 are checked explicitly because they are category Zl/Zp, not Cc, so char.IsControl
-    // alone misses them.
-    private static bool IsValidMemberEntry(string value) =>
-        !string.IsNullOrWhiteSpace(value) && !value.Any(c => char.IsControl(c) || c is '\u2028' or '\u2029');
+    private static bool IsValidMemberEntry(string value) => InternalValidation.IsValidBattleTag(value);
 
     private void LogUnexpected(Exception ex, string verb, string @ref) =>
         Log.Error(ex, "Internal channels endpoint failed {Caller} {Verb} {Ref}", InternalHmacAuthFilter.ResolveCaller(HttpContext), verb, @ref);

--- a/W3ChampionsChatService/Internal/InternalDtos.cs
+++ b/W3ChampionsChatService/Internal/InternalDtos.cs
@@ -141,6 +141,16 @@ public class InternalRelationshipChangeRequest
 }
 
 /// <summary>
+/// Body of <c>POST /internal/profile-changes</c>: the players whose flair website-backend believes
+/// may have changed. Capped at <see cref="Domain.ChatLimits.InternalMaxMembersPerCall"/>; the sender
+/// chunks larger sets into separate requests.
+/// </summary>
+public class InternalProfileChangeRequest
+{
+    public List<string> BattleTags { get; set; }
+}
+
+/// <summary>
 /// REST projection of a <see cref="ChatChannel"/> returned by <c>POST /internal/channels</c> (C7 Task
 /// 9) — System.Text.Json's default camelCase serialization matches the wire contract mm expects, so no
 /// custom naming policy is needed.

--- a/W3ChampionsChatService/Internal/InternalProfileChangesController.cs
+++ b/W3ChampionsChatService/Internal/InternalProfileChangesController.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Serilog;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+
+namespace W3ChampionsChatService.Internal;
+
+/// <summary>
+/// Receives flair-change notifications from website-backend. Enqueues each battleTag for a coalesced
+/// refresh and returns immediately — the sender is fire-and-forget with a 3 s per-attempt budget, so
+/// this must never do the refresh inline.
+/// </summary>
+[ApiController]
+[Route("internal/profile-changes")]
+[InternalHmacAuth(InternalCaller.Wb)]
+public class InternalProfileChangesController(FlairRefreshCoalescer coalescer) : ControllerBase
+{
+    private const string GenericValidationError = "Invalid request.";
+
+    [HttpPost]
+    public IActionResult Post([FromBody] InternalProfileChangeRequest request)
+    {
+        // Validate the WHOLE batch before enqueuing any of it — no partial processing, so a malformed
+        // request can never leave the coalescer holding half a batch.
+        if (request?.BattleTags == null
+            || request.BattleTags.Count == 0
+            || request.BattleTags.Count > ChatLimits.InternalMaxMembersPerCall
+            || request.BattleTags.Any(tag => !InternalValidation.IsValidBattleTag(tag)))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        foreach (var battleTag in request.BattleTags)
+        {
+            coalescer.RecordChange(battleTag);
+        }
+
+        Log.Information("Internal profile change {Caller} count={Count}",
+            InternalHmacAuthFilter.ResolveCaller(HttpContext), request.BattleTags.Count);
+
+        return Ok();
+    }
+}

--- a/W3ChampionsChatService/Internal/InternalRelationshipChangesController.cs
+++ b/W3ChampionsChatService/Internal/InternalRelationshipChangesController.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
 using W3ChampionsChatService.Authentication;
@@ -68,12 +67,5 @@ public class InternalRelationshipChangesController(IRelationshipProvider relatio
         _ => false,
     };
 
-    // Non-blank AND control-char-free. IsNullOrWhiteSpace rejects null/empty/all-whitespace; char.IsControl
-    // catches an EMBEDDED '\n'/'\r'/'\t'/NUL that a partly-printable value would otherwise smuggle into the
-    // structured {Actor}/{Target} log sink (log-injection guard — same class the Task 9 ref review caught).
-    // char.IsControl does NOT cover U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR (category Zl/Zp, not
-    // Cc) — a downstream JS/JSON log viewer can render either as a line break, spoofing a log line. Rejected
-    // explicitly here.
-    private static bool IsValidParticipant(string value) =>
-        !string.IsNullOrWhiteSpace(value) && !value.Any(c => char.IsControl(c) || c is '\u2028' or '\u2029');
+    private static bool IsValidParticipant(string value) => InternalValidation.IsValidBattleTag(value);
 }

--- a/W3ChampionsChatService/Internal/InternalValidation.cs
+++ b/W3ChampionsChatService/Internal/InternalValidation.cs
@@ -1,0 +1,19 @@
+using System.Linq;
+
+namespace W3ChampionsChatService.Internal;
+
+/// <summary>
+/// Validation shared by every <c>internal/*</c> endpoint. This rule must hold IDENTICALLY across all
+/// of them, so it lives in one place — it previously existed as two byte-identical private copies,
+/// one of which carried a comment promising it mirrored the other exactly.
+/// </summary>
+public static class InternalValidation
+{
+    /// <summary>
+    /// A usable battleTag: non-blank, and free of control characters. U+2028 and U+2029 are checked
+    /// explicitly because <c>char.IsControl</c> classifies them as separators, not controls, yet they
+    /// terminate lines in JavaScript sources and log viewers.
+    /// </summary>
+    public static bool IsValidBattleTag(string value) =>
+        !string.IsNullOrWhiteSpace(value) && !value.Any(c => char.IsControl(c) || c is '\u2028' or '\u2029');
+}

--- a/W3ChampionsChatService/Protocol/ChatEvents.cs
+++ b/W3ChampionsChatService/Protocol/ChatEvents.cs
@@ -42,4 +42,9 @@ public static class ChatEvents
     /// replaces the wb <c>FriendOnlineStatus</c> push (C6-plan.md D13). Carries a
     /// <c>FriendPresenceChangedDto</c>.</summary>
     public const string FriendPresenceChanged = nameof(FriendPresenceChanged);
+
+    /// <summary>C7: pushed when a player's flair (portrait, chat colour, chat icons, clan) changes,
+    /// to every connection focused on a channel that player is also focused on, plus the player's own
+    /// connection. Carries a <c>FlairChangedDto</c>.</summary>
+    public const string FlairChanged = nameof(FlairChanged);
 }

--- a/W3ChampionsChatService/Protocol/FlairChangedDto.cs
+++ b/W3ChampionsChatService/Protocol/FlairChangedDto.cs
@@ -1,0 +1,15 @@
+using W3ChampionsChatService.Domain;
+
+namespace W3ChampionsChatService.Protocol;
+
+/// <summary>
+/// A live flair update for one player, pushed when website-backend reports that their portrait, chat
+/// colour, chat icons or clan changed.
+/// <para>
+/// <see cref="Profile"/> is built by the same <see cref="ChatProfileMapper.FromChatUser"/> that
+/// supplies roster flair and message <c>sender.flair</c>, so a live update cannot render differently
+/// from what a fresh roster would have shown. It is never null: this event is only emitted after a
+/// resolution that was confirmed fresh from website-backend.
+/// </para>
+/// </summary>
+public record FlairChangedDto(string BattleTag, ChatProfile Profile);

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -166,6 +166,11 @@ public class Startup
         // (10s) and the accumulator (5s) on the injected TimeProvider clock. Without it the pure,
         // deterministic-time sinks above would never fire outside tests.
         services.AddHostedService<FanOutFlushService>();
+        // Fix round (P1): the live-flair drain's OWN hosted service, deliberately separate from
+        // FanOutFlushService above — a website-backend outage during FlairRefreshCoalescer.Flush must
+        // never stall the unrelated ActivityCoalescer/ViewersAccumulator fan-out on a shared loop. See
+        // FlairRefreshFlushService's doc comment.
+        services.AddHostedService<FlairRefreshFlushService>();
 
         // Task 10: JoinChannel's implicit-semiPublic-creation throttle. Singleton — a transient
         // registration would fragment each battleTag's per-hour creation counter across hub
@@ -183,7 +188,7 @@ public class Startup
         services.AddSingleton<IFlairRefresher, FlairRefresher>();
         // Task 5 (live flair propagation): coalesces bursty flair-change notifications into one refresh
         // per flush tick. Singleton — it holds the pending battleTag set that RecordChange (Task 6's
-        // endpoint) writes and FanOutFlushService drains; a transient would fragment that set.
+        // endpoint) writes and FlairRefreshFlushService drains; a transient would fragment that set.
         services.AddSingleton<FlairRefreshCoalescer>();
         // Reconciles the live mute cache from every ban WRITE path (hub + REST controller).
         // Singleton: it only holds the singleton ConnectionMapping + IHubContext<ChatHub>.

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -179,6 +179,8 @@ public class Startup
         // guarantees an initial roster and a ViewersChanged join delta can never render a viewer
         // differently.
         services.AddSingleton<ViewerResolver>();
+        // Singleton: holds only singletons plus the hub context. Consumed by FlairRefreshCoalescer.
+        services.AddSingleton<IFlairRefresher, FlairRefresher>();
         // Reconciles the live mute cache from every ban WRITE path (hub + REST controller).
         // Singleton: it only holds the singleton ConnectionMapping + IHubContext<ChatHub>.
         services.AddSingleton<MuteReconciliationService>();

--- a/W3ChampionsChatService/Startup.cs
+++ b/W3ChampionsChatService/Startup.cs
@@ -181,6 +181,10 @@ public class Startup
         services.AddSingleton<ViewerResolver>();
         // Singleton: holds only singletons plus the hub context. Consumed by FlairRefreshCoalescer.
         services.AddSingleton<IFlairRefresher, FlairRefresher>();
+        // Task 5 (live flair propagation): coalesces bursty flair-change notifications into one refresh
+        // per flush tick. Singleton — it holds the pending battleTag set that RecordChange (Task 6's
+        // endpoint) writes and FanOutFlushService drains; a transient would fragment that set.
+        services.AddSingleton<FlairRefreshCoalescer>();
         // Reconciles the live mute cache from every ban WRITE path (hub + REST controller).
         // Singleton: it only holds the singleton ConnectionMapping + IHubContext<ChatHub>.
         services.AddSingleton<MuteReconciliationService>();

--- a/docs/superpowers/plans/2026-08-10-live-flair-propagation-plan-b.md
+++ b/docs/superpowers/plans/2026-08-10-live-flair-propagation-plan-b.md
@@ -1,0 +1,2182 @@
+# Live Flair Propagation (Plan B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a player changes their portrait, chat colour, chat icons or clan, every other viewer who can see them in a chat roster sees the new flair within about a second — without anyone reconnecting.
+
+**Architecture:** website-backend notifies chat-service at the *persistence boundary*: decorators over `IPersonalSettingsRepository` and `IClanRepository` fire `IFlairChangeNotifier.NotifyChanged(battleTags)` after a successful write, so all five flair-write paths (and any sixth added later) are covered without editing a single command handler. The notifier POSTs HMAC-signed to `/internal/profile-changes` on chat-service, fire-and-forget. Chat-service coalesces the battleTags for one tick, then for each one with a live session re-resolves flair through the existing `GetUserFromIdentity` — refreshing `ConnectionMapping` and the user directory, and pushing a new `FlairChanged` event to the focused connections that can see them. Every layer is best-effort: connect always re-enriches from website-backend, so a dropped ping degrades to today's behaviour and never to a permanently wrong state.
+
+**Tech Stack:** C# / .NET 8, ASP.NET Core, Castle DynamicProxy (website-backend DI), SignalR (chat-service), NUnit + Moq (both; chat-service also uses Testcontainers), TypeScript / React / easy-peasy (launcher-e).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md`. This plan implements §3.2, §3.3 and the `FlairChangedDto` row of §4. §3.1 and the roster half of §4 shipped in Plan A (chat-service PR #44, launcher-e PR #850, both merged 2026-08-10).
+- **The `FreshFromWb` rule is the single most important behaviour in this plan.** On a refresh, if `GetUserFromIdentity` returns `FreshFromWb == false`, do **nothing at all** — no `RegisterUser`, no directory write, no `FlairChanged`. A website-backend blip would otherwise broadcast a degraded tier-3 profile (the sheep) to every viewer in the channel, turning a transient upstream hiccup into a visible regression for everyone. This is the one place this design could make things worse than today. It gets an explicit test.
+- **Never fail a caller's write.** A notifier fault must never surface to a settings save or clan operation. Notification fires only *after* the inner write succeeds, inside its own try/catch.
+- **Self-disabling.** Without `CHAT_INTERNAL_API_SECRET` the notifier is a silent no-op with one startup log line. This is what makes the feature deployable dark and enabled by configuration.
+- **Reuse, do not reinvent.** `IFlairChangeNotifier` clones the `RelationshipChangeNotifier` triad 1:1 — same `ChatInternalApiSigner` HMAC scheme and headers, same `ChatPingSettings`, same `Task.Run` fire-and-forget with 2 attempts and a 3 s per-attempt cap. The chat-service controller clones `InternalRelationshipChangesController`. The coalescer mirrors `ActivityCoalescer` / `ViewersAccumulator` discipline: mutate state under one lock, send outside it, fault-isolate per connection.
+- **Batch cap:** `ChatLimits.InternalMaxMembersPerCall` is **64**. The bulk clan-delete path can exceed that, so the notifier must chunk; the controller rejects any batch over the cap outright with no partial processing.
+- **launcher-e has no test runner.** Do not add one and do not write frontend tests. Verification there is `npm run type-check`, `npm run lint:prod`, `npm run dprint`, `npm run check:i18n`.
+- **Docker must be running** for the chat-service suite (Testcontainers spins up Mongo). The website-backend suite does **not** need Docker.
+- **website-backend test hazard:** any test deriving from `IntegrationTestBase` (`WC3ChampionsStatisticService.UnitTests/IntegrationTestBase.cs`) connects to a **shared remote MongoDB** and calls `DropDatabaseAsync` in `[SetUp]`. Every test this plan adds is a pure Moq/NUnit unit test with no Mongo dependency — model them on `WC3ChampionsStatisticService.UnitTests/Friend/RelationshipChangeNotifierTests.cs`, never on `ClanTests.cs`.
+- **Assertion style:** use `Assert.That(x, Is.EqualTo(y))` in both C# repos. Both suites contain older `Assert.AreEqual` call sites; do not add new ones.
+- **Branch base:** all three repos branch from their current default (`master` for chat-service and website-backend, `main` for launcher-e). Plan A is already merged into all of them.
+
+---
+
+## File Structure
+
+**website-backend** (branch off `master`)
+
+| File | Responsibility |
+|---|---|
+| `W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs` | *Modify.* Add a `Decorate<TInterface, TDecorator>` helper that wraps an existing registration in place, preserving the Castle tracing proxy underneath. |
+| `W3C.Domain/ChatService/IFlairChangeNotifier.cs` | **Create.** The notification port. |
+| `W3C.Domain/ChatService/FlairChangeNotifier.cs` | **Create.** HMAC-signed fire-and-forget POST to chat-service, chunked at 64. |
+| `W3ChampionsStatisticService/PersonalSettings/FlairNotifyingPersonalSettingsRepository.cs` | **Create.** Decorator over `IPersonalSettingsRepository`; notifies after `Save` / `SaveMany`. |
+| `W3ChampionsStatisticService/Clans/FlairNotifyingClanRepository.cs` | **Create.** Decorator over `IClanRepository`; notifies after `UpsertMemberShip` / `SaveMemberShips`. |
+| `W3ChampionsStatisticService/Program.cs` | *Modify.* Register the notifier and apply both decorators. |
+| `WC3ChampionsStatisticService.UnitTests/Extensions/ServiceCollectionDecorateTests.cs` | **Create.** Pins the decoration helper. |
+| `WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs` | **Create.** Pins the wire format, chunking, retry and self-disable. |
+| `WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs` | **Create.** Pins both decorators' notify-on-success / silent-on-throw behaviour. |
+
+**chat-service** (branch off `master`)
+
+| File | Responsibility |
+|---|---|
+| `W3ChampionsChatService/Protocol/FlairChangedDto.cs` | **Create.** The new event payload. |
+| `W3ChampionsChatService/Protocol/ChatEvents.cs` | *Modify.* Add the `FlairChanged` constant. |
+| `W3ChampionsChatService/Chats/UserDirectoryUpsert.cs` | **Create.** The directory-upsert block, extracted from `ChatHub` so the connect path and the refresh path share one implementation of the never-clobber rule instead of duplicating it. |
+| `W3ChampionsChatService/Chats/ChatHub.cs` | *Modify.* `UpsertDirectory` delegates to the extracted helper. |
+| `W3ChampionsChatService/FanOut/FlairRefresher.cs` | **Create.** Per-battleTag refresh: the `FreshFromWb` rule, `ConnectionMapping` refresh, directory upsert, targeted fan-out. |
+| `W3ChampionsChatService/FanOut/FlairRefreshCoalescer.cs` | **Create.** Bounded pending set; collapses a burst for one battleTag into one refresh per tick. |
+| `W3ChampionsChatService/FanOut/FanOutFlushService.cs` | *Modify.* Drive the new coalescer alongside the existing two. |
+| `W3ChampionsChatService/Domain/ChatLimits.cs` | *Modify.* Add `FlairRefreshPendingCap`. |
+| `W3ChampionsChatService/Internal/InternalValidation.cs` | **Create.** The blank/control-char battleTag check, factored out of its two existing private copies rather than adding a third. |
+| `W3ChampionsChatService/Internal/InternalRelationshipChangesController.cs` | *Modify.* Delegate to the shared validator. |
+| `W3ChampionsChatService/Internal/InternalChannelsController.cs` | *Modify.* Delegate to the shared validator. |
+| `W3ChampionsChatService/Internal/InternalProfileChangesController.cs` | **Create.** `POST /internal/profile-changes`, HMAC-gated to `Wb`. |
+| `W3ChampionsChatService/Internal/InternalDtos.cs` | *Modify.* Add the request DTO. |
+| `W3ChampionsChatService/Startup.cs` | *Modify.* Register the refresher and coalescer. |
+| `W3ChampionsChatService.Tests/FlairRefresherTests.cs` | **Create.** The `FreshFromWb` rule and fan-out targeting. |
+| `W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs` | **Create.** Burst collapsing and overflow. |
+| `W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs` | **Create.** Validation and enqueue behaviour. |
+
+**launcher-e** (branch off `main`)
+
+| File | Responsibility |
+|---|---|
+| `src/types/chat-protocol.types.ts` | *Modify.* `IFlairChangedDto` + the `FlairChanged` event name. |
+| `src/models/chat-core.ts` | *Modify.* `ingestFlairChanged` action. |
+| `src/services/chat.service.ts` | *Modify.* Bind the event. |
+
+---
+
+### Task 1: `Decorate` DI helper
+
+**Files:**
+- Modify: `W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs`
+- Test: `WC3ChampionsStatisticService.UnitTests/Extensions/ServiceCollectionDecorateTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `public static IServiceCollection Decorate<TInterface, TDecorator>(this IServiceCollection services) where TInterface : class where TDecorator : class, TInterface`
+
+**Why this task exists.** `IPersonalSettingsRepository` and `IClanRepository` are registered via `AddInterceptedTransient` (`Program.cs:178,187`), which registers the interface as a **Castle DynamicProxy** wrapping the concrete class with a `TracingInterceptor`. You cannot decorate that by simply re-registering the interface: `AddInterceptedTransient` resolves the decorator's constructor arguments straight out of the container by type, so a decorator whose parameter is `IPersonalSettingsRepository` would resolve to *itself* and recurse. Depending on the concrete class instead would silently drop tracing from the two most-used repositories in the service. This helper captures the existing descriptor and calls it to build the inner instance, so the proxy — and its tracing — survives underneath the decorator.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `WC3ChampionsStatisticService.UnitTests/Extensions/ServiceCollectionDecorateTests.cs`:
+
+```csharp
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using W3ChampionsStatisticService.Extensions;
+
+namespace WC3ChampionsStatisticService.UnitTests.Extensions;
+
+[TestFixture]
+public class ServiceCollectionDecorateTests
+{
+    private interface IGreeter
+    {
+        string Greet();
+    }
+
+    private class Inner : IGreeter
+    {
+        public string Greet() => "inner";
+    }
+
+    private class Outer(IGreeter inner) : IGreeter
+    {
+        public string Greet() => $"outer({inner.Greet()})";
+    }
+
+    private class Second(IGreeter inner) : IGreeter
+    {
+        public string Greet() => $"second({inner.Greet()})";
+    }
+
+    [Test]
+    public void Decorate_WrapsTheExistingRegistration()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IGreeter, Inner>();
+
+        services.Decorate<IGreeter, Outer>();
+
+        var resolved = services.BuildServiceProvider().GetRequiredService<IGreeter>();
+        Assert.That(resolved.Greet(), Is.EqualTo("outer(inner)"));
+    }
+
+    [Test]
+    public void Decorate_PreservesAFactoryRegistration()
+    {
+        // AddInterceptedTransient registers the interface via an ImplementationFactory that builds a
+        // Castle proxy. If Decorate ignored the factory and reflected over ImplementationType (null
+        // here), the tracing proxy would be silently dropped.
+        var services = new ServiceCollection();
+        services.AddTransient<IGreeter>(_ => new Inner());
+
+        services.Decorate<IGreeter, Outer>();
+
+        var resolved = services.BuildServiceProvider().GetRequiredService<IGreeter>();
+        Assert.That(resolved.Greet(), Is.EqualTo("outer(inner)"));
+    }
+
+    [Test]
+    public void Decorate_PreservesLifetime()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IGreeter, Inner>();
+
+        services.Decorate<IGreeter, Outer>();
+
+        var provider = services.BuildServiceProvider();
+        Assert.That(provider.GetRequiredService<IGreeter>(), Is.SameAs(provider.GetRequiredService<IGreeter>()));
+    }
+
+    [Test]
+    public void Decorate_Twice_NestsInRegistrationOrder()
+    {
+        var services = new ServiceCollection();
+        services.AddTransient<IGreeter, Inner>();
+
+        services.Decorate<IGreeter, Outer>();
+        services.Decorate<IGreeter, Second>();
+
+        var resolved = services.BuildServiceProvider().GetRequiredService<IGreeter>();
+        Assert.That(resolved.Greet(), Is.EqualTo("second(outer(inner))"));
+    }
+
+    [Test]
+    public void Decorate_WithNoExistingRegistration_ThrowsWithAnActionableMessage()
+    {
+        var services = new ServiceCollection();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => services.Decorate<IGreeter, Outer>());
+        Assert.That(ex.Message, Does.Contain("IGreeter"));
+        Assert.That(ex.Message, Does.Contain("AFTER"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd "<website-backend worktree>"
+dotnet test WC3ChampionsStatisticService.UnitTests --filter "FullyQualifiedName~ServiceCollectionDecorateTests"
+```
+
+Expected: FAIL to compile — `'IServiceCollection' does not contain a definition for 'Decorate'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs`, add these two members to the existing `ServiceCollectionExtensions` class (place them after `AddInterceptedTransient`, before the closing brace):
+
+```csharp
+    /// <summary>
+    /// Wraps the LAST existing registration of <typeparamref name="TInterface"/> in
+    /// <typeparamref name="TDecorator"/>, in place — same position in the collection, same lifetime.
+    /// <para>
+    /// This exists because <see cref="AddInterceptedTransient{TInterface,TImplementation}"/> registers
+    /// the interface as a Castle DynamicProxy over the concrete type. A decorator cannot be layered by
+    /// re-registering the interface: that helper resolves constructor arguments straight from the
+    /// container by type, so a decorator taking <typeparamref name="TInterface"/> would resolve to
+    /// ITSELF and recurse. Building the inner instance from the CAPTURED descriptor is what keeps the
+    /// tracing proxy alive underneath the decorator.
+    /// </para>
+    /// <para>
+    /// Must be called AFTER the registration it wraps. Decorating twice nests in call order:
+    /// the second decorator wraps the first.
+    /// </para>
+    /// </summary>
+    public static IServiceCollection Decorate<TInterface, TDecorator>(this IServiceCollection services)
+        where TInterface : class
+        where TDecorator : class, TInterface
+    {
+        var index = -1;
+        for (var i = services.Count - 1; i >= 0; i--)
+        {
+            if (services[i].ServiceType == typeof(TInterface))
+            {
+                index = i;
+                break;
+            }
+        }
+
+        if (index < 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot decorate {typeof(TInterface).Name} with {typeof(TDecorator).Name}: it has no existing "
+                + "registration. Decorate must be called AFTER the registration it wraps.");
+        }
+
+        var inner = services[index];
+
+        services[index] = new ServiceDescriptor(
+            typeof(TInterface),
+            serviceProvider => ActivatorUtilities.CreateInstance<TDecorator>(
+                serviceProvider,
+                CreateInner(serviceProvider, inner)),
+            inner.Lifetime);
+
+        return services;
+    }
+
+    // Rebuilds the captured registration by whichever of the three ServiceDescriptor forms it used.
+    private static object CreateInner(IServiceProvider serviceProvider, ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance != null) return descriptor.ImplementationInstance;
+        if (descriptor.ImplementationFactory != null) return descriptor.ImplementationFactory(serviceProvider);
+        return ActivatorUtilities.CreateInstance(serviceProvider, descriptor.ImplementationType);
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd "<website-backend worktree>"
+dotnet test WC3ChampionsStatisticService.UnitTests --filter "FullyQualifiedName~ServiceCollectionDecorateTests"
+```
+
+Expected: `Failed: 0, Passed: 5`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add W3ChampionsStatisticService/Extensions/ServiceCollectionExtensions.cs WC3ChampionsStatisticService.UnitTests/Extensions/ServiceCollectionDecorateTests.cs
+git commit -m "feat(di): add a Decorate helper that wraps an existing registration in place"
+```
+
+---
+
+### Task 2: `IFlairChangeNotifier`
+
+**Files:**
+- Create: `W3C.Domain/ChatService/IFlairChangeNotifier.cs`
+- Create: `W3C.Domain/ChatService/FlairChangeNotifier.cs`
+- Test: `WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs`
+
+**Interfaces:**
+- Consumes: `ChatPingSettings` (already registered as a singleton in `Program.cs`, with `ChatApiUrl`, `Secret`, `Enabled`); `ChatInternalApiSigner.CreateSignatureHeaderValue(string secret, string timestamp, string rawBody)`, `ChatInternalApiSigner.TimestampHeaderName`, `ChatInternalApiSigner.SignatureHeaderName`.
+- Produces:
+  - `interface IFlairChangeNotifier { void NotifyChanged(IReadOnlyCollection<string> battleTags); }`
+  - `class FlairChangeNotifier(IHttpClientFactory httpClientFactory, ChatPingSettings settings) : IFlairChangeNotifier` with a public `Task LastDispatch { get; }` test seam.
+
+This is a 1:1 clone of `RelationshipChangeNotifier` (`W3C.Domain/ChatService/RelationshipChangeNotifier.cs`) with three differences: a battleTag *list* instead of a type/actor/target triple, a different path, and **chunking at 64** because the bulk clan-delete path can affect more members than the receiver's per-call cap allows.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using W3C.Domain.ChatService;
+
+namespace WC3ChampionsStatisticService.UnitTests.Friend;
+
+[TestFixture]
+public class FlairChangeNotifierTests
+{
+    private List<HttpRequestMessage> _captured;
+    private List<string> _capturedBodies;
+
+    private FlairChangeNotifier CreateNotifier(ChatPingSettings settings, HttpStatusCode status = HttpStatusCode.OK)
+    {
+        _captured = new List<HttpRequestMessage>();
+        _capturedBodies = new List<string>();
+
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Returns(async (HttpRequestMessage request, CancellationToken _) =>
+            {
+                _captured.Add(request);
+                _capturedBodies.Add(request.Content == null ? null : await request.Content.ReadAsStringAsync());
+                return new HttpResponseMessage(status);
+            });
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient(handler.Object));
+
+        return new FlairChangeNotifier(factory.Object, settings);
+    }
+
+    private static ChatPingSettings Enabled() => new("https://chat.test", "test-secret");
+
+    [Test]
+    public async Task NotifyChanged_PostsTheBattleTagsToProfileChanges()
+    {
+        var notifier = CreateNotifier(Enabled());
+
+        notifier.NotifyChanged(new[] { "Foo#1234", "Bar#5678" });
+        await notifier.LastDispatch;
+
+        Assert.That(_captured, Has.Count.EqualTo(1));
+        Assert.That(_captured[0].Method, Is.EqualTo(HttpMethod.Post));
+        Assert.That(_captured[0].RequestUri.ToString(), Is.EqualTo("https://chat.test/internal/profile-changes"));
+
+        var body = JObject.Parse(_capturedBodies[0]);
+        Assert.That(body["battleTags"].Select(t => t.ToString()), Is.EqualTo(new[] { "Foo#1234", "Bar#5678" }));
+    }
+
+    [Test]
+    public async Task NotifyChanged_SignsWithTheSharedHmacScheme()
+    {
+        var notifier = CreateNotifier(Enabled());
+
+        notifier.NotifyChanged(new[] { "Foo#1234" });
+        await notifier.LastDispatch;
+
+        var timestamp = _captured[0].Headers.GetValues(ChatInternalApiSigner.TimestampHeaderName).Single();
+        var signature = _captured[0].Headers.GetValues(ChatInternalApiSigner.SignatureHeaderName).Single();
+
+        // The signature must be over the EXACT body bytes that were sent — a mismatch here is the
+        // classic "serialized twice" bug and chat-service would reject every ping.
+        Assert.That(signature, Is.EqualTo(
+            ChatInternalApiSigner.CreateSignatureHeaderValue("test-secret", timestamp, _capturedBodies[0])));
+    }
+
+    [Test]
+    public async Task NotifyChanged_ChunksAtSixtyFour()
+    {
+        // The receiver rejects any batch over ChatLimits.InternalMaxMembersPerCall (64) outright, and a
+        // clan delete can affect more members than that — so an unchunked notifier would silently lose
+        // the whole notification for exactly the largest clans.
+        var notifier = CreateNotifier(Enabled());
+        var tags = Enumerable.Range(0, 150).Select(i => $"Player{i}#1").ToArray();
+
+        notifier.NotifyChanged(tags);
+        await notifier.LastDispatch;
+
+        Assert.That(_captured, Has.Count.EqualTo(3));
+        var sent = _capturedBodies.SelectMany(b => JObject.Parse(b)["battleTags"].Select(t => t.ToString())).ToList();
+        Assert.That(sent, Is.EqualTo(tags));
+        Assert.That(JObject.Parse(_capturedBodies[0])["battleTags"].Count(), Is.EqualTo(64));
+        Assert.That(JObject.Parse(_capturedBodies[2])["battleTags"].Count(), Is.EqualTo(22));
+    }
+
+    [Test]
+    public async Task NotifyChanged_DedupesAndDropsBlanks()
+    {
+        var notifier = CreateNotifier(Enabled());
+
+        notifier.NotifyChanged(new[] { "Foo#1234", "foo#1234", "  ", null, "Bar#5678" });
+        await notifier.LastDispatch;
+
+        var sent = JObject.Parse(_capturedBodies[0])["battleTags"].Select(t => t.ToString()).ToList();
+        Assert.That(sent, Is.EqualTo(new[] { "Foo#1234", "Bar#5678" }));
+    }
+
+    [Test]
+    public void NotifyChanged_WhenDisabled_SendsNothing()
+    {
+        var notifier = CreateNotifier(new ChatPingSettings("https://chat.test", null));
+
+        notifier.NotifyChanged(new[] { "Foo#1234" });
+
+        Assert.That(notifier.LastDispatch.IsCompleted, Is.True);
+        Assert.That(_captured, Is.Empty);
+    }
+
+    [Test]
+    public void NotifyChanged_WithNoUsableTags_SendsNothing()
+    {
+        var notifier = CreateNotifier(Enabled());
+
+        notifier.NotifyChanged(new[] { "   ", null });
+
+        Assert.That(notifier.LastDispatch.IsCompleted, Is.True);
+        Assert.That(_captured, Is.Empty);
+    }
+
+    [Test]
+    public async Task NotifyChanged_OnNonSuccess_RetriesOnceThenGivesUp()
+    {
+        var notifier = CreateNotifier(Enabled(), HttpStatusCode.InternalServerError);
+
+        notifier.NotifyChanged(new[] { "Foo#1234" });
+        await notifier.LastDispatch;
+
+        Assert.That(_captured, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void NotifyChanged_NeverThrowsToTheCaller()
+    {
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Throws(new InvalidOperationException("boom"));
+
+        Assert.DoesNotThrow(() =>
+        {
+            var notifier = new FlairChangeNotifier(factory.Object, new ChatPingSettings("https://chat.test", null));
+            notifier.NotifyChanged(new[] { "Foo#1234" });
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd "<website-backend worktree>"
+dotnet test WC3ChampionsStatisticService.UnitTests --filter "FullyQualifiedName~FlairChangeNotifierTests"
+```
+
+Expected: FAIL to compile — `The type or namespace name 'FlairChangeNotifier' could not be found`.
+
+- [ ] **Step 3: Create the interface**
+
+Create `W3C.Domain/ChatService/IFlairChangeNotifier.cs`:
+
+```csharp
+using System.Collections.Generic;
+
+namespace W3C.Domain.ChatService;
+
+/// <summary>
+/// Tells chat-service that one or more players' flair (portrait, chat colour, chat icons, clan) may
+/// have changed, so it can re-resolve and push the update to anyone currently viewing them.
+/// <para>
+/// Fire-and-forget by contract: implementations must never throw and never block the caller. A lost
+/// notification degrades to the reconnect backstop — chat-service re-enriches from this service on
+/// every connect regardless.
+/// </para>
+/// </summary>
+public interface IFlairChangeNotifier
+{
+    void NotifyChanged(IReadOnlyCollection<string> battleTags);
+}
+```
+
+- [ ] **Step 4: Create the notifier**
+
+Create `W3C.Domain/ChatService/FlairChangeNotifier.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Serilog;
+
+namespace W3C.Domain.ChatService;
+
+/// <summary>
+/// Clone of <see cref="RelationshipChangeNotifier"/>'s dispatch discipline — same HMAC scheme, same
+/// fire-and-forget <see cref="Task.Run"/>, same 2 attempts at 3 s each, same self-disable and the same
+/// never-log-the-secret rule — carrying a battleTag list instead of a relationship triple.
+/// </summary>
+public class FlairChangeNotifier(IHttpClientFactory httpClientFactory, ChatPingSettings settings) : IFlairChangeNotifier
+{
+    private const int TimeoutSecondsPerAttempt = 3;
+    private const int MaxAttempts = 2; // initial + one retry, matching RelationshipChangeNotifier
+
+    // Chat-service rejects any batch above ChatLimits.InternalMaxMembersPerCall outright, with no
+    // partial processing. A clan delete can affect more members than that, so an unchunked send would
+    // lose the ENTIRE notification for exactly the largest clans.
+    private const int MaxBattleTagsPerRequest = 64;
+
+    private readonly ChatPingSettings _settings = settings;
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
+
+    /// <summary>Test seam: the background dispatch started by the most recent call.</summary>
+    public Task LastDispatch { get; private set; } = Task.CompletedTask;
+
+    public void NotifyChanged(IReadOnlyCollection<string> battleTags)
+    {
+        if (!_settings.Enabled) return; // silent no-op; startup already logged once (Program.cs)
+
+        if (battleTags == null) return;
+
+        var usable = battleTags
+            .Where(tag => !string.IsNullOrWhiteSpace(tag))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (usable.Count == 0) return;
+
+        LastDispatch = Task.Run(() => SendAllAsync(usable));
+    }
+
+    private async Task SendAllAsync(List<string> battleTags)
+    {
+        foreach (var chunk in battleTags.Chunk(MaxBattleTagsPerRequest))
+        {
+            await SendWithRetryAsync(chunk);
+        }
+    }
+
+    private async Task SendWithRetryAsync(IReadOnlyCollection<string> battleTags)
+    {
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
+        {
+            try
+            {
+                // Serialize ONCE and reuse the same string for both the signature and the content —
+                // signing a re-serialization would produce a valid-looking but rejected request.
+                var body = JsonConvert.SerializeObject(new { battleTags });
+                var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture);
+                var request = new HttpRequestMessage(HttpMethod.Post,
+                    $"{_settings.ChatApiUrl}/internal/profile-changes")
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json")
+                };
+                request.Headers.Add(ChatInternalApiSigner.TimestampHeaderName, timestamp);
+                request.Headers.Add(ChatInternalApiSigner.SignatureHeaderName,
+                    ChatInternalApiSigner.CreateSignatureHeaderValue(_settings.Secret, timestamp, body));
+
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(TimeoutSecondsPerAttempt));
+                var response = await _httpClientFactory.CreateClient().SendAsync(request, cts.Token);
+                if (response.IsSuccessStatusCode) return;
+            }
+            catch (Exception) when (attempt < MaxAttempts)
+            {
+                // Retry once, immediately — the retry may still succeed, so nothing is logged here.
+            }
+            catch (Exception e)
+            {
+                Log.Warning(e, "Flair change-ping failed after {Attempts} attempts for {Count} battleTag(s)",
+                    MaxAttempts, battleTags.Count); // never logs the secret, the signature, or the tags
+                return;
+            }
+        }
+
+        Log.Warning("Flair change-ping rejected by chat-service after {Attempts} attempts for {Count} battleTag(s)",
+            MaxAttempts, battleTags.Count);
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd "<website-backend worktree>"
+dotnet test WC3ChampionsStatisticService.UnitTests --filter "FullyQualifiedName~FlairChangeNotifierTests"
+```
+
+Expected: `Failed: 0, Passed: 8`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add W3C.Domain/ChatService/IFlairChangeNotifier.cs W3C.Domain/ChatService/FlairChangeNotifier.cs WC3ChampionsStatisticService.UnitTests/Friend/FlairChangeNotifierTests.cs
+git commit -m "feat(chat): notify chat-service when a player's flair changes"
+```
+
+---
+
+### Task 3: The repository decorators
+
+**Files:**
+- Create: `W3ChampionsStatisticService/PersonalSettings/FlairNotifyingPersonalSettingsRepository.cs`
+- Create: `W3ChampionsStatisticService/Clans/FlairNotifyingClanRepository.cs`
+- Modify: `W3ChampionsStatisticService/Program.cs` (after the registrations at lines 178 and 187; and beside the `IRelationshipChangeNotifier` registration around line 241-248)
+- Test: `WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs`
+
+**Interfaces:**
+- Consumes: `Decorate<TInterface, TDecorator>` (Task 1); `IFlairChangeNotifier.NotifyChanged(IReadOnlyCollection<string>)` (Task 2).
+- Produces: nothing consumed by later tasks.
+
+**Which methods notify, and why only these.** `IPersonalSettingsRepository` has eight members but only `Save` and `SaveMany` mutate. `IClanRepository` has nine but only `UpsertMemberShip` and `SaveMemberShips` change a player's *clan membership* — which is the only clan state that appears in flair. `UpsertClan` and `DeleteClan` carry no battleTags, and every path that calls them also persists the affected memberships through the two methods above, so hooking membership persistence covers the bulk clan-delete path (`ClanCommandHandler.DeleteClan` calls `SaveMemberShips` twice — once for members, once for revoked invitees) with no special-casing. Every other member is a pure read and is forwarded untouched.
+
+The identifiers to notify are `PersonalSetting.Id` (the battleTag; `PersonalSettings/PersonalSetting.cs:42`) and `ClanMembership.BattleTag` (`Clans/ClanMembership.cs:14`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using W3C.Domain.ChatService;
+using W3ChampionsStatisticService.Clans;
+using W3ChampionsStatisticService.PersonalSettings;
+using W3ChampionsStatisticService.Ports;
+
+namespace WC3ChampionsStatisticService.UnitTests.PersonalSettings;
+
+[TestFixture]
+public class FlairNotifyingRepositoryTests
+{
+    private Mock<IPersonalSettingsRepository> _settingsInner;
+    private Mock<IClanRepository> _clanInner;
+    private Mock<IFlairChangeNotifier> _notifier;
+    private List<string> _notified;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _settingsInner = new Mock<IPersonalSettingsRepository>();
+        _clanInner = new Mock<IClanRepository>();
+        _notifier = new Mock<IFlairChangeNotifier>();
+        _notified = new List<string>();
+        _notifier.Setup(n => n.NotifyChanged(It.IsAny<IReadOnlyCollection<string>>()))
+            .Callback((IReadOnlyCollection<string> tags) => _notified.AddRange(tags));
+    }
+
+    private FlairNotifyingPersonalSettingsRepository Settings() =>
+        new(_settingsInner.Object, _notifier.Object);
+
+    private FlairNotifyingClanRepository Clans() =>
+        new(_clanInner.Object, _notifier.Object);
+
+    [Test]
+    public async Task Save_NotifiesTheSavedBattleTag()
+    {
+        await Settings().Save(new PersonalSetting("peter#123"));
+
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123" }));
+    }
+
+    [Test]
+    public async Task SaveMany_NotifiesEveryBattleTag()
+    {
+        await Settings().SaveMany(new List<PersonalSetting>
+        {
+            new("peter#123"),
+            new("alice#456"),
+        });
+
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123", "alice#456" }));
+    }
+
+    [Test]
+    public async Task UpsertMemberShip_NotifiesTheMember()
+    {
+        await Clans().UpsertMemberShip(new ClanMembership { BattleTag = "peter#123", ClanId = "W3C" });
+
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123" }));
+    }
+
+    [Test]
+    public async Task SaveMemberShips_NotifiesEveryMember()
+    {
+        // This is the bulk clan-delete path: ClanCommandHandler.DeleteClan persists every former member
+        // through SaveMemberShips, so covering this one method covers the whole clan teardown.
+        await Clans().SaveMemberShips(new List<ClanMembership>
+        {
+            new() { BattleTag = "peter#123" },
+            new() { BattleTag = "alice#456" },
+            new() { BattleTag = "bob#789" },
+        });
+
+        Assert.That(_notified, Is.EqualTo(new[] { "peter#123", "alice#456", "bob#789" }));
+    }
+
+    [Test]
+    public void Save_WhenTheInnerWriteThrows_DoesNotNotify()
+    {
+        _settingsInner.Setup(r => r.Save(It.IsAny<PersonalSetting>())).ThrowsAsync(new InvalidOperationException("db down"));
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => Settings().Save(new PersonalSetting("peter#123")));
+        Assert.That(_notified, Is.Empty);
+    }
+
+    [Test]
+    public void UpsertMemberShip_WhenTheInnerWriteThrows_DoesNotNotify()
+    {
+        _clanInner.Setup(r => r.UpsertMemberShip(It.IsAny<ClanMembership>())).ThrowsAsync(new InvalidOperationException("db down"));
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => Clans().UpsertMemberShip(new ClanMembership { BattleTag = "peter#123" }));
+        Assert.That(_notified, Is.Empty);
+    }
+
+    [Test]
+    public void Save_WhenTheNotifierThrows_TheWriteStillSucceeds()
+    {
+        // A broken notifier must never cost a player their settings save.
+        _notifier.Setup(n => n.NotifyChanged(It.IsAny<IReadOnlyCollection<string>>()))
+            .Throws(new InvalidOperationException("notifier exploded"));
+
+        Assert.DoesNotThrowAsync(() => Settings().Save(new PersonalSetting("peter#123")));
+        _settingsInner.Verify(r => r.Save(It.IsAny<PersonalSetting>()), Times.Once);
+    }
+
+    [Test]
+    public void SaveMemberShips_WhenTheNotifierThrows_TheWriteStillSucceeds()
+    {
+        _notifier.Setup(n => n.NotifyChanged(It.IsAny<IReadOnlyCollection<string>>()))
+            .Throws(new InvalidOperationException("notifier exploded"));
+
+        Assert.DoesNotThrowAsync(() => Clans().SaveMemberShips(new List<ClanMembership>
+        {
+            new() { BattleTag = "peter#123" },
+        }));
+    }
+
+    [Test]
+    public async Task ReadMethods_AreForwardedAndDoNotNotify()
+    {
+        _settingsInner.Setup(r => r.Load("peter#123")).ReturnsAsync(new PersonalSetting("peter#123"));
+
+        var loaded = await Settings().Load("peter#123");
+
+        Assert.That(loaded.Id, Is.EqualTo("peter#123"));
+        _settingsInner.Verify(r => r.Load("peter#123"), Times.Once);
+        Assert.That(_notified, Is.Empty);
+    }
+
+    [Test]
+    public async Task DeleteClan_IsForwardedButDoesNotNotifyOnItsOwn()
+    {
+        // DeleteClan carries no battleTags. Its callers persist the affected memberships through
+        // SaveMemberShips, which is where the notification comes from.
+        await Clans().DeleteClan("W3C");
+
+        _clanInner.Verify(r => r.DeleteClan("W3C"), Times.Once);
+        Assert.That(_notified, Is.Empty);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd "<website-backend worktree>"
+dotnet test WC3ChampionsStatisticService.UnitTests --filter "FullyQualifiedName~FlairNotifyingRepositoryTests"
+```
+
+Expected: FAIL to compile — `The type or namespace name 'FlairNotifyingPersonalSettingsRepository' could not be found`.
+
+- [ ] **Step 3: Create the personal-settings decorator**
+
+Create `W3ChampionsStatisticService/PersonalSettings/FlairNotifyingPersonalSettingsRepository.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+using W3C.Domain.ChatService;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.PersonalSettings;
+
+/// <summary>
+/// Fires a flair change-ping after a successful settings write, so chat-service can push the new
+/// portrait / chat colour / chat icons to anyone currently viewing that player.
+/// <para>
+/// This hangs off the PERSISTENCE boundary rather than the command handlers deliberately. There are
+/// five separate flair-write paths — the portrait handler, the settings controller, both reward
+/// modules (which bypass the controller entirely) and the clan handler — and hooking them
+/// individually means a sixth added later is silently missed. Every one of them crosses this
+/// interface, so covering it here cannot be forgotten.
+/// </para>
+/// <para>
+/// Deliberately over-notifies: it fires on ANY settings save, not only flair-relevant ones.
+/// Fingerprinting the flair fields to suppress no-op pings was considered and rejected — it saves a
+/// call that only happens for players currently online in chat, at the cost of real machinery and a
+/// new way to be subtly wrong. Chat-side coalescing absorbs the volume.
+/// </para>
+/// </summary>
+public class FlairNotifyingPersonalSettingsRepository(
+    IPersonalSettingsRepository inner,
+    IFlairChangeNotifier notifier) : IPersonalSettingsRepository
+{
+    public Task<PersonalSetting> Load(string battletag) => inner.Load(battletag);
+    public Task<PersonalSetting> LoadOrCreate(string battletag) => inner.LoadOrCreate(battletag);
+    public Task<PersonalSetting> Find(string battletag) => inner.Find(battletag);
+    public Task<List<PersonalSetting>> LoadSince(DateTimeOffset from) => inner.LoadSince(from);
+    public Task<List<PersonalSetting>> LoadMany(string[] battletags) => inner.LoadMany(battletags);
+    public Task<List<PersonalSetting>> LoadAll() => inner.LoadAll();
+
+    public async Task Save(PersonalSetting setting)
+    {
+        await inner.Save(setting);
+        Notify(new[] { setting?.Id });
+    }
+
+    public async Task SaveMany(List<PersonalSetting> settings)
+    {
+        await inner.SaveMany(settings);
+        Notify(settings?.Select(s => s?.Id).ToList());
+    }
+
+    // Notification is strictly after a successful write and can never fail it: if the inner call
+    // throws we never get here, and if the notifier throws we swallow it. A player must not lose a
+    // settings save because chat-service is unreachable.
+    private void Notify(IReadOnlyCollection<string> battleTags)
+    {
+        if (battleTags == null || battleTags.Count == 0) return;
+
+        try
+        {
+            notifier.NotifyChanged(battleTags);
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Flair change-ping dispatch failed after a personal-settings write");
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Create the clan decorator**
+
+Create `W3ChampionsStatisticService/Clans/FlairNotifyingClanRepository.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Serilog;
+using W3C.Domain.ChatService;
+using W3ChampionsStatisticService.Ports;
+
+namespace W3ChampionsStatisticService.Clans;
+
+/// <summary>
+/// Fires a flair change-ping after a successful clan-membership write. Clan tag is part of a player's
+/// chat flair, so joining, leaving, being kicked, or having the clan deleted under them all need to
+/// reach chat-service.
+/// <para>
+/// Only the two MEMBERSHIP-persisting methods notify. <c>UpsertClan</c> and <c>DeleteClan</c> carry no
+/// battleTags, and every path that calls them also persists the affected memberships through
+/// <see cref="UpsertMemberShip"/> or <see cref="SaveMemberShips"/> — including the bulk teardown in
+/// <c>ClanCommandHandler.DeleteClan</c>, which calls <see cref="SaveMemberShips"/> twice (former
+/// members, then revoked invitees). So the bulk path is covered with no special-casing.
+/// </para>
+/// </summary>
+public class FlairNotifyingClanRepository(
+    IClanRepository inner,
+    IFlairChangeNotifier notifier) : IClanRepository
+{
+    public Task TryInsertClan(Clan clan) => inner.TryInsertClan(clan);
+    public Task<Clan> LoadClan(string clanId) => inner.LoadClan(clanId);
+    public Task UpsertClan(Clan clan) => inner.UpsertClan(clan);
+    public Task<ClanMembership> LoadMemberShip(string battleTag) => inner.LoadMemberShip(battleTag);
+    public Task DeleteClan(string clanId) => inner.DeleteClan(clanId);
+    public Task<List<ClanMembership>> LoadMemberShips(List<string> clanMembers) => inner.LoadMemberShips(clanMembers);
+    public Task<List<ClanMembership>> LoadMemberShipsSince(DateTimeOffset from) => inner.LoadMemberShipsSince(from);
+
+    public async Task UpsertMemberShip(ClanMembership clanMemberShip)
+    {
+        await inner.UpsertMemberShip(clanMemberShip);
+        Notify(new[] { clanMemberShip?.BattleTag });
+    }
+
+    public async Task SaveMemberShips(List<ClanMembership> clanMembers)
+    {
+        await inner.SaveMemberShips(clanMembers);
+        Notify(clanMembers?.Select(m => m?.BattleTag).ToList());
+    }
+
+    private void Notify(IReadOnlyCollection<string> battleTags)
+    {
+        if (battleTags == null || battleTags.Count == 0) return;
+
+        try
+        {
+            notifier.NotifyChanged(battleTags);
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Flair change-ping dispatch failed after a clan-membership write");
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd "<website-backend worktree>"
+dotnet test WC3ChampionsStatisticService.UnitTests --filter "FullyQualifiedName~FlairNotifyingRepositoryTests"
+```
+
+Expected: `Failed: 0, Passed: 10`
+
+- [ ] **Step 6: Wire the DI**
+
+In `W3ChampionsStatisticService/Program.cs`, find the existing chat-ping block (around lines 241-248, registering `ChatPingSettings` and `IRelationshipChangeNotifier`) and add the flair notifier beside it:
+
+```csharp
+builder.Services.AddSingleton<IFlairChangeNotifier, FlairChangeNotifier>();
+```
+
+Then, **after both** `AddInterceptedTransient` calls (currently lines 178 and 187), add:
+
+```csharp
+// Flair change-pings hang off the persistence boundary rather than the five separate command paths
+// that write flair — see FlairNotifyingPersonalSettingsRepository's class doc. Decorate MUST run
+// after the AddInterceptedTransient registrations above: it wraps whatever is registered at the time
+// it is called, and building the inner instance from that captured registration is what keeps the
+// Castle tracing proxy alive underneath the decorator.
+builder.Services.Decorate<IPersonalSettingsRepository, FlairNotifyingPersonalSettingsRepository>();
+builder.Services.Decorate<IClanRepository, FlairNotifyingClanRepository>();
+```
+
+Add `using W3C.Domain.ChatService;`, `using W3ChampionsStatisticService.Extensions;`, `using W3ChampionsStatisticService.PersonalSettings;` and `using W3ChampionsStatisticService.Clans;` to `Program.cs` if any are missing.
+
+- [ ] **Step 7: Run the full suite**
+
+```bash
+cd "<website-backend worktree>"
+dotnet test WC3ChampionsStatisticService.UnitTests
+```
+
+Expected: the baseline you recorded before starting, plus the 23 tests added by Tasks 1-3. Report both numbers so they reconcile. `dotnet format --verify-no-changes` must also pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add W3ChampionsStatisticService/PersonalSettings/FlairNotifyingPersonalSettingsRepository.cs W3ChampionsStatisticService/Clans/FlairNotifyingClanRepository.cs W3ChampionsStatisticService/Program.cs WC3ChampionsStatisticService.UnitTests/PersonalSettings/FlairNotifyingRepositoryTests.cs
+git commit -m "feat(chat): ping chat-service from the settings and clan persistence boundary"
+```
+
+---
+
+### Task 4: `FlairRefresher` — the refresh and the `FreshFromWb` rule
+
+**Files:**
+- Create: `W3ChampionsChatService/Protocol/FlairChangedDto.cs`
+- Modify: `W3ChampionsChatService/Protocol/ChatEvents.cs`
+- Create: `W3ChampionsChatService/Chats/UserDirectoryUpsert.cs`
+- Modify: `W3ChampionsChatService/Chats/ChatHub.cs` (the private `UpsertDirectory` method, currently lines 287-306)
+- Create: `W3ChampionsChatService/FanOut/FlairRefresher.cs`
+- Modify: `W3ChampionsChatService/Startup.cs`
+- Test: `W3ChampionsChatService.Tests/FlairRefresherTests.cs`
+
+**Interfaces:**
+- Consumes: `ISessionRegistry.GetByBattleTag(string) : ChatSession` with `ChatSession.ConnectionId` / `.Identity`; `IChatAuthenticationService.GetUserFromIdentity(W3CUserAuthentication) : Task<ChatUserResolution>` where `ChatUserResolution` is `record ChatUserResolution(ChatUser User, bool FreshFromWb)`; `ConnectionMapping.RegisterUser(string connectionId, ChatUser user)`; `FocusRegistry.GetFocusedChannels(string connectionId) : IReadOnlyCollection<string>` and `GetFocusedConnections(string channelId) : IReadOnlyCollection<string>`; `ChatProfileMapper.FromChatUser(ChatUser) : ChatProfile`; `UserDirectoryRepository.Load/Upsert`.
+- Produces:
+  - `record FlairChangedDto(string BattleTag, ChatProfile Profile)`
+  - `ChatEvents.FlairChanged`
+  - `static class UserDirectoryUpsert` with `static Task Apply(UserDirectoryRepository userDirectory, string battleTag, ChatUserResolution resolution, DateTime now)`
+  - `interface IFlairRefresher { Task Refresh(string battleTag); }` and `class FlairRefresher(...) : IFlairRefresher`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `W3ChampionsChatService.Tests/FlairRefresherTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using NUnit.Framework;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.Tests;
+
+/// <summary>
+/// The FreshFromWb rule is the single most important behaviour here: a website-backend blip must never
+/// broadcast a degraded profile to every viewer in a channel.
+/// </summary>
+public class FlairRefresherTests : IntegrationTestBase
+{
+    private const string ChangedTag = "peter#123";
+    private const string ViewerTag = "alice#456";
+
+    private HubPushCaptureHarness _harness;
+    private SessionRegistry _sessions;
+    private ConnectionMapping _connections;
+    private FocusRegistry _focus;
+    private UserDirectoryRepository _userDirectory;
+    private Mock<IChatAuthenticationService> _auth;
+    private FlairRefresher _refresher;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _harness = new HubPushCaptureHarness();
+        _sessions = new SessionRegistry();
+        _connections = new ConnectionMapping();
+        _focus = new FocusRegistry();
+        _userDirectory = new UserDirectoryRepository(MongoClient);
+        _auth = new Mock<IChatAuthenticationService>();
+
+        _refresher = new FlairRefresher(
+            _sessions, _auth.Object, _connections, _userDirectory, _focus,
+            _harness.HubContext, new FakeTimeProvider());
+    }
+
+    private static ChatUser UserWith(string battleTag, AvatarCategory race, long pictureId) =>
+        new(battleTag, false, "W3C",
+            new ProfilePicture { Race = race, PictureId = pictureId, IsClassic = false },
+            new ChatColor("chat_color_purple"),
+            [new ChatIcon("chat_icon_crown")]);
+
+    private void GoOnline(string connectionId, string battleTag)
+    {
+        _sessions.Register(connectionId, new W3CUserAuthentication { BattleTag = battleTag, Name = battleTag.Split('#')[0] }, null);
+        _connections.RegisterUser(connectionId, UserWith(battleTag, AvatarCategory.HU, 1));
+    }
+
+    private void ResolvesTo(ChatUser user, bool freshFromWb) =>
+        _auth.Setup(a => a.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()))
+            .ReturnsAsync(new ChatUserResolution(user, freshFromWb));
+
+    [Test]
+    public async Task Refresh_WithNoLiveSession_IsANoOp()
+    {
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        _auth.Verify(a => a.GetUserFromIdentity(It.IsAny<W3CUserAuthentication>()), Times.Never);
+        Assert.That(_harness.AllSignals, Is.Empty);
+    }
+
+    [Test]
+    public async Task Refresh_UpdatesConnectionMappingSoTheirOwnNextMessageCarriesTheNewFlair()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        var cached = _connections.GetUser("conn-peter");
+        Assert.That(cached.ProfilePicture.Race, Is.EqualTo(AvatarCategory.NE));
+        Assert.That(cached.ProfilePicture.PictureId, Is.EqualTo(7));
+    }
+
+    [Test]
+    public async Task Refresh_EmitsFlairChangedToTheChangedUsersOwnConnection_EvenWithNoFocus()
+    {
+        // A user focused on nothing must still see their OWN avatar update.
+        GoOnline("conn-peter", ChangedTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        var signals = _harness.SignalsFor("conn-peter").Where(s => s.Method == ChatEvents.FlairChanged).ToList();
+        Assert.That(signals, Has.Count.EqualTo(1));
+        var payload = (FlairChangedDto)signals.Single().Payload;
+        Assert.That(payload.BattleTag, Is.EqualTo(ChangedTag));
+        Assert.That(payload.Profile.ProfilePicture.PictureId, Is.EqualTo(7));
+        Assert.That(payload.Profile.ClanId, Is.EqualTo("W3C"));
+    }
+
+    [Test]
+    public async Task Refresh_EmitsToEveryConnectionFocusedOnAChannelTheChangedUserIsFocusedOn()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        GoOnline("conn-alice", ViewerTag);
+        _focus.Focus("conn-peter", "lounge", ChangedTag);
+        _focus.Focus("conn-alice", "lounge", ViewerTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_harness.SignalsFor("conn-alice").Count(s => s.Method == ChatEvents.FlairChanged), Is.EqualTo(1));
+        Assert.That(_harness.SignalsFor("conn-peter").Count(s => s.Method == ChatEvents.FlairChanged), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Refresh_SendsOncePerConnection_EvenWhenSharingSeveralChannels()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        GoOnline("conn-alice", ViewerTag);
+        _focus.Focus("conn-peter", "lounge", ChangedTag);
+        _focus.Focus("conn-peter", "clan", ChangedTag);
+        _focus.Focus("conn-alice", "lounge", ViewerTag);
+        _focus.Focus("conn-alice", "clan", ViewerTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_harness.SignalsFor("conn-alice").Count(s => s.Method == ChatEvents.FlairChanged), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Refresh_WhenNotFreshFromWb_DoesNothingAtAll()
+    {
+        // THE RULE. A wb blip resolves to a degraded tier-3 profile. Acting on it would replace good
+        // cached flair and broadcast the default avatar to everyone viewing this user — turning a
+        // transient upstream hiccup into a visible regression for the whole channel.
+        GoOnline("conn-peter", ChangedTag);
+        GoOnline("conn-alice", ViewerTag);
+        _focus.Focus("conn-peter", "lounge", ChangedTag);
+        _focus.Focus("conn-alice", "lounge", ViewerTag);
+
+        var degraded = new ChatUser(ChangedTag, false, null, new ProfilePicture(), null, null);
+        ResolvesTo(degraded, false);
+
+        await _refresher.Refresh(ChangedTag);
+
+        Assert.That(_harness.AllSignals, Is.Empty, "no FlairChanged may be emitted on a stale resolution");
+
+        var cached = _connections.GetUser("conn-peter");
+        Assert.That(cached.ProfilePicture.Race, Is.EqualTo(AvatarCategory.HU),
+            "the good cached ChatUser must survive — never clobbered by a degraded resolution");
+        Assert.That(cached.ClanTag, Is.EqualTo("W3C"));
+
+        var entry = await _userDirectory.Load(ChangedTag);
+        Assert.That(entry, Is.Null, "no directory write may happen on a stale resolution");
+    }
+
+    [Test]
+    public async Task Refresh_WhenFreshFromWb_WritesTheDirectoryProfile()
+    {
+        GoOnline("conn-peter", ChangedTag);
+        ResolvesTo(UserWith(ChangedTag, AvatarCategory.NE, 7), true);
+
+        await _refresher.Refresh(ChangedTag);
+
+        var entry = await _userDirectory.Load(ChangedTag);
+        Assert.That(entry, Is.Not.Null);
+        Assert.That(entry.Profile.ProfilePicture.PictureId, Is.EqualTo(7));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --filter "FullyQualifiedName~FlairRefresherTests" --nologo
+```
+
+Expected: FAIL to compile — `The type or namespace name 'FlairRefresher' could not be found`.
+
+- [ ] **Step 3: Add the event name and the payload DTO**
+
+In `W3ChampionsChatService/Protocol/ChatEvents.cs`, add this constant after `FriendPresenceChanged` (before the closing brace):
+
+```csharp
+    /// <summary>C7: pushed when a player's flair (portrait, chat colour, chat icons, clan) changes,
+    /// to every connection focused on a channel that player is also focused on, plus the player's own
+    /// connection. Carries a <c>FlairChangedDto</c>.</summary>
+    public const string FlairChanged = nameof(FlairChanged);
+```
+
+Create `W3ChampionsChatService/Protocol/FlairChangedDto.cs`:
+
+```csharp
+using W3ChampionsChatService.Domain;
+
+namespace W3ChampionsChatService.Protocol;
+
+/// <summary>
+/// A live flair update for one player, pushed when website-backend reports that their portrait, chat
+/// colour, chat icons or clan changed.
+/// <para>
+/// <see cref="Profile"/> is built by the same <see cref="ChatProfileMapper.FromChatUser"/> that
+/// supplies roster flair and message <c>sender.flair</c>, so a live update cannot render differently
+/// from what a fresh roster would have shown. It is never null: this event is only emitted after a
+/// resolution that was confirmed fresh from website-backend.
+/// </para>
+/// </summary>
+public record FlairChangedDto(string BattleTag, ChatProfile Profile);
+```
+
+- [ ] **Step 4: Extract the directory upsert**
+
+Create `W3ChampionsChatService/Chats/UserDirectoryUpsert.cs`:
+
+```csharp
+using System;
+using System.Threading.Tasks;
+using Serilog;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.Chats;
+
+/// <summary>
+/// The user-directory write shared by the connect path (<c>ChatHub.UpsertDirectory</c>) and the live
+/// flair-refresh path (<c>FanOut.FlairRefresher</c>).
+/// <para>
+/// Extracted so the NEVER-CLOBBER rule exists once: identity fields are always refreshed, but
+/// <see cref="UserDirectoryEntry.Profile"/> is replaced ONLY when the resolution came fresh from
+/// website-backend. Two copies of this rule would be two chances to get it wrong, and the failure
+/// mode — overwriting a good cached profile with a degraded one — is invisible until a user complains
+/// that their avatar reverted.
+/// </para>
+/// <para>
+/// Non-fatal by design: a directory write failure is logged and swallowed. Neither caller should fail
+/// because a cache update did.
+/// </para>
+/// </summary>
+public static class UserDirectoryUpsert
+{
+    public static async Task Apply(
+        UserDirectoryRepository userDirectory,
+        string battleTag,
+        ChatUserResolution resolution,
+        DateTime now)
+    {
+        try
+        {
+            var entry = await userDirectory.Load(battleTag)
+                ?? new UserDirectoryEntry { BattleTag = battleTag };
+            entry.DisplayBattleTag = battleTag;
+            entry.NormalizedName = battleTag?.Trim().ToLowerInvariant();
+            entry.LastSeenAt = now;
+            if (resolution.FreshFromWb)
+            {
+                entry.Profile = ChatProfileMapper.FromChatUser(resolution.User);
+            }
+            await userDirectory.Upsert(entry);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to upsert user_directory entry for {BattleTag}", battleTag);
+        }
+    }
+}
+```
+
+Then in `W3ChampionsChatService/Chats/ChatHub.cs`, replace the entire body of the private `UpsertDirectory` method (currently lines 287-306) so it delegates, keeping the existing method and its call site unchanged:
+
+```csharp
+    private Task UpsertDirectory(W3CUserAuthentication identity, ChatUserResolution resolution, DateTime now) =>
+        UserDirectoryUpsert.Apply(_userDirectory, identity.BattleTag, resolution, now);
+```
+
+- [ ] **Step 5: Create the refresher**
+
+Create `W3ChampionsChatService/FanOut/FlairRefresher.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Serilog;
+using W3ChampionsChatService.Chats;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.Protocol;
+using W3ChampionsChatService.Sessions;
+using W3ChampionsChatService.Users;
+
+namespace W3ChampionsChatService.FanOut;
+
+public interface IFlairRefresher
+{
+    Task Refresh(string battleTag);
+}
+
+/// <summary>
+/// Re-resolves one player's flair after website-backend reports a change, then pushes it to everyone
+/// who can currently see them.
+/// <para>
+/// Reuses <see cref="IChatAuthenticationService.GetUserFromIdentity"/> rather than reading settings
+/// directly, so admin colour/icon forcing, the three-tier fallback and the never-clobber invariant all
+/// come for free and cannot drift from the connect path. Because it also refreshes
+/// <see cref="ConnectionMapping"/>, the changed player's own subsequent messages carry the new flair
+/// within the same connection.
+/// </para>
+/// <para>
+/// A player with no live session is a no-op: their next connect re-enriches anyway. Work is therefore
+/// bounded by the set of players currently online in chat, not by website-backend's write volume.
+/// </para>
+/// </summary>
+public class FlairRefresher(
+    ISessionRegistry sessionRegistry,
+    IChatAuthenticationService chatAuthenticationService,
+    ConnectionMapping connections,
+    UserDirectoryRepository userDirectory,
+    FocusRegistry focusRegistry,
+    IHubContext<ChatHub> hubContext,
+    TimeProvider timeProvider) : IFlairRefresher
+{
+    private readonly ISessionRegistry _sessionRegistry = sessionRegistry;
+    private readonly IChatAuthenticationService _chatAuthenticationService = chatAuthenticationService;
+    private readonly ConnectionMapping _connections = connections;
+    private readonly UserDirectoryRepository _userDirectory = userDirectory;
+    private readonly FocusRegistry _focusRegistry = focusRegistry;
+    private readonly IHubContext<ChatHub> _hubContext = hubContext;
+    private readonly TimeProvider _timeProvider = timeProvider;
+
+    public async Task Refresh(string battleTag)
+    {
+        var session = _sessionRegistry.GetByBattleTag(battleTag);
+        if (session == null) return;
+
+        var resolution = await _chatAuthenticationService.GetUserFromIdentity(session.Identity);
+
+        // THE RULE (spec §5). A wb blip degrades to a tier-3 profile with FreshFromWb false. Acting on
+        // it would replace a good cached ChatUser and broadcast the default avatar to every viewer —
+        // converting a transient upstream hiccup into a visible regression for the whole channel. Doing
+        // nothing costs nothing: the next successful ping, or the player's next connect, re-enriches.
+        if (!resolution.FreshFromWb) return;
+
+        _connections.RegisterUser(session.ConnectionId, resolution.User);
+
+        await UserDirectoryUpsert.Apply(
+            _userDirectory, battleTag, resolution, _timeProvider.GetUtcNow().UtcDateTime);
+
+        var payload = new FlairChangedDto(battleTag, ChatProfileMapper.FromChatUser(resolution.User));
+
+        // Flair is user-scoped, not channel-scoped: the audience is every connection focused on any
+        // channel this player is focused on, deduped, plus their own connection unconditionally so a
+        // player focused on nothing still sees their own avatar update.
+        var targets = new HashSet<string>(StringComparer.Ordinal) { session.ConnectionId };
+        foreach (var channelId in _focusRegistry.GetFocusedChannels(session.ConnectionId))
+        {
+            foreach (var connectionId in _focusRegistry.GetFocusedConnections(channelId))
+            {
+                targets.Add(connectionId);
+            }
+        }
+
+        foreach (var connectionId in targets)
+        {
+            try
+            {
+                await _hubContext.Clients.Client(connectionId).SendAsync(ChatEvents.FlairChanged, payload);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Fan-out send of FlairChanged failed for connection {ConnectionId} — skipping", connectionId);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Register it**
+
+In `W3ChampionsChatService/Startup.cs`, immediately after the `ViewerResolver` registration (currently line 181):
+
+```csharp
+        // Singleton: holds only singletons plus the hub context. Consumed by FlairRefreshCoalescer.
+        services.AddSingleton<IFlairRefresher, FlairRefresher>();
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --filter "FullyQualifiedName~FlairRefresherTests" --nologo
+```
+
+Expected: `Failed: 0, Passed: 7`
+
+- [ ] **Step 8: Run the full suite**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --nologo
+```
+
+Expected: `Failed: 0, Passed: 1365` (the 1358 baseline plus 7). The `ChatHub.UpsertDirectory` extraction is behaviour-preserving, so no existing test may change.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add W3ChampionsChatService/Protocol/FlairChangedDto.cs W3ChampionsChatService/Protocol/ChatEvents.cs W3ChampionsChatService/Chats/UserDirectoryUpsert.cs W3ChampionsChatService/Chats/ChatHub.cs W3ChampionsChatService/FanOut/FlairRefresher.cs W3ChampionsChatService/Startup.cs W3ChampionsChatService.Tests/FlairRefresherTests.cs
+git commit -m "feat(chat): re-resolve and push flair when website-backend reports a change"
+```
+
+---
+
+### Task 5: `FlairRefreshCoalescer`
+
+**Files:**
+- Create: `W3ChampionsChatService/FanOut/FlairRefreshCoalescer.cs`
+- Modify: `W3ChampionsChatService/Domain/ChatLimits.cs`
+- Modify: `W3ChampionsChatService/FanOut/FanOutFlushService.cs`
+- Modify: `W3ChampionsChatService/Startup.cs`
+- Test: `W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs`
+
+**Interfaces:**
+- Consumes: `IFlairRefresher.Refresh(string battleTag) : Task` (Task 4).
+- Produces: `class FlairRefreshCoalescer(IFlairRefresher refresher)` with `void RecordChange(string battleTag)`, `Task Flush()`, and `internal int PendingCount`.
+
+`Flush()` deliberately takes no `now` parameter, unlike its two siblings. They coalesce over a multi-second window and need the clock to decide what is due; this one's window *is* the flush tick, so every pending tag is due on every flush and a `now` argument would be dead weight.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `W3ChampionsChatService.Tests/FlairRefreshCoalescerTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+
+namespace W3ChampionsChatService.Tests;
+
+public class FlairRefreshCoalescerTests
+{
+    private class RecordingRefresher : IFlairRefresher
+    {
+        public List<string> Refreshed { get; } = new();
+        public bool Throw { get; set; }
+
+        public Task Refresh(string battleTag)
+        {
+            Refreshed.Add(battleTag);
+            if (Throw) throw new System.InvalidOperationException("refresh exploded");
+            return Task.CompletedTask;
+        }
+    }
+
+    private RecordingRefresher _refresher;
+    private FlairRefreshCoalescer _coalescer;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _refresher = new RecordingRefresher();
+        _coalescer = new FlairRefreshCoalescer(_refresher);
+    }
+
+    [Test]
+    public async Task Flush_RefreshesEachRecordedBattleTagOnce()
+    {
+        _coalescer.RecordChange("peter#123");
+        _coalescer.RecordChange("alice#456");
+
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Is.EquivalentTo(new[] { "peter#123", "alice#456" }));
+    }
+
+    [Test]
+    public async Task Flush_CollapsesABurstForOneBattleTagIntoASingleRefresh()
+    {
+        // Five writes in one tick — e.g. a reward grant that touches colour then icons — must cost one
+        // website-backend round-trip, not five.
+        for (var i = 0; i < 5; i++) _coalescer.RecordChange("peter#123");
+
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Is.EqualTo(new[] { "peter#123" }));
+    }
+
+    [Test]
+    public async Task RecordChange_IsCaseInsensitive()
+    {
+        _coalescer.RecordChange("Peter#123");
+        _coalescer.RecordChange("peter#123");
+
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Flush_DrainsThePendingSet()
+    {
+        _coalescer.RecordChange("peter#123");
+        await _coalescer.Flush();
+        await _coalescer.Flush();
+
+        Assert.That(_refresher.Refreshed, Is.EqualTo(new[] { "peter#123" }));
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void RecordChange_AtCapacity_DropsRatherThanGrows()
+    {
+        for (var i = 0; i < ChatLimits.FlairRefreshPendingCap + 50; i++)
+        {
+            _coalescer.RecordChange($"player{i}#1");
+        }
+
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(ChatLimits.FlairRefreshPendingCap));
+    }
+
+    [Test]
+    public void RecordChange_IgnoresBlankTags()
+    {
+        _coalescer.RecordChange(null);
+        _coalescer.RecordChange("   ");
+
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Flush_WhenOneRefreshThrows_StillRefreshesTheRest()
+    {
+        _refresher.Throw = true;
+        _coalescer.RecordChange("peter#123");
+        _coalescer.RecordChange("alice#456");
+
+        Assert.DoesNotThrowAsync(() => _coalescer.Flush());
+        await Task.CompletedTask;
+
+        Assert.That(_refresher.Refreshed, Has.Count.EqualTo(2),
+            "one player's failed refresh must not cancel everyone else's");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --filter "FullyQualifiedName~FlairRefreshCoalescerTests" --nologo
+```
+
+Expected: FAIL to compile — `The type or namespace name 'FlairRefreshCoalescer' could not be found`.
+
+- [ ] **Step 3: Add the cap constant**
+
+In `W3ChampionsChatService/Domain/ChatLimits.cs`, add beside the other fan-out limits:
+
+```csharp
+    /// <summary>
+    /// Maximum battleTags the flair-refresh coalescer will hold between flushes. At the cap it DROPS
+    /// new tags rather than growing: a dropped refresh degrades to the reconnect backstop, whereas an
+    /// unbounded set would let a website-backend write storm consume memory here.
+    /// </summary>
+    public const int FlairRefreshPendingCap = 512;
+```
+
+- [ ] **Step 4: Create the coalescer**
+
+Create `W3ChampionsChatService/FanOut/FlairRefreshCoalescer.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Serilog;
+using W3ChampionsChatService.Domain;
+
+namespace W3ChampionsChatService.FanOut;
+
+/// <summary>
+/// Collapses a burst of flair-change notifications for the same player into one refresh per flush
+/// tick. website-backend deliberately over-notifies (it pings on any settings save, not only
+/// flair-relevant ones), and a single user action can cross the persistence boundary several times —
+/// this is where that volume is absorbed.
+/// <para>
+/// Mirrors the discipline of <see cref="ActivityCoalescer"/> and <see cref="ViewersAccumulator"/>:
+/// mutate state under one lock, do the work outside it, fault-isolate per item.
+/// </para>
+/// </summary>
+public class FlairRefreshCoalescer(IFlairRefresher refresher)
+{
+    private readonly IFlairRefresher _refresher = refresher;
+    private readonly HashSet<string> _pending = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _lock = new();
+
+    /// <summary>Test seam.</summary>
+    internal int PendingCount
+    {
+        get { lock (_lock) { return _pending.Count; } }
+    }
+
+    public void RecordChange(string battleTag)
+    {
+        if (string.IsNullOrWhiteSpace(battleTag)) return;
+
+        lock (_lock)
+        {
+            // At the cap, drop rather than grow. Dropping degrades to the reconnect backstop; growing
+            // without bound would let an upstream write storm become a memory problem here.
+            if (_pending.Count >= ChatLimits.FlairRefreshPendingCap && !_pending.Contains(battleTag))
+            {
+                return;
+            }
+
+            _pending.Add(battleTag);
+        }
+    }
+
+    public async Task Flush()
+    {
+        List<string> due;
+        lock (_lock)
+        {
+            if (_pending.Count == 0) return;
+            due = new List<string>(_pending);
+            _pending.Clear();
+        }
+
+        foreach (var battleTag in due)
+        {
+            try
+            {
+                await _refresher.Refresh(battleTag);
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Flair refresh failed for {BattleTag} — skipping, the next connect re-enriches", battleTag);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Drive it from the flush host**
+
+In `W3ChampionsChatService/FanOut/FanOutFlushService.cs`, add the coalescer as a third constructor parameter and give it its own independent try/catch, matching the existing two:
+
+```csharp
+public class FanOutFlushService(
+    ActivityCoalescer coalescer,
+    ViewersAccumulator accumulator,
+    FlairRefreshCoalescer flairRefreshCoalescer,
+    TimeProvider timeProvider) : BackgroundService
+```
+
+and inside the `do` block, after the `accumulator.FlushDue(now)` try/catch:
+
+```csharp
+            try
+            {
+                await flairRefreshCoalescer.Flush();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "FlairRefreshCoalescer flush failed; will retry next tick");
+            }
+```
+
+- [ ] **Step 6: Register it**
+
+In `W3ChampionsChatService/Startup.cs`, immediately after the `IFlairRefresher` registration added in Task 4:
+
+```csharp
+        services.AddSingleton<FlairRefreshCoalescer>();
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --filter "FullyQualifiedName~FlairRefreshCoalescerTests" --nologo
+```
+
+Expected: `Failed: 0, Passed: 7`
+
+- [ ] **Step 8: Run the full suite**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --nologo
+```
+
+Expected: `Failed: 0, Passed: 1372`. If any `FanOutFlushService` test fails to compile, it constructs the service directly and needs the new argument — add it, and report which tests you touched.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add W3ChampionsChatService/FanOut/FlairRefreshCoalescer.cs W3ChampionsChatService/Domain/ChatLimits.cs W3ChampionsChatService/FanOut/FanOutFlushService.cs W3ChampionsChatService/Startup.cs W3ChampionsChatService.Tests
+git commit -m "feat(chat): coalesce flair-change notifications into one refresh per tick"
+```
+
+---
+
+### Task 6: `POST /internal/profile-changes`
+
+**Files:**
+- Create: `W3ChampionsChatService/Internal/InternalValidation.cs`
+- Modify: `W3ChampionsChatService/Internal/InternalRelationshipChangesController.cs` (the private `IsValidParticipant`, currently lines 77-78)
+- Modify: `W3ChampionsChatService/Internal/InternalChannelsController.cs` (the private `IsValidMemberEntry`, currently lines 302-303)
+- Create: `W3ChampionsChatService/Internal/InternalProfileChangesController.cs`
+- Modify: `W3ChampionsChatService/Internal/InternalDtos.cs`
+- Test: `W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs`
+
+**Interfaces:**
+- Consumes: `FlairRefreshCoalescer.RecordChange(string battleTag)` (Task 5); `ChatLimits.InternalMaxMembersPerCall` (64).
+- Produces: `static class InternalValidation` with `static bool IsValidBattleTag(string value)`; `class InternalProfileChangeRequest { public List<string> BattleTags { get; set; } }`.
+
+The blank/control-char check already exists as two byte-identical private copies (`InternalRelationshipChangesController.IsValidParticipant` and `InternalChannelsController.IsValidMemberEntry`, the latter commented "mirrors ... EXACTLY"). This task factors it out rather than adding a third copy — a rule that must hold identically across every internal endpoint should exist once.
+
+The new controller needs no work to satisfy `InternalChannelsControllerTests`' HMAC sweep: that sweep discovers controllers dynamically off the compiled assembly by namespace or `internal/` route prefix, so living in `W3ChampionsChatService.Internal` is enough. It will *fail* the sweep if the class-level `[InternalHmacAuth(...)]` attribute is missing or its allow-list is empty.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using NUnit.Framework;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+using W3ChampionsChatService.Internal;
+
+namespace W3ChampionsChatService.Tests;
+
+public class InternalProfileChangesControllerTests
+{
+    private class NoOpRefresher : IFlairRefresher
+    {
+        public System.Threading.Tasks.Task Refresh(string battleTag) => System.Threading.Tasks.Task.CompletedTask;
+    }
+
+    private FlairRefreshCoalescer _coalescer;
+    private InternalProfileChangesController _controller;
+
+    [SetUp]
+    public void SetupBeforeEach()
+    {
+        _coalescer = new FlairRefreshCoalescer(new NoOpRefresher());
+        _controller = new InternalProfileChangesController(_coalescer);
+    }
+
+    private static InternalProfileChangeRequest Request(params string[] battleTags) =>
+        new() { BattleTags = battleTags.ToList() };
+
+    [Test]
+    public void Post_EnqueuesEveryBattleTag()
+    {
+        var result = _controller.Post(Request("peter#123", "alice#456"));
+
+        Assert.That(result, Is.InstanceOf<OkResult>());
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Post_AtTheCap_IsAccepted()
+    {
+        var tags = Enumerable.Range(0, ChatLimits.InternalMaxMembersPerCall).Select(i => $"player{i}#1").ToArray();
+
+        Assert.That(_controller.Post(Request(tags)), Is.InstanceOf<OkResult>());
+    }
+
+    [Test]
+    public void Post_OverTheCap_IsRejectedWithNoPartialProcessing()
+    {
+        var tags = Enumerable.Range(0, ChatLimits.InternalMaxMembersPerCall + 1).Select(i => $"player{i}#1").ToArray();
+
+        Assert.That(_controller.Post(Request(tags)), Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Post_WithNullRequest_IsRejected()
+    {
+        Assert.That(_controller.Post(null), Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [Test]
+    public void Post_WithNoBattleTags_IsRejected()
+    {
+        Assert.That(_controller.Post(new InternalProfileChangeRequest { BattleTags = null }), Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(_controller.Post(Request()), Is.InstanceOf<BadRequestObjectResult>());
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("peter\u0000123")]
+    [TestCase("peter\u2028123")]
+    [TestCase("peter\u2029123")]
+    public void Post_WithAnInvalidBattleTag_RejectsTheWholeBatch(string invalid)
+    {
+        // No partial processing: one bad entry rejects the batch, and nothing is enqueued.
+        Assert.That(_controller.Post(Request("peter#123", invalid)), Is.InstanceOf<BadRequestObjectResult>());
+        Assert.That(_coalescer.PendingCount, Is.EqualTo(0));
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --filter "FullyQualifiedName~InternalProfileChangesControllerTests" --nologo
+```
+
+Expected: FAIL to compile — `The type or namespace name 'InternalProfileChangesController' could not be found`.
+
+- [ ] **Step 3: Factor out the shared validator**
+
+Create `W3ChampionsChatService/Internal/InternalValidation.cs`:
+
+```csharp
+using System.Linq;
+
+namespace W3ChampionsChatService.Internal;
+
+/// <summary>
+/// Validation shared by every <c>internal/*</c> endpoint. This rule must hold IDENTICALLY across all
+/// of them, so it lives in one place — it previously existed as two byte-identical private copies,
+/// one of which carried a comment promising it mirrored the other exactly.
+/// </summary>
+public static class InternalValidation
+{
+    /// <summary>
+    /// A usable battleTag: non-blank, and free of control characters. U+2028 and U+2029 are checked
+    /// explicitly because <c>char.IsControl</c> classifies them as separators, not controls, yet they
+    /// terminate lines in JavaScript sources and log viewers.
+    /// </summary>
+    public static bool IsValidBattleTag(string value) =>
+        !string.IsNullOrWhiteSpace(value) && !value.Any(c => char.IsControl(c) || c is '\u2028' or '\u2029');
+}
+```
+
+In `W3ChampionsChatService/Internal/InternalRelationshipChangesController.cs`, replace the private helper (currently lines 77-78) with a delegation, leaving both call sites unchanged:
+
+```csharp
+    private static bool IsValidParticipant(string value) => InternalValidation.IsValidBattleTag(value);
+```
+
+In `W3ChampionsChatService/Internal/InternalChannelsController.cs`, do the same to `IsValidMemberEntry` (currently lines 302-303), and delete the now-inaccurate comment above it that describes mirroring the other controller's copy:
+
+```csharp
+    private static bool IsValidMemberEntry(string value) => InternalValidation.IsValidBattleTag(value);
+```
+
+- [ ] **Step 4: Add the request DTO**
+
+In `W3ChampionsChatService/Internal/InternalDtos.cs`, add beside `InternalRelationshipChangeRequest`:
+
+```csharp
+/// <summary>
+/// Body of <c>POST /internal/profile-changes</c>: the players whose flair website-backend believes
+/// may have changed. Capped at <see cref="Domain.ChatLimits.InternalMaxMembersPerCall"/>; the sender
+/// chunks larger sets into separate requests.
+/// </summary>
+public class InternalProfileChangeRequest
+{
+    public List<string> BattleTags { get; set; }
+}
+```
+
+Ensure the file has `using System.Collections.Generic;`.
+
+- [ ] **Step 5: Create the controller**
+
+Create `W3ChampionsChatService/Internal/InternalProfileChangesController.cs`:
+
+```csharp
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Serilog;
+using W3ChampionsChatService.Authentication;
+using W3ChampionsChatService.Domain;
+using W3ChampionsChatService.FanOut;
+
+namespace W3ChampionsChatService.Internal;
+
+/// <summary>
+/// Receives flair-change notifications from website-backend. Enqueues each battleTag for a coalesced
+/// refresh and returns immediately — the sender is fire-and-forget with a 3 s per-attempt budget, so
+/// this must never do the refresh inline.
+/// </summary>
+[ApiController]
+[Route("internal/profile-changes")]
+[InternalHmacAuth(InternalCaller.Wb)]
+public class InternalProfileChangesController(FlairRefreshCoalescer coalescer) : ControllerBase
+{
+    private const string GenericValidationError = "Invalid request.";
+
+    [HttpPost]
+    public IActionResult Post([FromBody] InternalProfileChangeRequest request)
+    {
+        // Validate the WHOLE batch before enqueuing any of it — no partial processing, so a malformed
+        // request can never leave the coalescer holding half a batch.
+        if (request?.BattleTags == null
+            || request.BattleTags.Count == 0
+            || request.BattleTags.Count > ChatLimits.InternalMaxMembersPerCall
+            || request.BattleTags.Any(tag => !InternalValidation.IsValidBattleTag(tag)))
+        {
+            return BadRequest(new ErrorResult(GenericValidationError));
+        }
+
+        foreach (var battleTag in request.BattleTags)
+        {
+            coalescer.RecordChange(battleTag);
+        }
+
+        Log.Information("Internal profile change {Caller} count={Count}",
+            InternalHmacAuthFilter.ResolveCaller(HttpContext), request.BattleTags.Count);
+
+        return Ok();
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --filter "FullyQualifiedName~InternalProfileChangesControllerTests" --nologo
+```
+
+Expected: `Failed: 0, Passed: 10`
+
+- [ ] **Step 7: Confirm the HMAC sweep covers the new controller**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --filter "FullyQualifiedName~InternalChannelsControllerTests.InternalControllers" --nologo
+```
+
+Expected: PASS. These tests discover internal controllers by reflection, so they now cover the new one automatically. To prove the sweep is really exercising it, temporarily delete the `[InternalHmacAuth(InternalCaller.Wb)]` line, re-run, confirm it FAILS naming `InternalProfileChangesController`, then restore it. Record that RED/GREEN in your report.
+
+- [ ] **Step 8: Run the full suite**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --nologo
+```
+
+Expected: `Failed: 0, Passed: 1382`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add W3ChampionsChatService/Internal W3ChampionsChatService.Tests/InternalProfileChangesControllerTests.cs
+git commit -m "feat(chat): accept flair-change notifications on /internal/profile-changes"
+```
+
+---
+
+### Task 7: launcher-e handles `FlairChanged`
+
+**Files:**
+- Modify: `src/types/chat-protocol.types.ts` (the `EChatHubEvent` object, currently lines 352-369; add the DTO near the other event payloads)
+- Modify: `src/models/chat-core.ts` (the `ChatCoreStoreModel` action declarations around lines 185-192; the action implementations beside `ingestViewersChanged`)
+- Modify: `src/services/chat.service.ts` (the `bindEvents` method, currently around lines 322-376)
+
+**Interfaces:**
+- Consumes: the Task 4 wire shape — `FlairChanged` carrying `{ battleTag: string, profile: IChatProfileDto }`.
+- Produces: nothing consumed by later tasks.
+
+All work is in the launcher-e worktree. There is no test runner; correctness rests on `tsc` plus the manual checks in Task 8.
+
+- [ ] **Step 1: Add the event name**
+
+In `src/types/chat-protocol.types.ts`, add to the `EChatHubEvent` object after `FriendPresenceChanged`:
+
+```ts
+    FlairChanged: "FlairChanged",
+```
+
+- [ ] **Step 2: Add the payload DTO**
+
+In the same file, immediately after the `IFriendPresenceChangedDto` declaration:
+
+```ts
+/**
+ * Wire event payload: `FlairChanged`. Pushed when a player's flair (portrait,
+ * chat colour, chat icons, clan) changes, to every connection focused on a
+ * channel that player is also focused on, plus the player's own connection.
+ *
+ * `profile` is built server-side by the same mapper that supplies roster flair
+ * and message `sender.flair`, so a live update cannot render differently from
+ * what a fresh roster would have shown. It is never null — the server only
+ * emits this event after a resolution confirmed fresh from website-backend.
+ */
+export interface IFlairChangedDto {
+    battleTag: string;
+    profile: IChatProfileDto;
+}
+```
+
+- [ ] **Step 3: Declare the action**
+
+In `src/models/chat-core.ts`, add to the `ChatCoreStoreModel` interface immediately after the `ingestViewersChanged` declaration (currently line 188):
+
+```ts
+    ingestFlairChanged: Action<ChatStoreModel, IFlairChangedDto>;
+```
+
+Add `IFlairChangedDto` to the existing `@/types/chat-protocol.types` import in this file.
+
+- [ ] **Step 4: Implement the action**
+
+In the same file, immediately after the `ingestViewersChanged` action implementation:
+
+```ts
+        ingestFlairChanged: action((state, payload) => {
+            // A live source, so it may write the flair slice — unlike message senders, whose flair is
+            // frozen at send time. Unconditional overwrite: this event is only emitted after the server
+            // confirmed a fresh resolution, so it is always newer than whatever is cached here.
+            if (!payload.profile) return;
+            state.flairByBattleTag[payload.battleTag.toLowerCase()] = payload.profile;
+        }),
+```
+
+- [ ] **Step 5: Bind the event**
+
+In `src/services/chat.service.ts`, inside `bindEvents`, add beside the other store-routed registrations (next to the `ViewersChanged` line):
+
+```ts
+        connection.on(EChatHubEvent.FlairChanged, (dto: IFlairChangedDto) => this.actions.ingestFlairChanged(dto));
+```
+
+Add `IFlairChangedDto` to the existing `@/types/chat-protocol.types` import in this file.
+
+- [ ] **Step 6: Verify**
+
+```bash
+cd "<launcher-e worktree>"
+npm run type-check
+```
+
+Expected: no output, exit 0.
+
+```bash
+cd "<launcher-e worktree>"
+npm run lint:prod
+```
+
+Expected: no output, exit 0.
+
+```bash
+cd "<launcher-e worktree>"
+npm run dprint
+```
+
+Expected: no output, exit 0. Run `npm run dprint:fix` if it reports differences. dprint here uses 4-space indent, double quotes, and effectively unlimited line width.
+
+```bash
+cd "<launcher-e worktree>"
+npm run check:i18n
+```
+
+Expected: `0 issues`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd "<launcher-e worktree>"
+git add src/types/chat-protocol.types.ts src/models/chat-core.ts src/services/chat.service.ts
+git commit -m "feat(chat): apply live flair updates to the roster"
+```
+
+---
+
+### Task 8: End-to-end verification
+
+**Files:** none modified.
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-7.
+- Produces: nothing.
+
+Every preceding task verified one side of a boundary in isolation. Nothing so far has run a real website-backend against a real chat-service against a real client.
+
+- [ ] **Step 1: Full website-backend suite**
+
+```bash
+cd "<website-backend worktree>"
+dotnet test WC3ChampionsStatisticService.UnitTests
+```
+
+Expected: the recorded baseline plus 23. Report both numbers.
+
+```bash
+cd "<website-backend worktree>"
+dotnet format --verify-no-changes --verbosity diagnostic
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Full chat-service suite**
+
+```bash
+cd "<chat-service worktree>"
+dotnet test --nologo
+```
+
+Expected: `Failed: 0, Passed: 1382`
+
+- [ ] **Step 3: Full launcher-e verification set**
+
+Run each separately from the launcher-e worktree: `npm run type-check`, `npm run lint:prod`, `npm run dprint`, `npm run check:i18n`. All four exit 0.
+
+- [ ] **Step 4: Confirm the notification cannot be bypassed**
+
+```bash
+cd "<website-backend worktree>"
+grep -rn "IPersonalSettingsRepository\|IClanRepository" W3ChampionsStatisticService/Program.cs
+```
+
+Expected: the two `AddInterceptedTransient` registrations, followed by the two `Decorate` calls. If any code resolves `PersonalSettingsRepository` or `ClanRepository` by **concrete type** it would bypass the decorator entirely — check for that too:
+
+```bash
+cd "<website-backend worktree>"
+grep -rn "GetRequiredService<PersonalSettingsRepository>\|GetRequiredService<ClanRepository>\|new PersonalSettingsRepository(\|new ClanRepository(" --include=*.cs W3ChampionsStatisticService W3C.Domain
+```
+
+Expected: no matches outside the DI extension itself. Any hit is a write path that will never notify — report it.
+
+- [ ] **Step 5: Confirm the `FreshFromWb` rule has no bypass**
+
+```bash
+cd "<chat-service worktree>"
+grep -n "FreshFromWb" W3ChampionsChatService/FanOut/FlairRefresher.cs W3ChampionsChatService/Chats/UserDirectoryUpsert.cs
+```
+
+Expected: the guard in `FlairRefresher.Refresh` and the conditional in `UserDirectoryUpsert.Apply`. Confirm no code path in `FlairRefresher` reaches `RegisterUser`, the directory write, or a `SendAsync` before that guard.
+
+- [ ] **Step 6: Manual smoke test**
+
+Run all three services together with `CHAT_INTERNAL_API_SECRET` set to the same value on both sides, and confirm:
+
+1. Player A and player B are both in the Lounge, both focused. A changes their portrait on the website. Within ~2 seconds B sees A's avatar change **without either reconnecting**.
+2. A's chat colour and icons update the same way.
+3. A joins or leaves a clan; B sees A's clan tag update live.
+4. A deletes a clan with more than 64 members; every former member's flair updates (this exercises the notifier's chunking).
+5. A's own next message carries the new flair — confirming `ConnectionMapping` was refreshed, not just the roster.
+6. A player with no channel focused still sees their **own** avatar update.
+7. Stop website-backend's chat pings by unsetting `CHAT_INTERNAL_API_SECRET` and restarting it: everything still works exactly as it does today, with one startup log line saying pings are disabled.
+8. **The `FreshFromWb` case:** make website-backend's `clan-and-picture` endpoint fail (stop the service or block the route), then trigger a flair change ping by hand. Confirm no `FlairChanged` is emitted and **no viewer's avatar changes to the sheep**. This is the one scenario where this feature could make production worse than before it existed.
+
+- [ ] **Step 7: Report**
+
+Report the two suite counts, the four launcher-e exit codes, the two grep results, and the outcome of each of the eight manual checks. Do not claim completion without the manual results — no automated test in this plan exercises all three services together.
+
+---
+
+## Rollout
+
+This plan is step 4 of the spec's §8 rollout, and steps 1-3 have already shipped. It is deployable **dark**: without `CHAT_INTERNAL_API_SECRET` the notifier self-disables and nothing changes. Deploy chat-service first (the endpoint is inert until something calls it), then website-backend, then set the secret to enable.
+
+Unlike Plan A, nothing here is a breaking wire change. `FlairChanged` is a new event; a client that does not bind it simply ignores it, and the launcher change in Task 7 can ship on any schedule.
+
+## Known and accepted
+
+Carried forward from the spec's non-goals, unchanged by this plan:
+
+- Already-rendered message history is never repaired. `ChannelMessage.Sender.Flair` stays an immutable send-time snapshot.
+- The per-message flair storage cost (~49% of a message document) is not addressed.
+- `ProfilePicture.Default()` in website-backend still picks a random `STARTER 1-4`.
+- Flair is not propagated for players who are offline, or online but not focused on any channel the changed player is in. They pick it up on their next focus or connect.
+- The reconnect window noted in Plan A's final review still exists: between `SessionRegistry.Register` and `ConnectionMapping.RegisterUser` there is up to ~4 s of awaited I/O during which a refresh finds a session but no cached `ChatUser`. `FlairRefresher` degrades correctly there (it re-registers from a fresh resolution), so this plan neither widens nor fixes it.

--- a/docs/superpowers/plans/2026-08-10-live-flair-propagation-plan-b.md
+++ b/docs/superpowers/plans/2026-08-10-live-flair-propagation-plan-b.md
@@ -13,7 +13,7 @@
 - **Spec:** `docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md`. This plan implements §3.2, §3.3 and the `FlairChangedDto` row of §4. §3.1 and the roster half of §4 shipped in Plan A (chat-service PR #44, launcher-e PR #850, both merged 2026-08-10).
 - **The `FreshFromWb` rule is the single most important behaviour in this plan.** On a refresh, if `GetUserFromIdentity` returns `FreshFromWb == false`, do **nothing at all** — no `RegisterUser`, no directory write, no `FlairChanged`. A website-backend blip would otherwise broadcast a degraded tier-3 profile (the sheep) to every viewer in the channel, turning a transient upstream hiccup into a visible regression for everyone. This is the one place this design could make things worse than today. It gets an explicit test.
 - **Never fail a caller's write.** A notifier fault must never surface to a settings save or clan operation. Notification fires only *after* the inner write succeeds, inside its own try/catch.
-- **Self-disabling.** Without `CHAT_INTERNAL_API_SECRET` the notifier is a silent no-op with one startup log line. This is what makes the feature deployable dark and enabled by configuration.
+- **Self-disabling.** Without `CHAT_INTERNAL_API_SECRET` the notifier is a silent no-op with one startup log line. **Correction (2026-08-10, from the final review):** this does *not* make the feature deployable dark. `ChatPingSettings` is keyed on the same `CHAT_INTERNAL_API_SECRET` the already-shipped `RelationshipChangeNotifier` uses, so in any environment where relationship pings work — production included — the flair notifier is enabled the moment website-backend deploys. There is no configuration state in which website-backend ships this dormant. The mitigation is deploy order, not configuration: see Rollout.
 - **Reuse, do not reinvent.** `IFlairChangeNotifier` clones the `RelationshipChangeNotifier` triad 1:1 — same `ChatInternalApiSigner` HMAC scheme and headers, same `ChatPingSettings`, same `Task.Run` fire-and-forget with 2 attempts and a 3 s per-attempt cap. The chat-service controller clones `InternalRelationshipChangesController`. The coalescer mirrors `ActivityCoalescer` / `ViewersAccumulator` discipline: mutate state under one lock, send outside it, fault-isolate per connection.
 - **Batch cap:** `ChatLimits.InternalMaxMembersPerCall` is **64**. The bulk clan-delete path can exceed that, so the notifier must chunk; the controller rejects any batch over the cap outright with no partial processing.
 - **launcher-e has no test runner.** Do not add one and do not write frontend tests. Verification there is `npm run type-check`, `npm run lint:prod`, `npm run dprint`, `npm run check:i18n`.
@@ -2167,7 +2167,11 @@ Report the two suite counts, the four launcher-e exit codes, the two grep result
 
 ## Rollout
 
-This plan is step 4 of the spec's §8 rollout, and steps 1-3 have already shipped. It is deployable **dark**: without `CHAT_INTERNAL_API_SECRET` the notifier self-disables and nothing changes. Deploy chat-service first (the endpoint is inert until something calls it), then website-backend, then set the secret to enable.
+This plan is step 4 of the spec's §8 rollout, and steps 1-3 have already shipped.
+
+**Deploy order is load-bearing: chat-service first, then website-backend.** `CHAT_INTERNAL_API_SECRET` is already set in production (it is shared with the relationship pings), so website-backend starts POSTing the moment it deploys. If the chat-service route does not exist yet, every settings save and clan write gets a 404, retries once, and logs `Flair change-ping rejected by chat-service`. No user-visible harm — the write has already committed and the notifier cannot fail it — but it is sustained log noise proportional to site write volume, and it is also the rollback story: reverting chat-service alone leaves website-backend warning on every write until it follows.
+
+The chat-service side is inert on its own: the endpoint exists but nothing calls it until website-backend ships.
 
 Unlike Plan A, nothing here is a breaking wire change. `FlairChanged` is a new event; a client that does not bind it simply ignores it, and the launcher change in Task 7 can ship on any schedule.
 


### PR DESCRIPTION
> **PR set (3 repos).** Deploy order: **1.** chat-service https://github.com/w3champions/chat-service/pull/45 → **2.** website-backend https://github.com/w3champions/website-backend/pull/554 → **3.** launcher-e https://github.com/w3champions/launcher-e/pull/852 *(any time)*.
>
> This is **1 of 3 — chat-service**.

> [!IMPORTANT]
> **Deploy this before the website-backend PR.** See [Deploy order](#deploy-order). This side is inert on its own — the endpoint exists but nothing calls it until website-backend ships.

## What this does

A player changes their portrait, chat colour, chat icons or clan. Today every other viewer keeps seeing the old flair until one of them reconnects. After this, they see it within about a second.

This is the follow-up promised in #44 ("live propagation of a flair *change* to already-connected clients is out of scope — planned follow-up").

## The chain

website-backend fires an HMAC-signed, fire-and-forget POST at its **persistence boundary** (decorators over the settings and clan repositories, so every write path is covered without touching a command handler). This PR is the receiving half:

```
POST /internal/profile-changes   →  validate whole batch, reject >64 outright
      ↓
FlairRefreshCoalescer            →  collapse a burst per battleTag into one refresh per tick
      ↓
FlairRefresher                   →  re-resolve through GetUserFromIdentity
      ↓                             ── if !FreshFromWb: stop here, do nothing ──
      ↓
ConnectionMapping + user directory refreshed, FlairChanged pushed to viewers
```

## The `FreshFromWb` rule

This is the one place this design could make production *worse* than not having it.

`GetUserFromIdentity` has a three-tier fallback: fresh from website-backend, then cache, then a degraded default profile — the sheep. If a refresh accepted a degraded resolution, a transient website-backend blip would broadcast the sheep to **every viewer in the channel**, converting a brief upstream hiccup into a visible regression for everyone.

So `FlairRefresher.Refresh` returns immediately unless `FreshFromWb` is true — before `RegisterUser`, before the directory write, before any send. The test asserts all three consequences, not just the absent event.

The review traced this to its source rather than taking it on faith: `WebsiteBackendRepository.GetChatDetails` calls `EnsureSuccessStatusCode()` and throws on a success-status-with-unusable-body, specifically so a 4xx/5xx error envelope cannot deserialize into an all-null DTO and get stamped fresh. `FreshFromWb == true` really does mean a round trip succeeded on this call.

## What changed

- **`InternalProfileChangesController`** (new) — `POST /internal/profile-changes`, `[InternalHmacAuth(InternalCaller.Wb)]`. Validates the entire batch before enqueuing anything: an oversize batch is rejected outright with no partial processing, because the sender chunks to match and a partially-processed batch would silently lose changes.
- **`InternalValidation`** (new) — the blank/control-char battleTag check. It already existed as two byte-identical private copies, one commented as mirroring the other *exactly*; both now delegate here rather than a third copy being added.
- **`FlairRefreshCoalescer`** (new) — bounded pending set (`FlairRefreshPendingCap = 512`), drained on the existing `FanOutFlushService` tick as an independent third participant with its own try/catch. Same lock discipline as its two siblings: mutate under the lock, send outside it, fault-isolate per item.
- **`FlairRefresher`** (new) — the refresh above. Fan-out targets the changed player's own connection plus every connection focused on a channel they are focused on — deduped, and fault-isolated per connection so one dead socket cannot abort the rest.
- **`UserDirectoryUpsert`** (new) — the never-clobber directory rule, extracted from `ChatHub.UpsertDirectory`. Connect and refresh now share one implementation instead of two copies that can drift.
- **`FlairChangedDto`** + `ChatEvents.FlairChanged` — the new event.

## What review caught

Worth calling out, because both were silent-failure classes rather than broken behaviour:

- **The flush-service drain had no test.** `FanOutFlushServiceTests` was updated only enough to satisfy the new constructor parameter — the refresher passed in was inert and never observed. Deleting the flair drain block from `ExecuteAsync` left all 1409 tests green while, in production, no flair would ever propagate and the coalescer would fill to 512 and drop. Now uses a recording refresher, mutation-verified (drain deleted → red, restored → green).
- **The drain was unbounded per tick.** `Flush` drained the whole pending set. A clan delete with ~30 online members against a slow website-backend is ~30 sequential 2 s HTTP calls in one tick, during which `ActivityCoalescer` (10 s cadence) and `ViewersAccumulator` (5 s cadence) don't flush at all — `WaitForNextTickAsync` returns immediately on a dropped tick, so the loop runs late rather than catching up. That's a latency regression in two shipped features caused by this one. Now bounded by `ChatLimits.FlairRefreshPerTickBudget = 32`; the remainder waits for the next tick, which the coalescer's semantics already tolerate.
- **Fan-out had no negative test** — a regression to `Clients.All` would have passed the whole file. Now there's a bystander connection asserted to receive nothing.

## Verification

`Failed: 0, Passed: 1411` after rebasing onto `master`. 25 tests added by this branch.

The auth attribute was RED/GREEN checked: removing `[InternalHmacAuth]` makes the repo's reflection sweep fail and name this controller, so the new endpoint is genuinely covered by the existing security sweep rather than silently exempt. A separate assertion pins it to `Wb` **only** — verified mutation-sensitive by temporarily widening it to `Mm` and watching it fail.

## Deploy order

**chat-service (this PR) → website-backend → launcher-e (any time).**

The plan originally claimed this was deployable dark. It isn't, and that claim has been corrected in the plan document. `ChatPingSettings` is keyed on the same `CHAT_INTERNAL_API_SECRET` the already-shipped relationship pings use — that secret is already set in production, so website-backend starts POSTing the moment it deploys. There is no configuration state in which it ships dormant.

If this PR isn't live first, every settings save and clan write gets a 404, retries once, and logs a warning. No user-visible harm — the write already committed and the notifier cannot fail it — but it's sustained log noise proportional to write volume. It's also the rollback story: reverting this alone leaves website-backend warning on every write until it follows.

Unlike #44, nothing here is a breaking wire change. `FlairChanged` is a **new** event name; a client that doesn't bind it logs a warning and drops the frame. The launcher can ship whenever.

## Still owed: manual verification

No automated test runs all three services together. These are unverified:

1. A and B both in the Lounge, both focused. A changes their portrait on the website → within ~2 s B sees it, neither reconnecting.
2. Chat colour and icons update the same way.
3. A joins or leaves a clan → B sees the clan tag update live.
4. A deletes a clan with **more than 64 members** → every former member's flair updates (exercises the notifier's chunking; an unchunked send would be rejected wholesale by this PR's cap).
5. A's own next message carries the new flair — confirms `ConnectionMapping` was refreshed, not just the roster.
6. A player with no channel focused still sees their **own** avatar update.
7. Unset `CHAT_INTERNAL_API_SECRET` on website-backend and restart: everything behaves as it does today, with one startup log line.
8. **The `FreshFromWb` case.** Make website-backend's `clan-and-picture` endpoint fail, then trigger a ping by hand. Confirm no `FlairChanged` is emitted and **no viewer's avatar turns into the sheep.**

Check 8 is the one that matters most — it's the scenario where this feature could make things worse than not shipping it.

## Known and accepted

- Message history is never repaired; `ChannelMessage.Sender.Flair` stays an immutable send-time snapshot.
- **Clan changes are half-live by design.** The displayed clan tag updates immediately, but clan-*channel* seating is reconciled only on connect (`ChatHub.ReconcileClanMembership`). After a live clan change the roster shows the new tag while the player still sits in the old clan channel until they reconnect. Correct scoping for a flair feature — flagged so it isn't reported as a bug later.
- Nothing propagates to players who are offline, or online but not focused on a channel the changed player is in. They pick it up on next focus or connect.
- Coalescer overflow at the 512 cap has no operator signal today. Worth a rate-limited warning later; out of scope here.
- **The user directory's write is a blind replace, and concurrent writers can lose an update.** `UserDirectoryRepository.Upsert` is a `ReplaceOneAsync` keyed only on `BattleTag` with no version guard, and every caller is a read-modify-write with an await in the middle. That file is untouched here and the race predates this branch — two concurrent connects for the same battleTag already hit it on `master`. This PR adds a second writer (refresh vs. connect; refresh vs. refresh is impossible, the coalescer drains serially). The affected field is the directory `Profile`, read by mention-candidate lookup and the website-backend-outage fallback cache — not by the live broadcast, which uses the in-memory resolution. It self-heals on the next connect or refresh. Tracked separately in #46, which proposes optimistic concurrency at the write; caller-side revalidation cannot close it.
- The reconnect window from #44's review still exists (`SessionRegistry.Register` repoints before `ConnectionMapping.RegisterUser` runs). `FlairRefresher` degrades correctly there — it re-registers from a fresh resolution — so this neither widens nor fixes it.

## Design docs

- Spec: `docs/superpowers/specs/2026-08-09-roster-flair-enrichment-design.md` (§3.2, §3.3, §5)
- Plan: `docs/superpowers/plans/2026-08-10-live-flair-propagation-plan-b.md`
