### PR TITLE
fix(auth): toggleable ticket-mint JWT lifetime enforcement + per-IP shield amplification

### DIFF
--- a/W3ChampionsChatService.Tests/AuthSessionControllerTests.cs
+++ b/W3ChampionsChatService.Tests/AuthSessionControllerTests.cs
@@ -115,8 +115,15 @@ public class AuthSessionControllerTests
         Assert.IsNull(secondIdentity);
     }
 
+    /// <summary>
+    /// The mint path's `exp` handling is governed by <see cref="ChatLimits.EnforceJwtLifetimeOnTicketMint"/>,
+    /// so this test follows the toggle rather than hard-coding one outcome — flipping the const must
+    /// keep the suite green in BOTH positions, and this is the test that proves it.
+    /// <para>Asserted via computed expectations (not if/else) because the toggle is a compile-time
+    /// <c>const</c>: a literal branch on it would be unreachable code (CS0162) in one position.</para>
+    /// </summary>
     [Test]
-    public void ExpiredJwt_Returns401()
+    public void ExpiredJwt_MintOutcome_FollowsTheEnforcementToggle()
     {
         var (jwt, publicKeyPem) = CreateSignedJwt("peter#123", true, new[] { "Moderation" },
             expires: DateTime.UtcNow.AddMinutes(-10));
@@ -127,8 +134,67 @@ public class AuthSessionControllerTests
 
         var result = controller.MintTicket();
 
-        Assert.IsInstanceOf<UnauthorizedResult>(result, "An expired JWT must be rejected with 401");
-        Assert.AreEqual(0, ticketStore.Count, "No ticket must be minted for an expired JWT");
+        var enforced = ChatLimits.EnforceJwtLifetimeOnTicketMint;
+
+        Assert.AreEqual(enforced, result is UnauthorizedResult, enforced
+            ? "with enforcement ON, an expired JWT must be rejected with 401"
+            : "with enforcement OFF, an expired JWT must still mint — the connect handshake mirrors "
+              + "website-backend's WebsiteBackendHub, which does not validate lifetime at connect");
+        Assert.AreEqual(enforced ? 0 : 1, ticketStore.Count,
+            "the ticket store must reflect the toggle: no ticket when enforcing, exactly one when not");
+    }
+
+    /// <summary>
+    /// The identity carried by a ticket minted from an EXPIRED token must be the real, signature-proven
+    /// identity — turning off the lifetime check must never weaken signature verification or silently
+    /// drop claims. Only meaningful while enforcement is off; a no-op assertion otherwise.
+    /// </summary>
+    [Test]
+    public void ExpiredJwt_WhenNotEnforcing_MintsTicketCarryingTheProvenIdentity()
+    {
+        // Read into a local FIRST: branching on the const directly makes one arm unreachable (CS0162).
+        // A local is not a constant expression, so reachability analysis leaves both arms alone.
+        var enforced = ChatLimits.EnforceJwtLifetimeOnTicketMint;
+        if (enforced)
+        {
+            Assert.Pass("enforcement is ON — an expired token mints nothing; covered by the toggle test above");
+        }
+
+        var (jwt, publicKeyPem) = CreateSignedJwt("peter#123", true, new[] { "Moderation" },
+            expires: DateTime.UtcNow.AddMinutes(-10));
+        var authService = new W3CAuthenticationService(publicKeyPem);
+        var ticketStore = new TicketStore();
+        var controller = BuildController(authService, ticketStore, new MintRateLimiter(), $"Bearer {jwt}");
+
+        var result = controller.MintTicket() as OkObjectResult;
+        Assert.IsNotNull(result, "an expired but validly-signed JWT mints while enforcement is off");
+
+        var ticket = ((TicketResponse)result.Value).Ticket;
+        Assert.IsTrue(ticketStore.TryConsume(ticket, DateTime.UtcNow, out var identity));
+        Assert.AreEqual("peter#123", identity.BattleTag, "the battleTag claim must survive intact");
+        Assert.IsTrue(identity.IsAdmin, "the isAdmin claim must survive intact");
+        Assert.IsTrue(identity.Permissions.Contains(EPermission.Moderation),
+            "permission claims must survive intact — skipping the lifetime check must not drop claims");
+    }
+
+    /// <summary>
+    /// Skipping `exp` must NOT skip signature verification: a token signed by a different key is
+    /// rejected regardless of the toggle. This is the invariant that keeps the toggle safe.
+    /// </summary>
+    [Test]
+    public void BadSignature_IsAlwaysRejected_RegardlessOfTheEnforcementToggle()
+    {
+        var (jwt, _) = CreateSignedJwt("peter#123", true, new[] { "Moderation" });
+        var (_, otherKeyPem) = CreateSignedJwt("someoneElse#1", false, Array.Empty<string>());
+        var authService = new W3CAuthenticationService(otherKeyPem);
+        var ticketStore = new TicketStore();
+        var controller = BuildController(authService, ticketStore, new MintRateLimiter(), $"Bearer {jwt}");
+
+        var result = controller.MintTicket();
+
+        Assert.IsInstanceOf<UnauthorizedResult>(result,
+            "a signature mismatch must 401 whether or not the lifetime check is enforced");
+        Assert.AreEqual(0, ticketStore.Count, "no ticket may ever be minted for an unverifiable token");
     }
 
     [Test]

--- a/W3ChampionsChatService.Tests/AuthSessionControllerTests.cs
+++ b/W3ChampionsChatService.Tests/AuthSessionControllerTests.cs
@@ -370,10 +370,12 @@ public class AuthSessionControllerTests
     }
 
     [Test]
-    public void PerBattleTagThrottledMint_ChargesThePerIpBudget()
+    public void PerBattleTagThrottledMint_DoesNotChargeThePerIpBudget()
     {
-        // A per-battleTag-throttled attempt is itself a REJECTION, so it charges the per-IP budget too —
-        // while the 10 SUCCESSFUL mints that exhausted the per-battleTag cap did not charge it at all.
+        // A per-battleTag-throttled attempt reaches the throttle only by presenting a VALIDLY SIGNED
+        // token — it has already paid full RSA validation, so it was never the cheap pre-validation
+        // attack the per-IP shield exists to stop. Charging the shared IP budget for it let ONE client
+        // degrade every other user behind the same address, so it no longer does.
         var (jwt, publicKeyPem) = CreateSignedJwt("peter#123", true, new[] { "Moderation" });
         var authService = new W3CAuthenticationService(publicKeyPem);
         var ticketStore = new TicketStore();
@@ -391,9 +393,45 @@ public class AuthSessionControllerTests
 
         var throttled = BuildController(authService, ticketStore, limiter, $"Bearer {jwt}", ip).MintTicket();
 
-        Assert.IsInstanceOf<StatusCodeResult>(throttled, "the 11th mint is per-battleTag-throttled");
+        Assert.IsInstanceOf<StatusCodeResult>(throttled, "the 11th mint is still per-battleTag-throttled");
         Assert.AreEqual(StatusCodes.Status429TooManyRequests, ((StatusCodeResult)throttled).StatusCode);
-        Assert.IsTrue(limiter.IsAtLimit($"ip:{ip}", 1, DateTime.UtcNow),
-            "the per-battleTag-throttled rejection must have charged the per-IP budget once");
+        Assert.IsFalse(limiter.IsAtLimit($"ip:{ip}", 1, DateTime.UtcNow),
+            "the per-battleTag-throttled rejection must NOT charge the per-IP budget — the per-battleTag "
+            + "cap is the correct bound for a proven identity, and the IP budget is not its overflow");
+    }
+
+    /// <summary>
+    /// The amplification regression test. One client flapping far past its own per-battleTag cap must
+    /// not degrade its NEIGHBOURS: behind CGNAT or a shared proxy, everyone else on that address is an
+    /// unrelated user who did nothing wrong. Before this, ~40 requests from a single reconnect loop
+    /// exhausted the shared per-IP budget and 429'd every valid token behind the same address.
+    /// </summary>
+    [Test]
+    public void OneFlappingBattleTag_CannotLockOutOtherUsersBehindTheSameIp()
+    {
+        using var rsa = RSA.Create(2048);
+        var publicKeyPem = rsa.ExportSubjectPublicKeyInfoPem();
+        var authService = new W3CAuthenticationService(publicKeyPem);
+        var ticketStore = new TicketStore();
+        var limiter = new MintRateLimiter();
+        const string sharedNatIp = "100.64.0.1"; // RFC 6598 CGNAT space — the realistic shared-address case
+
+        // The flapper: burns its per-battleTag cap, then keeps hammering well past the per-IP limit.
+        var flapperJwt = SignJwt(rsa, "flapper#1", isAdmin: false, new[] { "Moderation" });
+        var attempts = ChatLimits.TicketMintPerBattleTagLimit + ChatLimits.TicketMintPerIpLimit + 5;
+        for (var i = 0; i < attempts; i++)
+        {
+            BuildController(authService, ticketStore, limiter, $"Bearer {flapperJwt}", sharedNatIp).MintTicket();
+        }
+
+        Assert.IsFalse(limiter.IsAtLimit($"ip:{sharedNatIp}", ChatLimits.TicketMintPerIpLimit, DateTime.UtcNow),
+            "a single flapping battleTag must never exhaust the shared per-IP budget");
+
+        // The innocent neighbour: a DIFFERENT valid battleTag on the SAME address must still mint.
+        var neighbourJwt = SignJwt(rsa, "neighbour#2", isAdmin: false, new[] { "Moderation" });
+        var result = BuildController(authService, ticketStore, limiter, $"Bearer {neighbourJwt}", sharedNatIp).MintTicket();
+
+        Assert.IsInstanceOf<OkObjectResult>(result,
+            "an unrelated valid user behind the same shared IP must still mint after a neighbour's reconnect loop");
     }
 }

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -95,13 +95,22 @@ public static class ChatLimits
     /// bounding per-user abuse.
     ///
     /// <para><see cref="TicketMintPerIpLimit"/> = 30/window is a pre-validation DoS shield that, after the
-    /// F1 reconnect-storm rework, caps ONLY REJECTED mint attempts per source IP — auth failures
-    /// (bad/expired token) and per-battleTag-throttled attempts. A SUCCESSFUL mint (valid, non-expired
-    /// JWT under the per-battleTag cap) does NOT charge this budget, so a legitimate mass reconnect of
-    /// thousands of DISTINCT valid battleTags behind one shared/NAT'd proxy IP is never IP-throttled
-    /// (each is still bounded by the per-battleTag cap). It stays a hard-coded const by the ChatLimits
-    /// philosophy; the forwarded-headers TRUST boundary (Startup) is likewise hardcoded to the sibling
-    /// services' convention, so the shield keys on the real client IP.</para></summary>
+    /// F1 reconnect-storm rework, caps ONLY REJECTED mint attempts per source IP. A SUCCESSFUL mint does
+    /// NOT charge this budget, so a legitimate mass reconnect of thousands of DISTINCT valid battleTags
+    /// behind one shared/NAT'd proxy IP is never IP-throttled (each is still bounded by the per-battleTag
+    /// cap). It stays a hard-coded const by the ChatLimits philosophy; the forwarded-headers TRUST
+    /// boundary (Startup) is likewise hardcoded to the sibling services' convention, so the shield keys
+    /// on the real client IP.</para>
+    ///
+    /// <para>Only the two genuinely CHEAP rejection paths charge it: a malformed/non-Bearer header and a
+    /// signature failure. Per-battleTag-THROTTLED attempts deliberately do not (they once did): reaching
+    /// that throttle requires a validly signed token, so the attempt has already paid full RSA validation
+    /// and is bounded by <see cref="TicketMintPerBattleTagLimit"/> anyway. Charging the shared IP budget
+    /// for it meant a single flapping client (≈40 requests in one window) could exhaust the budget and
+    /// 429 every OTHER user behind the same address — an availability hit to unrelated users behind CGNAT
+    /// or a shared proxy. RESIDUAL, accepted: a holder of one valid JWT can now drive unbounded
+    /// past-cap attempts from a single IP without ever tripping the shield, each costing one signature
+    /// validation. Bounding that needs a cost-based (not count-based) limiter, tracked separately.</para></summary>
     public const int TicketMintPerBattleTagLimit = 10;
     public const int TicketMintPerIpLimit = 30;
     public static readonly TimeSpan TicketMintWindow = TimeSpan.FromMinutes(1);

--- a/W3ChampionsChatService/Domain/ChatLimits.cs
+++ b/W3ChampionsChatService/Domain/ChatLimits.cs
@@ -60,6 +60,35 @@ public static class ChatLimits
     /// <summary>Auth ticket TTL (one-time).</summary>
     public static readonly TimeSpan TicketTtl = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    /// Whether <c>POST /auth/session</c> enforces the JWT's <c>exp</c> when minting a connect ticket.
+    /// Toggle in the identification-service <c>AuthorizationController.ENFORCE_*</c> spirit — one const,
+    /// flip it here, no env plumbing (the ChatLimits philosophy).
+    ///
+    /// <para>Currently <c>false</c>. identification-service issues JWTs with a 7-day lifetime
+    /// (<c>W3CUserAuthentication.Create</c>: <c>expires: DateTime.UtcNow.AddDays(7)</c>) and exposes NO
+    /// refresh/renew endpoint — the only way to obtain a new token is a full Blizzard OAuth re-login.
+    /// Meanwhile website-backend deliberately does NOT validate lifetime on its player-facing surfaces,
+    /// notably its SignalR connect (<c>WebsiteBackendHub</c>, <c>GetUserByToken(accessToken, false)</c>).
+    /// With this ON, chat was the strict outlier: a user past day 7 still browsed the website and still
+    /// looked logged in, but could not connect to chat — surfacing as an unexplained auth error.
+    /// OFF makes our connect handshake match the equivalent website-backend surface.</para>
+    ///
+    /// <para>SCOPE — this governs the TICKET-MINT path ONLY. Two things are deliberately unaffected:
+    /// signature verification (an unverifiable token is ALWAYS rejected — the invariant that keeps this
+    /// toggle safe), and the moderation REST surface
+    /// (<see cref="Authentication.UserHasPermissionFilter"/>), which keeps enforcing <c>exp</c> and
+    /// keeps returning <c>AUTH_TOKEN_EXPIRED</c>. That split mirrors website-backend exactly: lax at
+    /// hub connect, strict on the permission filter.</para>
+    ///
+    /// <para>KNOWN COST: <see cref="Sessions.ChatSession.HasPermission"/> gates moderation HUB methods
+    /// on the claims carried by the consumed ticket, so while this is off, an expired-but-validly-signed
+    /// admin token retains its in-hub moderation powers until the holder's permissions change upstream.
+    /// website-backend's hub already carries this same posture. The durable fix is a refresh endpoint in
+    /// identification-service; flip this back to <c>true</c> once one exists.</para>
+    /// </summary>
+    public const bool EnforceJwtLifetimeOnTicketMint = false;
+
     /// <summary>Ticket mint rate limit (C2): fixed window (<see cref="TicketMintWindow"/>). Values are a
     /// C2 plan decision (not spec §13). <see cref="TicketMintPerBattleTagLimit"/> = 10/min caps
     /// SUCCESSFUL-or-not mint attempts per validated battleTag, tolerating reconnect flapping while

--- a/W3ChampionsChatService/Sessions/AuthSessionController.cs
+++ b/W3ChampionsChatService/Sessions/AuthSessionController.cs
@@ -43,7 +43,14 @@ public class AuthSessionController(
         try { token = UserHasPermissionFilter.GetToken(Request.Headers[HeaderNames.Authorization]); }
         catch (SecurityTokenValidationException) { rateLimiter.Record(ipKey, now); return Unauthorized(); }
 
-        var identity = authService.GetUserByTokenEnforcingLifetime(token);
+        // `exp` enforcement here is governed by ChatLimits.EnforceJwtLifetimeOnTicketMint (see that
+        // const for the full rationale). Both overloads verify the SIGNATURE identically — an
+        // unverifiable token is rejected either way; the toggle only decides whether a validly-signed
+        // but expired token may still mint. Ternary (not `if`) so the compile-time const cannot make
+        // either branch unreachable code.
+        var identity = ChatLimits.EnforceJwtLifetimeOnTicketMint
+            ? authService.GetUserByTokenEnforcingLifetime(token)
+            : authService.GetUserByToken(token);
         if (identity == null) { rateLimiter.Record(ipKey, now); return Unauthorized(); }
 
         if (!rateLimiter.TryAcquire($"bt:{identity.BattleTag}", ChatLimits.TicketMintPerBattleTagLimit, now))

--- a/W3ChampionsChatService/Sessions/AuthSessionController.cs
+++ b/W3ChampionsChatService/Sessions/AuthSessionController.cs
@@ -28,14 +28,19 @@ public class AuthSessionController(
         var ip = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
         var ipKey = $"ip:{ip}";
 
-        // F1 reconnect-storm rework: the per-IP budget counts ONLY REJECTED mint attempts, never
-        // successful ones (see the Record() calls below vs the success path, which does NOT charge it).
+        // F1 reconnect-storm rework: the per-IP budget counts ONLY the two CHEAP rejection paths — a
+        // malformed/non-Bearer header and a signature failure (see the Record() calls below). Neither a
+        // successful mint NOR a per-battleTag-throttled attempt charges it.
         // WHY successful mints aren't charged: a legitimate mass reconnect of thousands of DISTINCT
         // valid battleTags behind ONE shared proxy IP must not be IP-throttled — each valid user is
-        // already bounded by the per-battleTag 10/min cap. The pre-validation DoS shield is preserved:
-        // after TicketMintPerIpLimit REJECTIONS per window per IP, further attempts short-circuit here
-        // BEFORE the expensive RSA validation. IsAtLimit is a pure read; the charge is deferred to the
-        // specific rejection branches so the whole valid path stays IP-charge-free.
+        // already bounded by the per-battleTag 10/min cap.
+        // WHY throttled attempts aren't either: they required a validly signed token, so they are not
+        // the cheap pre-validation attack this shield targets, and charging them let ONE flapping client
+        // lock out every other user behind a shared address (see the branch below).
+        // The pre-validation DoS shield is preserved: after TicketMintPerIpLimit cheap REJECTIONS per
+        // window per IP, further attempts short-circuit here BEFORE the expensive RSA validation.
+        // IsAtLimit is a pure read; the charge is deferred to those rejection branches so the whole
+        // valid path stays IP-charge-free.
         if (rateLimiter.IsAtLimit(ipKey, ChatLimits.TicketMintPerIpLimit, now))
             return StatusCode(StatusCodes.Status429TooManyRequests);
 
@@ -53,9 +58,16 @@ public class AuthSessionController(
             : authService.GetUserByToken(token);
         if (identity == null) { rateLimiter.Record(ipKey, now); return Unauthorized(); }
 
+        // Per-battleTag throttling does NOT charge the per-IP budget. Reaching this line required a
+        // VALIDLY SIGNED token, so the attempt already paid full RSA validation — it was never the cheap
+        // pre-validation attack the IP shield exists to stop, and the per-battleTag cap is itself the
+        // correct bound for an identity we have already proven. Charging the shared IP budget here let a
+        // SINGLE flapping client (10 successes + 30 throttled attempts ≈ 40 requests inside one window)
+        // exhaust the budget and 429 every OTHER user behind the same address — behind CGNAT or a shared
+        // proxy, unrelated users who did nothing wrong. The shield keeps its teeth where it matters: the
+        // two genuinely cheap rejection paths above (malformed header, signature failure) still charge.
         if (!rateLimiter.TryAcquire($"bt:{identity.BattleTag}", ChatLimits.TicketMintPerBattleTagLimit, now))
         {
-            rateLimiter.Record(ipKey, now);
             return StatusCode(StatusCodes.Status429TooManyRequests);
         }
 


### PR DESCRIPTION
Two related fixes on the `POST /auth/session` mint path. Both came out of investigating reports of users hitting an unexplained authentication error in chat.

---

## 1. JWT lifetime enforcement is now a toggle, defaulted off

### Problem

Users were reporting an authentication error in chat while still appearing logged in everywhere else. The root cause is a cross-repo asymmetry, not a bug in this service:

- **identification-service** issues JWTs with a **7-day** lifetime (`W3CAuthentication/W3CUserAuthentication.cs` — `expires: DateTime.UtcNow.AddDays(7)`) and exposes **no refresh/renew endpoint**. The only way to obtain a new token is a full Blizzard OAuth re-login via `GET /api/oauth/token` with a fresh `code`.
- **website-backend** deliberately does *not* validate lifetime on its player-facing surfaces — notably its SignalR connect (`WebsiteBackendHub`: `GetUserByToken(accessToken, false)`), plus `BearerCheckIfBattleTagBelongsToAuthFilter` and `InjectActingPlayerFromAuthCodeFilter`. identification-service's own `/api/oauth/user-info` doesn't either.

chat-service was the strict outlier. Past day 7 a user still browsed the website and still *looked* logged in, but could not connect to chat — which is exactly why the reports didn't read as an expiry problem.

### Change

`POST /auth/session` routes its `exp` check through a single const:

```csharp
public const bool EnforceJwtLifetimeOnTicketMint = false;
```

In the identification-service `AuthorizationController.ENFORCE_*` spirit — one flip, no env plumbing, per the ChatLimits philosophy. Defaulted **off** so our connect handshake matches the equivalent website-backend surface. The call site uses a ternary rather than an `if`, so the compile-time const can't render either branch unreachable (CS0162).

### Deliberately unaffected

- **Signature verification.** An unverifiable token is rejected in both toggle positions. A test pins this as the invariant that keeps the toggle safe.
- **The moderation REST surface** (`UserHasPermissionFilter`) keeps enforcing `exp` and keeps returning `AUTH_TOKEN_EXPIRED`. That split mirrors website-backend exactly: lax at hub connect, strict on the permission filter.

### Known cost

Recorded in full on the const: `ChatSession.HasPermission` gates moderation **hub** methods on the claims carried by the consumed ticket, so while this is off, an expired-but-validly-signed admin token retains its in-hub moderation powers until its permissions change upstream. website-backend's hub already carries this same posture, so this is not a new class of exposure — but it is the real price of the workaround.

**The durable fix is a refresh endpoint in identification-service.** Flip the const back to `true` once one exists.

---

## 2. Per-battleTag throttling no longer charges the per-IP budget

### Problem

The per-IP mint shield is keyed on source address alone, so whatever fills it degrades **every** user behind that address. Per-battleTag-throttled attempts were charging it, which let a single flapping client lock out its neighbours:

| Requests from one battleTag, one 60s window | Effect |
|---|---|
| 1–10 | succeed, no IP charge |
| 11–40 | per-battleTag cap exceeded → 429, **each charged the shared IP budget** |
| 41+ | `ip:X` full → **every request from X 429s pre-validation**, valid tokens included |

Roughly 40 requests inside one window — well within reach of a reconnect loop. Behind CGNAT or a shared proxy, the collateral is a whole population of unrelated users.

### Change

Dropped the `Record(ipKey, now)` on the per-battleTag-throttle branch. Reaching that throttle requires a **validly signed** token, so the attempt has already paid full RSA validation — it was never the cheap pre-validation attack the IP shield exists to stop, and `TicketMintPerBattleTagLimit` is itself the correct bound for an already-proven identity.

The shield keeps its teeth where it matters: the two genuinely cheap rejection paths — malformed/non-Bearer header, and signature failure — still charge it, so an unauthenticated attacker is still clamped before the expensive RSA work.

### Residual, accepted

Documented on the const: a holder of one valid JWT can now drive unbounded past-cap attempts from a single IP without tripping the shield, each costing one signature validation. Bounding that properly needs a cost-based rather than count-based limiter — tracked separately, not in this PR.

---

## Test plan

- [x] Full suite green — **1525 passed, 0 failed**
- [x] Suite green with `EnforceJwtLifetimeOnTicketMint` flipped to `true` as well (flipped, ran, flipped back) — the toggle is genuinely reversible, not just nominally
- [x] `dotnet format --verify-no-changes` clean
- [x] No new compiler warnings
- [x] Expiry coverage: outcome follows the toggle; claims (`battleTag`, `isAdmin`, `permissions`) survive intact when not enforcing; bad signatures rejected regardless of toggle position
- [x] Existing `UserHasPermissionFilterTests.ExpiredToken_ShortCircuits401_WithAuthTokenExpired` still green, proving the REST surface stays strict
- [x] `PerBattleTagThrottledMint_DoesNotChargeThePerIpBudget` — inverted from the old assertion, which pinned the behaviour being fixed
- [x] `OneFlappingBattleTag_CannotLockOutOtherUsersBehindTheSameIp` — regression test for the vector itself: one battleTag flapping past both caps must leave a *different* valid battleTag on the same address able to mint
- [x] Existing shield coverage still green: `IpLimitExhausted_Returns429_BeforeJwtValidation`, `InvalidTokens_FromOneIp_ChargeTheBudget_ThenBlockPreValidation`, `ManyDistinctValidBattleTags_FromOneIp_AllMint_PastTheOldPerIpCap`

## Follow-ups (not in this PR)

- **Refresh endpoint in identification-service** — the actual root cause. A 7-day lifetime with no renewal path makes every service-level accommodation a symptom fix.
- **Cost-based limiting on the mint path**, to bound the residual above.
- **Logging on the mint path.** It currently has none — no Serilog import at all, not for 401s and not for either 429. Operators cannot distinguish "shield working as designed" from "we are 429ing valid users." `ReadRateLimiter` already solved exactly this (fix round 1, finding F3: denials "were previously invisible to operators… unfalsifiable in production"); the same treatment belongs here.
